### PR TITLE
Workaround for Mono bug with IPv4 address when IPv6 is supported

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
@@ -80,6 +80,10 @@ namespace RabbitMQ.Client.Impl
                 {
                     m_socket = null;
                 }
+                catch (SocketException) // Mono might raise a SocketException when using IPv4 addresses on an OS that supports IPv6
+                {
+                    m_socket = null;
+                }
             }
             if (m_socket == null)
             {


### PR DESCRIPTION
Some versions of Mono, such as the one used by Unity up to 4.5.x, raise
a SocketException when attempting to connect to a IPv4 address on
platforms that support IPv6.  This change makes SocketFrameHandler retry
the connection using AddressFamily.InterNetwork if that happens.
