### PR TITLE
Exposes Overloaded Constructor on EventingBasicConsumer that Accepts IModel Instances

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/events/EventingBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/EventingBasicConsumer.cs
@@ -51,6 +51,17 @@ namespace RabbitMQ.Client.Events
     ///</remarks>
     public class EventingBasicConsumer : DefaultBasicConsumer
     {
+        ///<summary>Default constructor.</summary>
+        public EventingBasicConsumer() : base()
+        {
+        }
+
+        ///<summary>Constructor which sets the Model property to the
+        ///given value.</summary>
+        public EventingBasicConsumer(IModel model) : base(model) 
+        {
+        }
+
         ///<summary>Fires the Unregistered event.</summary>
         public override void HandleBasicCancelOk(string consumerTag)
         {


### PR DESCRIPTION
Very simple change. When inheriting from EventingBasicConsumer it is important to have access to the underlying IModel instance for certain operations (i.e. message acks). Fixes issue #17.
