### PR TITLE
Add Background thread option to connections

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
@@ -65,6 +65,7 @@ namespace RabbitMQ.Client
     ///     factory.VirtualHost = ConnectionFactory.DefaultVHost;
     ///     factory.HostName = hostName;
     ///     factory.Port     = AmqpTcpEndpoint.UseDefaultPort;
+    ///     factory.IsBackground = false;
     ///     //
     ///     IConnection conn = factory.CreateConnection();
     ///     //
@@ -160,6 +161,9 @@ namespace RabbitMQ.Client
         /// AmqpTcpEndpoint.UseDefaultPort indicates the default for
         /// the protocol should be used.</summary>
         public int Port = AmqpTcpEndpoint.UseDefaultPort;
+
+        /// <summary>Will connection threads be created as background threads</summary>
+        public bool IsBackground = false;
 
         ///<summary> SASL auth mechanisms to use.</summary>
         public AuthMechanismFactory[] AuthMechanisms = DefaultAuthMechanisms;

--- a/projects/client/RabbitMQ.Client/src/client/impl/ConnectionBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ConnectionBase.cs
@@ -544,6 +544,7 @@ namespace RabbitMQ.Client.Impl
         {
             Thread mainLoopThread = new Thread(new ThreadStart(MainLoop));
             mainLoopThread.Name = "AMQP Connection " + Endpoint.ToString();
+            mainLoopThread.IsBackground = m_factory.IsBackground;
             mainLoopThread.Start();
         }
 
@@ -559,6 +560,7 @@ namespace RabbitMQ.Client.Impl
         {
             Thread heartbeatLoop = new Thread(loop);
             heartbeatLoop.Name = "AMQP Heartbeat " + name + " for Connection " + Endpoint.ToString();
+            heartbeatLoop.IsBackground = m_factory.IsBackground;
             heartbeatLoop.Start();
         }
 


### PR DESCRIPTION
This update allows the user to select if they want to have their connection threads be run as background threads or not. The default is to have the threads run as foreground threads (factory.IsBackground = false) so this does not change the existing behavior expected by current clients.
