### PR TITLE
Connection timeouts and socket options

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/IProtocol.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IProtocol.cs
@@ -40,6 +40,8 @@
 
 using RabbitMQ.Client.Impl;
 
+using System.Net.Sockets;
+
 namespace RabbitMQ.Client
 {
     ///<summary>Object describing various overarching parameters
@@ -60,7 +62,7 @@ namespace RabbitMQ.Client
         int DefaultPort { get; }
 
         ///<summary>Construct a frame handler for a given endpoint.</summary>
-        IFrameHandler CreateFrameHandler(AmqpTcpEndpoint endpoint);
+        IFrameHandler CreateFrameHandler(TcpClient socket, AmqpTcpEndpoint endpoint, int timeout);
         ///<summary>Construct a connection from a given set of
         ///parameters and a frame handler. The "insist" parameter is
         ///passed on to the AMQP connection.open method.</summary>

--- a/projects/client/RabbitMQ.Client/src/client/impl/AbstractProtocolBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AbstractProtocolBase.cs
@@ -43,6 +43,7 @@ using RabbitMQ.Client.Impl;
 using RabbitMQ.Util;
 
 using System.Collections;
+using System.Net.Sockets;
 
 namespace RabbitMQ.Client.Impl {
     public abstract class AbstractProtocolBase: IProtocol {
@@ -54,7 +55,7 @@ namespace RabbitMQ.Client.Impl {
 
         public IDictionary Capabilities = new Hashtable();
 
-        public abstract IFrameHandler CreateFrameHandler(AmqpTcpEndpoint endpoint);
+        public abstract IFrameHandler CreateFrameHandler(TcpClient socket, AmqpTcpEndpoint endpoint, int timeout);
         public abstract IConnection CreateConnection(ConnectionFactory factory,
                                                      bool insist,
                                                      IFrameHandler frameHandler);

--- a/projects/client/RabbitMQ.Client/src/client/impl/v0_8/ProtocolBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/v0_8/ProtocolBase.cs
@@ -42,11 +42,16 @@ using RabbitMQ.Client;
 using RabbitMQ.Client.Impl;
 using RabbitMQ.Util;
 
+using System.Net.Sockets;
+
 namespace RabbitMQ.Client.Framing.Impl.v0_8 {
     public abstract class ProtocolBase: AbstractProtocolBase {
 
-        public override IFrameHandler CreateFrameHandler(AmqpTcpEndpoint endpoint) {
-            return new SocketFrameHandler_0_9(endpoint);
+        public override IFrameHandler CreateFrameHandler(TcpClient socket,
+                                                         AmqpTcpEndpoint endpoint,
+                                                         int timeout)
+        {
+            return new SocketFrameHandler_0_9(socket, endpoint, timeout);
         }
 
         public override IModel CreateModel(ISession session) {

--- a/projects/client/RabbitMQ.Client/src/client/impl/v0_8qpid/ProtocolBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/v0_8qpid/ProtocolBase.cs
@@ -42,11 +42,16 @@ using RabbitMQ.Client;
 using RabbitMQ.Client.Impl;
 using RabbitMQ.Util;
 
+using System.Net.Sockets;
+
 namespace RabbitMQ.Client.Framing.Impl.v0_8qpid {
     public abstract class ProtocolBase: AbstractProtocolBase {
 
-        public override IFrameHandler CreateFrameHandler(AmqpTcpEndpoint endpoint) {
-            return new SocketFrameHandler_0_9(endpoint);
+        public override IFrameHandler CreateFrameHandler(TcpClient socket,
+                                                         AmqpTcpEndpoint endpoint,
+                                                         int timeout)
+        {
+            return new SocketFrameHandler_0_9(socket, endpoint, timeout);
         }
 
         public override IModel CreateModel(ISession session) {

--- a/projects/client/RabbitMQ.Client/src/client/impl/v0_9/ProtocolBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/v0_9/ProtocolBase.cs
@@ -42,11 +42,16 @@ using RabbitMQ.Client;
 using RabbitMQ.Client.Impl;
 using RabbitMQ.Util;
 
+using System.Net.Sockets;
+
 namespace RabbitMQ.Client.Framing.Impl.v0_9 {
     public abstract class ProtocolBase: AbstractProtocolBase {
 
-        public override IFrameHandler CreateFrameHandler(AmqpTcpEndpoint endpoint) {
-            return new SocketFrameHandler_0_9(endpoint);
+        public override IFrameHandler CreateFrameHandler(TcpClient socket,
+                                                         AmqpTcpEndpoint endpoint,
+                                                         int timeout)
+        {
+            return new SocketFrameHandler_0_9(socket, endpoint, timeout);
         }
 
         public override IModel CreateModel(ISession session) {

--- a/projects/client/RabbitMQ.Client/src/client/impl/v0_9_1/ProtocolBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/v0_9_1/ProtocolBase.cs
@@ -43,6 +43,7 @@ using RabbitMQ.Client.Impl;
 using RabbitMQ.Util;
 
 using System.Collections;
+using System.Net.Sockets;
 
 namespace RabbitMQ.Client.Framing.Impl.v0_9_1 {
     public abstract class ProtocolBase: AbstractProtocolBase {
@@ -54,8 +55,11 @@ namespace RabbitMQ.Client.Framing.Impl.v0_9_1 {
             Capabilities["consumer_cancel_notify"] = true;
         }
 
-        public override IFrameHandler CreateFrameHandler(AmqpTcpEndpoint endpoint) {
-            return new SocketFrameHandler_0_9(endpoint);
+        public override IFrameHandler CreateFrameHandler(TcpClient socket,
+                                                         AmqpTcpEndpoint endpoint,
+                                                         int timeout)
+        {
+            return new SocketFrameHandler_0_9(socket, endpoint, timeout);
         }
 
         public override IModel CreateModel(ISession session) {


### PR DESCRIPTION
ConnectionFactory now passes a connection timeout value and TcpClient
object down to the SocketFrameHandler_0_9 class. This allows setting a
timeout value, and configuring socket options prior to a connection
attempt.

The ConnectionFactory can be subclassed, and the virtual ConfigureSocket
hook function should be overridden to set custom socket options.
