### PR TITLE
Revert client authentication changes in 36efc00

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/SslHelper.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/SslHelper.cs
@@ -72,13 +72,7 @@ namespace RabbitMQ.Client
 
             var sslStream = new SslStream(tcpStream, false, remoteCertValidator, localCertSelector);
 
-            if(sslOption.Certs == null || sslOption.Certs.Count == 0)
-            {
-                sslStream.AuthenticateAsClient(sslOption.ServerName);
-            } else
-            {
-                sslStream.AuthenticateAsClient(sslOption.ServerName, sslOption.Certs, sslOption.Version, false);
-            }
+            sslStream.AuthenticateAsClient(sslOption.ServerName, sslOption.Certs, sslOption.Version, false);
 
             return sslStream;
         }

--- a/projects/client/Unit/src/unit/TestSsl.cs
+++ b/projects/client/Unit/src/unit/TestSsl.cs
@@ -93,6 +93,22 @@ namespace RabbitMQ.Client.Unit
         }
 
         [Test]
+        public void TestVersionVerified() {
+            string sslDir = Environment.GetEnvironmentVariable("SSL_CERTS_DIR");
+            if (null == sslDir) return;
+
+            ConnectionFactory cf = new ConnectionFactory();
+            cf.Ssl.Version = SslProtocols.Ssl2;
+            cf.Ssl.AcceptablePolicyErrors = (SslPolicyErrors)~0;
+            cf.Ssl.ServerName = "*";
+            cf.Ssl.Enabled = true;
+            Assert.Throws<BrokerUnreachableException>(() => SendReceive(cf));
+
+            cf.Ssl.Version = SslProtocols.Default;
+            Assert.DoesNotThrow(() => SendReceive(cf));
+        }
+
+        [Test]
         public void TestClientAndServerVerified() {
             string sslDir = Environment.GetEnvironmentVariable("SSL_CERTS_DIR");
             if (null == sslDir) return;


### PR DESCRIPTION
The change in 36efc00 broke the client's ability to require specific version(s) of SSL. This pull request contains a test that fails when the feature is broken, and a revert commit to fix it.

This seems to work correctly whether I am presenting a client certificate or not. I can't speak for Mono, but everything works fine this way on Windows.
