### PR TITLE
SocketFrameHandler_0_9 can cause connection thread to crash

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler_0_9.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler_0_9.cs
@@ -150,8 +150,16 @@ namespace RabbitMQ.Client.Impl
 
         public void Close()
         {
-            m_socket.LingerState = new LingerOption(true, SOCKET_CLOSING_TIMEOUT);
-            m_socket.Close();
+            try
+            {
+                m_socket.LingerState = new LingerOption(true, SOCKET_CLOSING_TIMEOUT);
+                m_socket.Close();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Ignore the exception if the socket is already closed/disposed
+                return;
+            }
         }
     }
 }


### PR DESCRIPTION
When using .NET 4.0 SocketFrameHandler_0_9.Close() can throw ObjectDisposedException.
Apparently, TcpClient.Close() calls this.Dispose(), which causes the issue.

This patch simply handles the exception and ignores it, since the socket is already closed.
