### PR TITLE
Added versions of WaitForConfirms and WaitForConfirmsOrDie with timeouts

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/IModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IModel.cs
@@ -334,6 +334,28 @@ namespace RabbitMQ.Client
 
         ///<summary>Wait until all published messages have been confirmed.
         ///</summary>
+        ///<returns>true if no nacks were received within the timeout, 
+        ///otherwise false</returns>
+        ///<param name="timeout">How long to wait (at most) before returning 
+        ///whether or not any nacks were returned</param>
+        ///<param name="timedOut">True if the method returned because
+        ///the timeout elapsed, not because all messages were ack'd
+        ///or at least one nack'd.</param>
+        ///<remarks>
+        ///Waits until all messages published since the last call have
+        ///been either ack'd or nack'd by the broker.  Returns whether
+        ///all the messages were ack'd (and none were nack'd). Note,
+        ///when called on a non-Confirm channel, returns true
+        ///immediately.
+        ///</remarks>
+        [AmqpMethodDoNotImplement(null)]
+        [AmqpUnsupported("RabbitMQ.Client.Framing.v0_8qpid")]
+        [AmqpUnsupported("RabbitMQ.Client.Framing.v0_8")]
+        [AmqpUnsupported("RabbitMQ.Client.Framing.v0_9")]
+        bool WaitForConfirms(TimeSpan timeout, out bool timedOut);
+
+        ///<summary>Wait until all published messages have been confirmed.
+        ///</summary>
         ///<remarks>
         ///Waits until all messages published since the last call have
         ///been ack'd by the broker.  If a nack is received, throws an
@@ -344,6 +366,20 @@ namespace RabbitMQ.Client
         [AmqpUnsupported("RabbitMQ.Client.Framing.v0_8")]
         [AmqpUnsupported("RabbitMQ.Client.Framing.v0_9")]
         void WaitForConfirmsOrDie();
+
+        ///<summary>Wait until all published messages have been confirmed.
+        ///</summary>
+        ///<remarks>
+        ///Waits until all messages published since the last call have
+        ///been ack'd by the broker.  If a nack is received or the timeout 
+        ///elapses, throws an OperationInterrupedException exception 
+        ///immediately.
+        ///</remarks>
+        [AmqpMethodDoNotImplement(null)]
+        [AmqpUnsupported("RabbitMQ.Client.Framing.v0_8qpid")]
+        [AmqpUnsupported("RabbitMQ.Client.Framing.v0_8")]
+        [AmqpUnsupported("RabbitMQ.Client.Framing.v0_9")]
+        void WaitForConfirmsOrDie(TimeSpan timeout);
 
         ///<summary>Start a Basic content-class consumer.</summary>
         ///<remarks>


### PR DESCRIPTION
It makes sense to have timeouting versions of these methods for the following case (which is my use case):

I'm keeping track of all unconfirmed messages so I can requeue them in case RabbitMQ crashes. But I would not like to do so unless really necessary, because this may lead to duplication of messages and duplication of work.

So, when closing a connection, I'm checking if there are unconfirmed messages. If there are, I'm requeueing them in transactions (for example) or doing something else to make sure they aren't lost even if RabbitMQ crashes right after I close my connection.

However waiting for RabbitMQ to confirm all of them may be a little too long for me, and I definitely don't want this wait period to be out of my control. So I better say "I'm ok with waiting for confirms for 3 seconds, but then I'll kill the connection and deal with the remaining unconfirmed messages myself".
