### PR TITLE
Add SSL cert selector and validator callback support

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/SslHelper.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/SslHelper.cs
@@ -91,9 +91,15 @@ namespace RabbitMQ.Client
         public static Stream TcpUpgrade(Stream tcpStream, SslOption sslOption)
         {
             SslHelper helper = new SslHelper(sslOption);
-            SslStream sslStream = new SslStream(tcpStream, false,
-                                                new RemoteCertificateValidationCallback(helper.CertificateValidationCallback),
-                                                new LocalCertificateSelectionCallback(helper.CertificateSelectionCallback));
+            
+			// Use the client specified remote certificate validation callback if it is not null
+            RemoteCertificateValidationCallback remoteCertValidator = sslOption.CertificateValidationCallback ?? new RemoteCertificateValidationCallback(
+                                                                                                               helper.CertificateValidationCallback);
+            // Use the client specified local certificate selector callback if it is not null
+            LocalCertificateSelectionCallback localCertSelector = sslOption.CertificateSelectionCallback ?? new LocalCertificateSelectionCallback(
+                                                                                                               helper.CertificateSelectionCallback);
+
+            SslStream sslStream = new SslStream(tcpStream, false, remoteCertValidator, localCertSelector);
             
             sslStream.AuthenticateAsClient(sslOption.ServerName,
                                            sslOption.Certs,

--- a/projects/client/RabbitMQ.Client/src/client/api/SslOption.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/SslOption.cs
@@ -137,12 +137,26 @@ namespace RabbitMQ.Client
             set { m_acceptablePolicyErrors = value; }
         }
 
+        /// <summary>
+        /// An optional client specified SSL certificate validation callback.  If this is not specified,
+        /// the default callback will be used in conjunction with the AcceptablePolicyErrors property to 
+        /// determine if the remote server certificate is valid.
+        /// </summary>
+        public RemoteCertificateValidationCallback CertificateValidationCallback { get; set; }
+
+        /// <summary>
+        /// An optional client specified SSL certificate selection callback.  If this is not specified,
+        /// the first valid certificate found will be used.
+        /// </summary>
+        public LocalCertificateSelectionCallback CertificateSelectionCallback { get; set; }
 
         ///<summary>Construct an SslOption specifying both the server cannonical name
-        ///and the client's certificate path.
+        /// and the client's certificate path.
         ///</summary>
         public SslOption(string serverName, string certPath, bool enabled)
         {
+            CertificateSelectionCallback = null;
+            CertificateValidationCallback = null;
             m_serverName= serverName;
             m_certPath = certPath;
             m_enabled = enabled;


### PR DESCRIPTION
With our usage of the .NET client, we came across the need to allow our code to select the client certificate being used and also to manually validate the remote SSL certificate.

This change allows the user code to set the SSL callbacks through the SslOption class that will be used by the SslHelper class.  If the user does not set either of these callbacks, then the default ones will be used, just like the previous version of the code.

I submitted the contributor agreement a while back, but haven't had a chance to send this change until now.
