### PR TITLE
Make WinRT compile with recent heartbeat implementation changes

### DIFF
--- a/projects/client/RabbitMQ.Client.WinRT/src/client/impl/SocketFrameHandler.cs
+++ b/projects/client/RabbitMQ.Client.WinRT/src/client/impl/SocketFrameHandler.cs
@@ -61,7 +61,6 @@ namespace RabbitMQ.Client.Impl
         public const int SOCKET_CLOSING_TIMEOUT = 1;
 
         public StreamSocket m_socket;
-        private CancellationTokenSource cts;
         public NetworkBinaryReader m_reader;
         public NetworkBinaryWriter m_writer;
         private bool _closed = false;
@@ -83,7 +82,7 @@ namespace RabbitMQ.Client.Impl
                 IAsyncAction ar = null;
                 try
                 {
-                    cts = new CancellationTokenSource();
+                    var cts = new CancellationTokenSource();
                     if (this.defaultTimeout.HasValue)
                         cts.CancelAfter(this.defaultTimeout.Value);
 
@@ -135,11 +134,6 @@ namespace RabbitMQ.Client.Impl
         {
             set
             {
-                defaultTimeout = value;
-                if (cts != null && cts.Token.CanBeCanceled)
-                {
-                    cts.CancelAfter(value);
-                }
             }
         }
 
@@ -152,7 +146,6 @@ namespace RabbitMQ.Client.Impl
                     // TODO: Figure out the equivalent for LingerState
                     //m_socket.LingerState = new LingerOption(true, SOCKET_CLOSING_TIMEOUT);
                     m_socket.Dispose();
-                    cts.Dispose();
                     _closed = true;
                 }
             }
@@ -203,7 +196,7 @@ namespace RabbitMQ.Client.Impl
             IAsyncAction ar = null;
             try
             {
-                cts = new CancellationTokenSource();
+                var cts = new CancellationTokenSource();
                 if (this.defaultTimeout.HasValue)
                     cts.CancelAfter(this.defaultTimeout.Value);
 

--- a/projects/client/RabbitMQ.Client.WinRT/src/client/impl/SocketFrameHandler.cs
+++ b/projects/client/RabbitMQ.Client.WinRT/src/client/impl/SocketFrameHandler.cs
@@ -38,24 +38,21 @@
 //  Copyright (c) 2007-2014 GoPivotal, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
+using RabbitMQ.Client.Exceptions;
+using RabbitMQ.Util;
 using System;
 using System.IO;
 using System.Text;
-
 using System.Threading;
-
 using Windows.Foundation;
 using Windows.Networking;
 using Windows.Networking.Sockets;
 
-using RabbitMQ.Util;
-using RabbitMQ.Client.Exceptions;
-
 namespace RabbitMQ.Client.Impl
 {
     /// <summary>
-    /// Implement <see cref="IFrameHandler"/> for WinRT.  The significant 
-    /// difference is that TcpClient is not available and the new 
+    /// Implement <see cref="IFrameHandler"/> for WinRT.  The significant
+    /// difference is that TcpClient is not available and the new
     /// <see cref="StreamSocket"/> needs to be used.
     /// </summary>
     public class SocketFrameHandler : IFrameHandler
@@ -89,7 +86,7 @@ namespace RabbitMQ.Client.Impl
                     cts = new CancellationTokenSource();
                     if (this.defaultTimeout.HasValue)
                         cts.CancelAfter(this.defaultTimeout.Value);
-                    
+
                     ar = this.m_socket.UpgradeToSslAsync(
                         SocketProtectionLevel.Ssl, new HostName(endpoint.Ssl.ServerName));
                     ar.AsTask(cts.Token).Wait();
@@ -122,6 +119,7 @@ namespace RabbitMQ.Client.Impl
                 return port;
             }
         }
+
         public int RemotePort
         {
             get
@@ -154,6 +152,7 @@ namespace RabbitMQ.Client.Impl
                     // TODO: Figure out the equivalent for LingerState
                     //m_socket.LingerState = new LingerOption(true, SOCKET_CLOSING_TIMEOUT);
                     m_socket.Dispose();
+                    cts.Dispose();
                     _closed = true;
                 }
             }

--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -592,7 +592,6 @@ namespace RabbitMQ.Client.Framing.Impl
                     e));
                 shouldTerminate = true;
             }
-
             if (m_closed || shouldTerminate)
             {
                 TerminateMainloop();
@@ -684,7 +683,7 @@ namespace RabbitMQ.Client.Framing.Impl
                         }
                         else
                         {
-                            throw;
+                            throw ex;
                         }
                     }
 #else

--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -47,9 +47,11 @@ using System.Collections.Generic;
 using System.IO;
 
 #if NETFX_CORE
+
 using System.Threading.Tasks;
 using Windows.Networking.Sockets;
 using Windows.ApplicationModel;
+
 #else
 using System.Net;
 using System.Net.Sockets;
@@ -121,14 +123,14 @@ namespace RabbitMQ.Client.Framing.Impl
             StartMainLoop(factory.UseBackgroundThreadsForIO);
             Open(insist);
             StartHeartbeatTimer();
-            
+
 #if NETFX_CORE
 #pragma warning disable 0168
             try
             {
                 Windows.UI.Xaml.Application.Current.Suspending += this.HandleApplicationSuspend;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 // If called from a desktop app (i.e. unit tests), then there is no current application
             }
@@ -316,7 +318,7 @@ namespace RabbitMQ.Client.Framing.Impl
         {
             Assembly assembly =
 #if NETFX_CORE
-                System.Reflection.IntrospectionExtensions.GetTypeInfo(typeof(Connection)).Assembly;
+ System.Reflection.IntrospectionExtensions.GetTypeInfo(typeof(Connection)).Assembly;
 #else
                 System.Reflection.Assembly.GetAssembly(typeof(Connection));
 #endif
@@ -511,6 +513,7 @@ namespace RabbitMQ.Client.Framing.Impl
         }
 
 #if NETFX_CORE
+
         /// <remarks>
         /// We need to close the socket, otherwise suspending the application will take the maximum time allowed
         /// </remarks>
@@ -518,6 +521,7 @@ namespace RabbitMQ.Client.Framing.Impl
         {
             Abort(Constants.InternalError, "Application Suspend");
         }
+
 #else
         /// <remarks>
         /// We need to close the socket, otherwise attempting to unload the domain
@@ -668,7 +672,7 @@ namespace RabbitMQ.Client.Framing.Impl
                     try
                     {
                         ClosingLoop();
-                    } 
+                    }
 #if NETFX_CORE
                     catch (Exception ex)
                     {
@@ -756,10 +760,12 @@ namespace RabbitMQ.Client.Framing.Impl
                     }
                 }
             }
+#if !NETFX_CORE
             catch (SocketException ioe)
             {
                 HandleIOException(ioe);
             }
+#endif
             catch (IOException ioe)
             {
                 HandleIOException(ioe);
@@ -943,7 +949,7 @@ namespace RabbitMQ.Client.Framing.Impl
 #else
                 Console.Error.WriteLine(
 #endif
-                    "No errors reported when closing connection {0}", this);
+"No errors reported when closing connection {0}", this);
             }
             else
             {
@@ -952,15 +958,15 @@ namespace RabbitMQ.Client.Framing.Impl
 #else
                 Console.Error.WriteLine(
 #endif
-                    "Log of errors while closing connection {0}:", this);
+"Log of errors while closing connection {0}:", this);
                 foreach (ShutdownReportEntry entry in ShutdownReport)
                 {
 #if NETFX_CORE
-                System.Diagnostics.Debug.WriteLine(
+                    System.Diagnostics.Debug.WriteLine(
 #else
                     Console.Error.WriteLine(
 #endif
-                        entry.ToString());
+entry.ToString());
                 }
             }
         }

--- a/projects/client/RabbitMQ.Client/src/client/impl/Frame.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Frame.cs
@@ -47,7 +47,9 @@ using System.IO;
 #if NETFX_CORE
 using Windows.Networking.Sockets;
 #else
+
 using System.Net.Sockets;
+
 #endif
 
 namespace RabbitMQ.Client.Impl
@@ -145,7 +147,6 @@ namespace RabbitMQ.Client.Impl
                     throw ioe;
                 }
                 throw ioe.InnerException;
-
 #endif
             }
 

--- a/projects/client/Unit/src/unit/TestConsumerOperationDispatch.cs
+++ b/projects/client/Unit/src/unit/TestConsumerOperationDispatch.cs
@@ -57,17 +57,16 @@ namespace RabbitMQ.Client.Unit
         private List<CollectingConsumer> consumers = new List<CollectingConsumer>();
 
         // number of channels (and consumers)
-        private const int y = 200;
+        private const int y = 100;
 
         // number of messages to be published
-        private const int n = 250;
+        private const int n = 100;
 
         public static CountdownEvent counter = new CountdownEvent(y);
 
         [TearDown]
         protected override void ReleaseResources()
         {
-            base.ReleaseResources();
             foreach (var ch in channels)
             {
                 if (ch.IsOpen)
@@ -78,6 +77,7 @@ namespace RabbitMQ.Client.Unit
             queues.Clear();
             consumers.Clear();
             counter.Reset();
+            base.ReleaseResources();
         }
 
         private class CollectingConsumer : DefaultBasicConsumer

--- a/projects/client/Unit/src/unit/TestHeartbeats.cs
+++ b/projects/client/Unit/src/unit/TestHeartbeats.cs
@@ -55,12 +55,6 @@ namespace RabbitMQ.Client.Unit
         [Category("LongRunning")]
         public void TestThatHeartbeatWriterUsesConfigurableInterval()
         {
-            if (!LongRunningTestsEnabled())
-            {
-                Console.WriteLine("RABBITMQ_LONG_RUNNING_TESTS is not set, skipping test");
-                return;
-            }
-
             var cf = new ConnectionFactory()
             {
                 RequestedHeartbeat = heartbeatTimeout,
@@ -93,12 +87,6 @@ namespace RabbitMQ.Client.Unit
         [Category("LongRunning")]
         public void TestHundredsOfConnectionsWithRandomHeartbeatInterval()
         {
-            if (!LongRunningTestsEnabled())
-            {
-                Console.WriteLine("RABBITMQ_LONG_RUNNING_TESTS is not set, skipping test");
-                return;
-            }
-
             var rnd = new Random();
             List<IConnection> xs = new List<IConnection>();
             for (var i = 0; i < 200; i++)
@@ -133,16 +121,6 @@ namespace RabbitMQ.Client.Unit
                 Console.WriteLine(s);
                 Assert.Fail(s);
             }
-        }
-
-        private bool LongRunningTestsEnabled()
-        {
-            var s = Environment.GetEnvironmentVariable("RABBITMQ_LONG_RUNNING_TESTS");
-            if (s == null || s.Equals(""))
-            {
-                return false;
-            }
-            return true;
         }
 
         private void SleepFor(int t)

--- a/projects/client/Unit/src/unit/TestHeartbeats.cs
+++ b/projects/client/Unit/src/unit/TestHeartbeats.cs
@@ -44,6 +44,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 
+#if !NETFX_CORE
 namespace RabbitMQ.Client.Unit
 {
     [TestFixture]
@@ -128,3 +129,4 @@ namespace RabbitMQ.Client.Unit
         }
     }
 }
+#endif

--- a/projects/client/Unit/src/unit/TestHeartbeats.cs
+++ b/projects/client/Unit/src/unit/TestHeartbeats.cs
@@ -51,8 +51,7 @@ namespace RabbitMQ.Client.Unit
     {
         private const UInt16 heartbeatTimeout = 2;
 
-        [Test]
-        [Category("LongRunning")]
+        [Test, Category("LongRunning"), Timeout(35000)]
         public void TestThatHeartbeatWriterUsesConfigurableInterval()
         {
             var cf = new ConnectionFactory()
@@ -83,8 +82,7 @@ namespace RabbitMQ.Client.Unit
             conn.Close();
         }
 
-        [Test]
-        [Category("LongRunning")]
+        [Test, Category("LongRunning"), Timeout(65000)]
         public void TestHundredsOfConnectionsWithRandomHeartbeatInterval()
         {
             var rnd = new Random();


### PR DESCRIPTION
Fixes #72.

The right thing to do is #82, but at least the WinRT client compiles and passes over 98% of tests.

I've tried re-working `NetworkBinaryReader` and related classes for async I/O in 4.5 and async/await. That almost gets us there but eventually WinRT classes leak in the API, making unit tests project require both classes in .NET 4.5 and WinRT. So we need a properly designed solution.