### PR TITLE
Rework heartbeat handling, fixes #68

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,4 +87,10 @@ Backup*/
 UpgradeLog*.XML
 UpgradeLog*.htm
 
+# Unit tests
+
 projects/client/Unit/TestResult.xml
+
+# Development scripts
+
+*.fsx

--- a/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
@@ -38,13 +38,13 @@
 //  Copyright (c) 2007-2014 GoPivotal, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
+using RabbitMQ.Client.Exceptions;
+using RabbitMQ.Client.Framing.Impl;
+using RabbitMQ.Client.Impl;
 using System;
 using System.Collections.Generic;
 using System.Net.Security;
 using System.Threading.Tasks;
-using RabbitMQ.Client.Exceptions;
-using RabbitMQ.Client.Framing.Impl;
-using RabbitMQ.Client.Impl;
 
 namespace RabbitMQ.Client
 {
@@ -103,7 +103,7 @@ namespace RabbitMQ.Client
         /// <summary>
         /// Default value for connection attempt timeout, in milliseconds.
         /// </summary>
-        public const int DefaultConnectionTimeout = 30*1000;
+        public const int DefaultConnectionTimeout = 30 * 1000;
 
         /// <summary>
         /// Default value for the desired maximum frame size, with zero meaning unlimited (value: 0).
@@ -138,7 +138,7 @@ namespace RabbitMQ.Client
         /// <summary>
         ///  Default SASL auth mechanisms to use.
         /// </summary>
-        public static AuthMechanismFactory[] DefaultAuthMechanisms = {new PlainMechanismFactory()};
+        public static AuthMechanismFactory[] DefaultAuthMechanisms = { new PlainMechanismFactory() };
 
         /// <summary>
         ///  SASL auth mechanisms to use.
@@ -282,7 +282,6 @@ namespace RabbitMQ.Client
         /// </summary>
         public AuthMechanismFactory AuthMechanismFactory(string[] mechanismNames)
         {
-
             // Our list is in order of preference, the server one is not.
             foreach (AuthMechanismFactory factory in AuthMechanisms)
             {

--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -235,7 +235,7 @@ namespace RabbitMQ.Client.Framing.Impl
                 m_heartbeat = value;
                 // timers fire at half the interval to avoid race
                 // conditions
-                m_heartbeatTimeSpan = TimeSpan.FromSeconds(value / 2);
+                m_heartbeatTimeSpan = TimeSpan.FromMilliseconds((value * 1000) / 2.0);
                 m_frameHandler.Timeout = (value * 1000) / 2;
             }
         }

--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -78,9 +78,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public IConnectionFactory m_factory;
         public IFrameHandler m_frameHandler;
         public ushort m_heartbeat = 0;
-
-        public AutoResetEvent m_heartbeatRead = new AutoResetEvent(false);
-        public AutoResetEvent m_heartbeatWrite = new AutoResetEvent(false);
+        public TimeSpan m_heartbeatTimeSpan = TimeSpan.FromSeconds(0);
 
         public Guid m_id = Guid.NewGuid();
 
@@ -91,8 +89,12 @@ namespace RabbitMQ.Client.Framing.Impl
         public SessionManager m_sessionManager;
 
         public IList<ShutdownReportEntry> m_shutdownReport = new SynchronizedList<ShutdownReportEntry>(new List<ShutdownReportEntry>());
-        private Timer _heartbeatReadTimer;
         private Timer _heartbeatWriteTimer;
+
+        // true if we haven't finished connection negotiation.
+        // In this state socket exceptions are treated as fatal connection
+        // errors, otherwise as read timeouts
+        private bool m_inConnectionNegotiation;
 
         public ConsumerWorkService ConsumerWorkService { get; private set; }
 
@@ -110,7 +112,8 @@ namespace RabbitMQ.Client.Framing.Impl
 
             StartMainLoop(factory.UseBackgroundThreadsForIO);
             Open(insist);
-            StartHeartbeatTimers();
+
+            StartHeartbeatTimer();
             AppDomain.CurrentDomain.DomainUnload += HandleDomainUnload;
         }
 
@@ -230,10 +233,10 @@ namespace RabbitMQ.Client.Framing.Impl
             set
             {
                 m_heartbeat = value;
-                // Socket read timeout is twice the hearbeat
-                // because when we hit the timeout socket is
-                // in unusable state
-                m_frameHandler.Timeout = value * 2 * 1000;
+                // timers fire at half the interval to avoid race
+                // conditions
+                m_heartbeatTimeSpan = TimeSpan.FromSeconds(value / 2);
+                m_frameHandler.Timeout = value * 1000;
             }
         }
 
@@ -463,8 +466,7 @@ namespace RabbitMQ.Client.Framing.Impl
         {
             // Notify hearbeat loops that they can leave
             m_closed = true;
-            m_heartbeatRead.Set();
-            m_heartbeatWrite.Set();
+            StopHeartbeatTimer();
 
             m_frameHandler.Close();
             m_model0.SetCloseReason(m_closeReason);
@@ -520,47 +522,6 @@ namespace RabbitMQ.Client.Framing.Impl
             return false;
         }
 
-        public void HeartbeatReadTimerCallback(object state)
-        {
-            bool shouldTerminate = false;
-            if (!m_closed)
-            {
-                if (!m_heartbeatRead.WaitOne(0, false))
-                {
-                    m_missedHeartbeats++;
-                }
-                else
-                {
-                    m_missedHeartbeats = 0;
-                }
-
-                // Has to miss two full heartbeats to force socket close
-                if (m_missedHeartbeats > 1)
-                {
-                    String description = "Heartbeat missing with heartbeat == " +
-                                         m_heartbeat + " seconds";
-                    var eose = new EndOfStreamException(description);
-                    m_shutdownReport.Add(new ShutdownReportEntry(description, eose));
-                    HandleMainLoopException(new ShutdownEventArgs(
-                        ShutdownInitiator.Library,
-                        0,
-                        "End of stream",
-                        eose));
-                    shouldTerminate = true;
-                }
-            }
-
-            if (shouldTerminate)
-            {
-                TerminateMainloop();
-                FinishClose();
-            }
-            else
-            {
-                _heartbeatReadTimer.Change(Heartbeat * 1000, Timeout.Infinite);
-            }
-        }
-
         public void HeartbeatWriteTimerCallback(object state)
         {
             bool shouldTerminate = false;
@@ -568,10 +529,7 @@ namespace RabbitMQ.Client.Framing.Impl
             {
                 if (!m_closed)
                 {
-                    if (!m_heartbeatWrite.WaitOne(0, false))
-                    {
-                        WriteFrame(m_heartbeatFrame);
-                    }
+                    WriteFrame(m_heartbeatFrame);
                 }
             }
             catch (Exception e)
@@ -588,10 +546,6 @@ namespace RabbitMQ.Client.Framing.Impl
             {
                 TerminateMainloop();
                 FinishClose();
-            }
-            else
-            {
-                _heartbeatWriteTimer.Change(Heartbeat * 1000, Timeout.Infinite);
             }
         }
 
@@ -693,65 +647,90 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public void MainLoopIteration()
         {
-            Frame frame = m_frameHandler.ReadFrame();
+            try
+            {
+                Frame frame = m_frameHandler.ReadFrame();
 
-            NotifyHeartbeatListener();
-            // We have received an actual frame.
-            if (frame.Type == Constants.FrameHeartbeat)
-            {
-                // Ignore it: we've already just reset the heartbeat
-                // counter.
-                return;
-            }
-
-            if (frame.Channel == 0)
-            {
-                // In theory, we could get non-connection.close-ok
-                // frames here while we're quiescing (m_closeReason !=
-                // null). In practice, there's a limited number of
-                // things the server can ask of us on channel 0 -
-                // essentially, just connection.close. That, combined
-                // with the restrictions on pipelining, mean that
-                // we're OK here to handle channel 0 traffic in a
-                // quiescing situation, even though technically we
-                // should be ignoring everything except
-                // connection.close-ok.
-                m_session0.HandleFrame(frame);
-            }
-            else
-            {
-                // If we're still m_running, but have a m_closeReason,
-                // then we must be quiescing, which means any inbound
-                // frames for non-zero channels (and any inbound
-                // commands on channel zero that aren't
-                // Connection.CloseOk) must be discarded.
-                if (m_closeReason == null)
+                // We have received an actual frame.
+                m_missedHeartbeats = 0;
+                if (frame.Type == Constants.FrameHeartbeat)
                 {
-                    // No close reason, not quiescing the
-                    // connection. Handle the frame. (Of course, the
-                    // Session itself may be quiescing this particular
-                    // channel, but that's none of our concern.)
-                    ISession session = m_sessionManager.Lookup(frame.Channel);
-                    if (session == null)
+                    // Ignore it: we've already just reset the heartbeat
+                    // counter.
+                    return;
+                }
+
+                if (frame.Channel == 0)
+                {
+                    // In theory, we could get non-connection.close-ok
+                    // frames here while we're quiescing (m_closeReason !=
+                    // null). In practice, there's a limited number of
+                    // things the server can ask of us on channel 0 -
+                    // essentially, just connection.close. That, combined
+                    // with the restrictions on pipelining, mean that
+                    // we're OK here to handle channel 0 traffic in a
+                    // quiescing situation, even though technically we
+                    // should be ignoring everything except
+                    // connection.close-ok.
+                    m_session0.HandleFrame(frame);
+                }
+                else
+                {
+                    // If we're still m_running, but have a m_closeReason,
+                    // then we must be quiescing, which means any inbound
+                    // frames for non-zero channels (and any inbound
+                    // commands on channel zero that aren't
+                    // Connection.CloseOk) must be discarded.
+                    if (m_closeReason == null)
                     {
-                        throw new ChannelErrorException(frame.Channel);
-                    }
-                    else
-                    {
-                        session.HandleFrame(frame);
+                        // No close reason, not quiescing the
+                        // connection. Handle the frame. (Of course, the
+                        // Session itself may be quiescing this particular
+                        // channel, but that's none of our concern.)
+                        ISession session = m_sessionManager.Lookup(frame.Channel);
+                        if (session == null)
+                        {
+                            throw new ChannelErrorException(frame.Channel);
+                        }
+                        else
+                        {
+                            session.HandleFrame(frame);
+                        }
                     }
                 }
+            } catch (IOException ioe)
+            {
+                HandleIOException(ioe);
             }
+
         }
 
-        public void NotifyHeartbeatListener()
+        protected void HandleIOException(IOException ioe)
         {
-            if (m_heartbeat == 0)
+            // socket error when in negotiation, throw BrokerUnreachableException
+            // immediately
+            if(m_inConnectionNegotiation)
             {
-                // Heartbeating not enabled for this connection.
-                return;
+                var cfe = new ConnectFailureException("I/O error before connection negotiation was completed", ioe);
+                throw new BrokerUnreachableException(cfe);
             }
-            m_heartbeatRead.Set();
+
+            // socket receive timeout is configured to be 1/2 of the heartbeat timeout,
+            // the peer must be considered dead after two subsequent missed heartbeats
+            if(++m_missedHeartbeats >= 4)
+            {
+                var description =
+                    String.Format("Peer missed 2 heartbeats with heartbeat timeout set to {0} seconds",
+                                  m_heartbeat);
+                var eose = new EndOfStreamException(description);
+                m_shutdownReport.Add(new ShutdownReportEntry(description, eose));
+                HandleMainLoopException(new ShutdownEventArgs(ShutdownInitiator.Library,
+                                                              0,
+                                                              "End of stream",
+                                                              eose));
+                TerminateMainloop();
+                FinishClose();
+            }
         }
 
         public void NotifyReceivedCloseOk()
@@ -968,15 +947,12 @@ namespace RabbitMQ.Client.Framing.Impl
             }
         }
 
-        public void StartHeartbeatTimers()
+        public void StartHeartbeatTimer()
         {
             if (Heartbeat != 0)
             {
                 _heartbeatWriteTimer = new Timer(HeartbeatWriteTimerCallback);
-                _heartbeatWriteTimer.Change(Heartbeat * 1000, Timeout.Infinite);
-
-                _heartbeatReadTimer = new Timer(HeartbeatReadTimerCallback);
-                _heartbeatReadTimer.Change(Heartbeat * 1000, Timeout.Infinite);
+                _heartbeatWriteTimer.Change(m_heartbeatTimeSpan, m_heartbeatTimeSpan);
             }
         }
 
@@ -988,10 +964,12 @@ namespace RabbitMQ.Client.Framing.Impl
             mainLoopThread.Start();
         }
 
-        protected void StopHeartbeatTimers()
+        protected void StopHeartbeatTimer()
         {
-            _heartbeatReadTimer.Dispose();
-            _heartbeatWriteTimer.Dispose();
+            if(_heartbeatWriteTimer != null)
+            {
+                _heartbeatWriteTimer.Dispose();
+            }
         }
 
         ///<remarks>
@@ -999,7 +977,7 @@ namespace RabbitMQ.Client.Framing.Impl
         ///</remarks>
         public void TerminateMainloop()
         {
-            StopHeartbeatTimers();
+            StopHeartbeatTimer();
             m_running = false;
         }
 
@@ -1011,7 +989,6 @@ namespace RabbitMQ.Client.Framing.Impl
         public void WriteFrame(Frame f)
         {
             m_frameHandler.WriteFrame(f);
-            m_heartbeatWrite.Set();
         }
 
         ///<summary>API-side invocation of connection abort.</summary>
@@ -1084,7 +1061,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         void IDisposable.Dispose()
         {
-            StopHeartbeatTimers();
+            StopHeartbeatTimer();
             Abort();
             if (ShutdownReport.Count > 0)
             {
@@ -1113,6 +1090,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         protected void StartAndTune()
         {
+            m_inConnectionNegotiation = true;
             var connectionStartCell = new BlockingCell();
             m_model0.m_connectionStartCell = connectionStartCell;
             m_frameHandler.Timeout = HandshakeTimeout;
@@ -1211,6 +1189,8 @@ namespace RabbitMQ.Client.Framing.Impl
             m_model0.ConnectionTuneOk(channelMax,
                 frameMax,
                 heartbeat);
+
+            m_inConnectionNegotiation = false;
         }
 
         private static uint NegotiatedMaxValue(uint clientValue, uint serverValue)

--- a/projects/client/RabbitMQ.Client/src/client/impl/Frame.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Frame.cs
@@ -38,12 +38,12 @@
 //  Copyright (c) 2007-2014 GoPivotal, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
+using RabbitMQ.Client.Exceptions;
+using RabbitMQ.Client.Framing;
+using RabbitMQ.Util;
 using System;
 using System.IO;
 using System.Net.Sockets;
-using RabbitMQ.Client.Exceptions;
-using RabbitMQ.Util;
-using RabbitMQ.Client.Framing;
 
 namespace RabbitMQ.Client.Impl
 {

--- a/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
@@ -164,13 +164,16 @@ namespace RabbitMQ.Client.Impl
                     try
                     {
                         m_socket.LingerState = new LingerOption(true, SOCKET_CLOSING_TIMEOUT);
+                        m_socket.Close();
                     }
-                    catch (ArgumentException _)
+                    catch (Exception _)
                     {
                         // ignore, we are closing anyway
                     }
-                    m_socket.Close();
-                    _closed = true;
+                    finally
+                    {
+                        _closed = true;
+                    }
                 }
             }
         }

--- a/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
@@ -38,13 +38,13 @@
 //  Copyright (c) 2007-2014 GoPivotal, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
+using RabbitMQ.Client.Exceptions;
+using RabbitMQ.Util;
 using System;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
-using RabbitMQ.Client.Exceptions;
-using RabbitMQ.Util;
 
 namespace RabbitMQ.Client.Impl
 {
@@ -54,6 +54,7 @@ namespace RabbitMQ.Client.Impl
 
         // Timeout in seconds to wait for a clean socket close.
         public const int SOCKET_CLOSING_TIMEOUT = 1;
+
         public const int WSAEWOULDBLOCK = 10035;
 
         public NetworkBinaryReader m_reader;
@@ -79,8 +80,8 @@ namespace RabbitMQ.Client.Impl
                 {
                     m_socket = null;
                 }
-                    // Mono might raise a SocketException when using IPv4 addresses on
-                    // an OS that supports IPv6
+                // Mono might raise a SocketException when using IPv4 addresses on
+                // an OS that supports IPv6
                 catch (SocketException)
                 {
                     m_socket = null;
@@ -163,7 +164,8 @@ namespace RabbitMQ.Client.Impl
                     try
                     {
                         m_socket.LingerState = new LingerOption(true, SOCKET_CLOSING_TIMEOUT);
-                    } catch (ArgumentException _)
+                    }
+                    catch (ArgumentException _)
                     {
                         // ignore, we are closing anyway
                     }

--- a/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
@@ -160,7 +160,13 @@ namespace RabbitMQ.Client.Impl
             {
                 if (!_closed)
                 {
-                    m_socket.LingerState = new LingerOption(true, SOCKET_CLOSING_TIMEOUT);
+                    try
+                    {
+                        m_socket.LingerState = new LingerOption(true, SOCKET_CLOSING_TIMEOUT);
+                    } catch (ArgumentException _)
+                    {
+                        // ignore, we are closing anyway
+                    }
                     m_socket.Close();
                     _closed = true;
                 }

--- a/projects/client/Unit/RabbitMQ.Client.Unit.csproj
+++ b/projects/client/Unit/RabbitMQ.Client.Unit.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Warning! This file contains important customizations. Using Visual Studio to edit project's properties might break things. -->
   <!-- Props file -->
@@ -110,6 +110,7 @@
     <Compile Include="src\unit\TestExtensions.cs" />
     <Compile Include="src\unit\TestFieldTableFormatting.cs" />
     <Compile Include="src\unit\TestFieldTableFormattingGeneric.cs" />
+    <Compile Include="src\unit\TestHeartbeats.cs" />    
     <Compile Include="src\unit\TestIntAllocator.cs" />
     <Compile Include="src\unit\TestInvalidAck.cs" />
     <Compile Include="src\unit\TestMainLoop.cs" />

--- a/projects/client/Unit/src/unit/Fixtures.cs
+++ b/projects/client/Unit/src/unit/Fixtures.cs
@@ -320,6 +320,11 @@ namespace RabbitMQ.Client.Unit
             AssertShutdownError(args, Constants.PreconditionFailed);
         }
 
+        protected bool InitiatedByPeerOrLibrary(ShutdownEventArgs evt)
+        {
+            return !(evt.Initiator == ShutdownInitiator.Application);
+        }
+
         //
         // Concurrency
         //
@@ -372,7 +377,7 @@ namespace RabbitMQ.Client.Unit
         {
             var proc = new Process
             {
-                StartInfo = 
+                StartInfo =
                 {
                     CreateNoWindow = true,
                     UseShellExecute = false

--- a/projects/client/Unit/src/unit/TestHeartbeats.cs
+++ b/projects/client/Unit/src/unit/TestHeartbeats.cs
@@ -55,6 +55,12 @@ namespace RabbitMQ.Client.Unit
         [Category("Focus")]
         public void TestThatHeartbeatWriterUsesConfigurableInterval()
         {
+            if (!LongRunningTestsEnabled())
+            {
+                Console.WriteLine("RABBITMQ_LONG_RUNNING_TESTS is not set, skipping test");
+                return;
+            }
+
             var cf = new ConnectionFactory()
             {
                 RequestedHeartbeat = heartbeatTimeout,
@@ -75,7 +81,7 @@ namespace RabbitMQ.Client.Unit
                     }
                 }
             };
-            Thread.Sleep(heartbeatTimeout * 10 * 1000);
+            SleepFor(30);
 
             Assert.IsFalse(wasShutdown, "shutdown event should not have been fired");
             Assert.IsTrue(conn.IsOpen, "connection should be open");
@@ -87,6 +93,13 @@ namespace RabbitMQ.Client.Unit
         [Category("Focus")]
         public void TestHundredsOfConnectionsWithRandomHeartbeatInterval()
         {
+            if (!LongRunningTestsEnabled())
+            {
+                Console.WriteLine("RABBITMQ_LONG_RUNNING_TESTS is not set, skipping test");
+                return;
+            }
+
+
             var rnd = new Random();
             List<IConnection> xs = new List<IConnection>();
             for(var i = 0; i < 200; i++)
@@ -104,7 +117,7 @@ namespace RabbitMQ.Client.Unit
                     };
             }
 
-            Thread.Sleep(20 * 1000);
+            SleepFor(60);
 
             foreach(var x in xs)
             {
@@ -122,6 +135,22 @@ namespace RabbitMQ.Client.Unit
                 Console.WriteLine(s);
                 Assert.Fail(s);
             }
+        }
+
+        private bool LongRunningTestsEnabled()
+        {
+            var s = Environment.GetEnvironmentVariable("RABBITMQ_LONG_RUNNING_TESTS");
+            if(s == null || s.Equals(""))
+            {
+                return false;
+            }
+            return true;
+        }
+
+        private void SleepFor(int t)
+        {
+            Console.WriteLine("Testing heartbeats, sleeping for {0} seconds", t);
+            Thread.Sleep(t * 1000);
         }
     }
 }

--- a/projects/client/Unit/src/unit/TestHeartbeats.cs
+++ b/projects/client/Unit/src/unit/TestHeartbeats.cs
@@ -52,7 +52,6 @@ namespace RabbitMQ.Client.Unit
         private const UInt16 heartbeatTimeout = 2;
 
         [Test]
-        [Category("Focus")]
         public void TestThatHeartbeatWriterUsesConfigurableInterval()
         {
             if (!LongRunningTestsEnabled())
@@ -74,7 +73,7 @@ namespace RabbitMQ.Client.Unit
             {
                 lock (conn)
                 {
-                    if(InitiatedByPeerOrLibrary(evt))
+                    if (InitiatedByPeerOrLibrary(evt))
                     {
                         CheckInitiator(evt);
                         wasShutdown = true;
@@ -90,7 +89,6 @@ namespace RabbitMQ.Client.Unit
         }
 
         [Test]
-        [Category("Focus")]
         public void TestHundredsOfConnectionsWithRandomHeartbeatInterval()
         {
             if (!LongRunningTestsEnabled())
@@ -99,10 +97,9 @@ namespace RabbitMQ.Client.Unit
                 return;
             }
 
-
             var rnd = new Random();
             List<IConnection> xs = new List<IConnection>();
-            for(var i = 0; i < 200; i++)
+            for (var i = 0; i < 200; i++)
             {
                 var n = Convert.ToUInt16(rnd.Next(2, 6));
                 var cf = new ConnectionFactory() { RequestedHeartbeat = n, AutomaticRecoveryEnabled = false };
@@ -119,16 +116,15 @@ namespace RabbitMQ.Client.Unit
 
             SleepFor(60);
 
-            foreach(var x in xs)
+            foreach (var x in xs)
             {
                 x.Close();
             }
-
         }
 
         private void CheckInitiator(ShutdownEventArgs evt)
         {
-            if(InitiatedByPeerOrLibrary(evt))
+            if (InitiatedByPeerOrLibrary(evt))
             {
                 var s = String.Format("Shutdown: {0}, initiated by: {1}",
                                       evt, evt.Initiator);
@@ -140,7 +136,7 @@ namespace RabbitMQ.Client.Unit
         private bool LongRunningTestsEnabled()
         {
             var s = Environment.GetEnvironmentVariable("RABBITMQ_LONG_RUNNING_TESTS");
-            if(s == null || s.Equals(""))
+            if (s == null || s.Equals(""))
             {
                 return false;
             }

--- a/projects/client/Unit/src/unit/TestHeartbeats.cs
+++ b/projects/client/Unit/src/unit/TestHeartbeats.cs
@@ -1,0 +1,75 @@
+// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 1.1.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (C) 2007-2014 GoPivotal, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v1.1:
+//
+//---------------------------------------------------------------------------
+//  The contents of this file are subject to the Mozilla Public License
+//  Version 1.1 (the "License"); you may not use this file except in
+//  compliance with the License. You may obtain a copy of the License
+//  at http://www.mozilla.org/MPL/
+//
+//  Software distributed under the License is distributed on an "AS IS"
+//  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+//  the License for the specific language governing rights and
+//  limitations under the License.
+//
+//  The Original Code is RabbitMQ.
+//
+//  The Initial Developer of the Original Code is GoPivotal, Inc.
+//  Copyright (c) 2007-2014 GoPivotal, Inc.  All rights reserved.
+//---------------------------------------------------------------------------
+
+using NUnit.Framework;
+using RabbitMQ.Client.Impl;
+using System;
+using System.Threading;
+
+namespace RabbitMQ.Client.Unit
+{
+    [TestFixture]
+    internal class TestHeartbeats : IntegrationFixture
+    {
+        private const UInt16 heartbeatTimeout = 2;
+
+        [Test]
+        [Category("Focus")]
+        public void TestThatHeartbeatWriterUsesConfigurableInterval()
+        {
+            var cf = new ConnectionFactory() { RequestedHeartbeat = heartbeatTimeout, AutomaticRecoveryEnabled = false };
+            var conn = cf.CreateConnection();
+            var ch = conn.CreateModel();
+            bool wasShutdown = false;
+
+            conn.ConnectionShutdown += (sender, evt) =>
+            {
+                lock(conn)
+                {
+                    wasShutdown = true;
+                }
+            };
+            Thread.Sleep(heartbeatTimeout * 10 * 1000);
+
+            Assert.IsFalse(wasShutdown, "shutdown event should not have been fired");
+            Assert.IsTrue(conn.IsOpen, "connection should be open");
+        }
+    }
+}

--- a/projects/client/Unit/src/unit/TestHeartbeats.cs
+++ b/projects/client/Unit/src/unit/TestHeartbeats.cs
@@ -54,14 +54,18 @@ namespace RabbitMQ.Client.Unit
         [Category("Focus")]
         public void TestThatHeartbeatWriterUsesConfigurableInterval()
         {
-            var cf = new ConnectionFactory() { RequestedHeartbeat = heartbeatTimeout, AutomaticRecoveryEnabled = false };
+            var cf = new ConnectionFactory()
+            {
+                RequestedHeartbeat = heartbeatTimeout,
+                AutomaticRecoveryEnabled = false
+            };
             var conn = cf.CreateConnection();
             var ch = conn.CreateModel();
             bool wasShutdown = false;
 
             conn.ConnectionShutdown += (sender, evt) =>
             {
-                lock(conn)
+                lock (conn)
                 {
                     wasShutdown = true;
                 }


### PR DESCRIPTION
With this change .NET client uses the same approach as the Java
one.

Previously in 3.5.x we've used two timers that
re-scheduled themselves and used auto-reset events to be
notified about connection activity on the I/O loop.

This turned out to have some issues:

 * It was clever but fairly complicated
 * Picking the wrong heartbeat interval value led to sporadic
   failures due to race conditions [on the wire]
 * It didn't play well with socket timeouts

Our new strategy is more straightforward:
heartbeat writer uses a periodic timer that always sends
a frame, regardless of recent activity, every 1/2nd a timeout.

Given that heartbeat timeouts are often in minutes, this is not
unreasonable but possibly the most straightforward implementation
possible. It also doesn't suffer from race conditions on the wire
because we send a heartbeat frame every half the interval, so
slight inaccuracy in .NET runtime scheduling of timers won't
get in our way with reasonable (> 1 second) heartbeat intervals.

Heartbeat "reader" now relies on the socket receive timeout,
just like in the Java client. This is more straightforward
and there is no dissonance between I/O timeouts and the one we
use for incoming heartbeats.

Various cases when a SocketException could indicate a problem
other than a timeout (usually early in the connection
lifecycle) are accounted for.