### PR TITLE
Support for QueueDeclareFull, which gives number of messages and consumer

### DIFF
--- a/projects/client/ApigenBootstrap/RabbitMQ.Client.ApigenBootstrap.csproj
+++ b/projects/client/ApigenBootstrap/RabbitMQ.Client.ApigenBootstrap.csproj
@@ -66,6 +66,9 @@
     <Compile Include="..\RabbitMQ.Client\src\client\api\PublicationAddress.cs">
       <Link>src\client\api\PublicationAddress.cs</Link>
     </Compile>
+    <Compile Include="..\RabbitMQ.Client\src\client\api\QueueDeclareResult.cs">
+      <Link>src\client\api\QueueDeclareResult.cs</Link>
+    </Compile>
     <Compile Include="..\RabbitMQ.Client\src\client\api\ShutdownEventArgs.cs">
       <Link>src\client\api\ShutdownEventArgs.cs</Link>
     </Compile>

--- a/projects/client/RabbitMQ.Client/src/client/api/IModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IModel.cs
@@ -258,6 +258,11 @@ namespace RabbitMQ.Client
         string QueueDeclare(string queue, bool durable, bool exclusive,
                     bool autoDelete, IDictionary arguments);
 
+        ///<summary>(Spec method) Declare a queue.</summary>
+        [AmqpMethodDoNotImplement(null)]
+        QueueDeclareResult QueueDeclareFull(string queue, bool passive, bool durable, bool exclusive,
+                                            bool autoDelete, bool nowait, IDictionary arguments);
+
         ///<summary>(Spec method) Bind a queue to an exchange.</summary>
         [AmqpMethodDoNotImplement(null)]
         void QueueBind(string queue,
@@ -665,15 +670,21 @@ namespace RabbitMQ.Client.Impl
         ///<summary>Used to send a Queue.Declare method. Called by the
         ///public declare method.</summary>
         [AmqpMethodMapping(null, "queue", "declare")]
-        [return: AmqpFieldMapping(null, "queue")]
-        string _Private_QueueDeclare(string queue,
-                                     bool passive,
-                                     bool durable,
-                                     bool exclusive,
-                                     bool autoDelete,
-                                     [AmqpNowaitArgument(null)]
-                                     bool nowait,
-                                     IDictionary arguments);
+        [AmqpForceOneWay]
+        void _Private_QueueDeclare(string queue,
+                                   bool passive,
+                                   bool durable,
+                                   bool exclusive,
+                                   bool autoDelete,
+                                   [AmqpNowaitArgument(null)]
+                                   bool nowait,
+                                   IDictionary arguments);
+
+        ///<summary>Handle incoming Queue.DeclareOk methods. Routes the
+        ///information to a waiting Queue.DeclareOk continuation.</summary>
+        void HandleQueueDeclareOk(string queue,
+                                  uint messageCount,
+                                  uint consumerCount);
 
         ///<summary>Used to send a Queue.Bind method. Called by the
         ///public bind method.</summary>

--- a/projects/client/RabbitMQ.Client/src/client/api/QueueDeclareResult.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/QueueDeclareResult.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace RabbitMQ.Client
+{
+    public class QueueDeclareResult
+    {
+        public string Queue { get; private set; }
+        public uint MessageCount { get; private set; }
+        public uint ConsumerCount { get; private set; }
+
+        public QueueDeclareResult(string queue, uint messageCount, uint consumerCount)
+        {
+            this.Queue = queue;
+            this.MessageCount = messageCount;
+            this.ConsumerCount = consumerCount;
+        }
+    }
+}


### PR DESCRIPTION
I added this support because 1) AMQP supports it 2) it is useful :)

For me this is a very useful feature, as in my application I have to know when a queue becomes empty (e.g. to start workstealing from another queue), and there is no other reliable way to do that (I don't want to use BasicGet, because I'm consuming the queue) and to distinguish between "queue is really empty" and "broker is too busy to push messages to me".

I ran my application with this change and it worked. Unfortunately the built-in tests hung for me in the Debug configuration; not sure what's wrong (I was running on VS2010), so I wasn't able to run them.
