### PR TITLE
Connection threads are now background threads

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/ConnectionBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ConnectionBase.cs
@@ -544,6 +544,7 @@ namespace RabbitMQ.Client.Impl
         {
             Thread mainLoopThread = new Thread(new ThreadStart(MainLoop));
             mainLoopThread.Name = "AMQP Connection " + Endpoint.ToString();
+            mainLoopThread.IsBackground = true;
             mainLoopThread.Start();
         }
 
@@ -559,6 +560,7 @@ namespace RabbitMQ.Client.Impl
         {
             Thread heartbeatLoop = new Thread(loop);
             heartbeatLoop.Name = "AMQP Heartbeat " + name + " for Connection " + Endpoint.ToString();
+            heartbeatLoop.IsBackground = true;
             heartbeatLoop.Start();
         }
 


### PR DESCRIPTION
If a connection is opened on a worker thread and then not explicitly
closed, then the RabbitMQ connection threads will prevent the
application from closing normally. i.e. If a thread is created to
dequeue events and then the main window is closed (which should
terminate the application) then the application will still be running in
the background due to the RabbitMQ threads not ending.
