### PR TITLE
Fixes issue with closed merge #66

### DIFF
--- a/projects/examples/WinRT/Subscriber/RabbitMQ.Client.Examples.WinRT.Subscriber.csproj
+++ b/projects/examples/WinRT/Subscriber/RabbitMQ.Client.Examples.WinRT.Subscriber.csproj
@@ -159,16 +159,20 @@
   <!-- Mono compatibility workarounds -->
   <PropertyGroup Condition=" '$(PropUsingMono)' == 'true'">
     <_DisabledWarnings>$(NoWarn)</_DisabledWarnings>
+    
+    <BuildDependsOn>SkippingBuild</BuildDependsOn>
+    <CleanDependsOn>SkippingClean</CleanDependsOn>
+    <RebuildDependsOn>SkippingRebuild</RebuildDependsOn>
   </PropertyGroup>
-
-  <!-- Microsoft CSharp targets; replace Build, Rebuild and Clean targets if building WinRT version is turned off -->
-  <Target Name="Build" Condition="'$(PropBuildWinRT)' != 'true'">
+  
+  <!-- Replace Build, Rebuild and Clean DependsOnTargets with these Targets if building WinRT version is turned off -->
+  <Target Name="SkippingBuild">
     <Message Text="Not building anything in $(MSBuildProjectName) because PropBuildWinRT is false." />
   </Target>
-  <Target Name="Rebuild" Condition="'$(PropBuildWinRT)' != 'true'">
+  <Target Name="SkippingRebuild">
     <Message Text="Not rebuilding anything in $(MSBuildProjectName) because PropBuildWinRT is false." />
   </Target>
-  <Target Name="Clean" Condition="'$(PropBuildWinRT)' != 'true'">
+  <Target Name="SkippingClean">
     <Message Text="Not cleaning anything in $(MSBuildProjectName) because PropBuildWinRT is false." />
   </Target>  
 </Project>


### PR DESCRIPTION
Change Build,Rebuild,Clean Target behavior through changing DependsOn properties instead of replacing Targets.

@michaelklishin Can you check out that this works with Mono?  