### PR TITLE
Added Nack method to the Subscription class of Message Patterns

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/messagepatterns/Subscription.cs
+++ b/projects/client/RabbitMQ.Client/src/client/messagepatterns/Subscription.cs
@@ -187,6 +187,35 @@ namespace RabbitMQ.Client.MessagePatterns {
             }
         }
 
+        /// <summary>
+        /// If LatestEvent is non-null, passes it to Nack(BasicDeliverEventArgs, bool). Causes LatestEvent to become null.
+        /// </summary>
+        public void Nack(bool requeue)
+        {
+            if (m_latestEvent != null)
+                Nack(m_latestEvent, requeue);
+        }
+
+        /// <summary>
+        /// If we are not in "noAck" mode, calls IModel.BasicNack with the delivery-tag from the passed in
+        /// event; otherwise, sends nothing to the server. In both cases, if the passed-in event is the same as LatestEvent
+        /// (by pointer comparison), sets LatestEvent to null.
+        /// </summary>
+        public void Nack(BasicDeliverEventArgs evt, bool requeue)
+        {
+            if (evt == null) {
+                return;
+            }
+
+            if (!m_noAck) {
+                m_model.BasicNack(evt.DeliveryTag, false, requeue);
+            }
+
+            if (evt == m_latestEvent) {
+                m_latestEvent = null;
+            }
+        }
+
         ///<summary>Retrieves the next incoming delivery in our
         ///subscription queue.</summary>
         ///<remarks>


### PR DESCRIPTION
The Subscription class lacks a way to reject messages so that the server can discard or requeue them. I added a Nack method to the class to address that scenario.
