### PR TITLE
Replace hostnames with full endpoints in AutorecoveringConnection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ projects/client/Unit*/TestResult.xml
 
 *.fsx
 *.pcap
+*.nupkg
 
 # Vim
 .sw?

--- a/projects/client/RabbitMQ.Client/RabbitMQ.Client.csproj
+++ b/projects/client/RabbitMQ.Client/RabbitMQ.Client.csproj
@@ -139,7 +139,7 @@
     <Compile Include="src\client\api\IConnection.cs" />
     <Compile Include="src\client\api\IConnectionFactory.cs" />
     <Compile Include="src\client\api\IContentHeader.cs" />
-    <Compile Include="src\client\api\IHostnameSelector.cs" />
+    <Compile Include="src\client\api\IEndpointSelector.cs" />
     <Compile Include="src\client\api\IMethod.cs" />
     <Compile Include="src\client\api\IModel.cs" />
     <Compile Include="src\client\api\IProtocol.cs" />
@@ -235,7 +235,7 @@
     <Compile Include="src\client\impl\ProtocolBase.cs" />
     <Compile Include="src\client\impl\ProtocolException.cs" />
     <Compile Include="src\client\impl\QuiescingSession.cs" />
-    <Compile Include="src\client\impl\RandomHostnameSelector.cs" />
+    <Compile Include="src\client\impl\RandomEndpointSelector.cs" />
     <Compile Include="src\client\impl\RecordedBinding.cs" />
     <Compile Include="src\client\impl\RecordedConsumer.cs" />
     <Compile Include="src\client\impl\RecordedEntity.cs" />

--- a/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
@@ -265,11 +265,12 @@ namespace RabbitMQ.Client
                 {
                     protocol = "amqps";
                 }
-                var uriString = protocol + "://" + HostName + ":" + Port + "/";
-                if (VirtualHost != null && !VirtualHost.Equals(""))
+                var uriString = protocol + "://" + HostName;
+                if (Port != AmqpTcpEndpoint.UseDefaultPort)
                 {
-                    uriString = uriString + VirtualHost;
+                    uriString += ":" + Port;
                 }
+                uriString += VirtualHost;
                 return uriString;
             }
         }

--- a/projects/client/RabbitMQ.Client/src/client/api/IEndpointSelector.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IEndpointSelector.cs
@@ -43,14 +43,15 @@ using System.Collections.Generic;
 
 namespace RabbitMQ.Client
 {
-    public interface IHostnameSelector
+    public interface IEndpointSelector
     {
         /// <summary>
-        /// Picks a hostname from a list of options that should be used
+        /// Picks an endpoint from a list of options that should be used
         /// by <see cref="IConnectionFactory"/>.
         /// </summary>
         /// <param name="options"></param>
         /// <returns></returns>
-        string NextFrom(IList<string> options);
+        AmqpTcpEndpoint NextFrom(IList<AmqpTcpEndpoint> options);
+       
     }
 }

--- a/projects/client/RabbitMQ.Client/src/client/api/SslOption.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/SslOption.cs
@@ -53,7 +53,7 @@ namespace RabbitMQ.Client
     /// <summary>
     /// Represents a configurable SSL option, used in setting up an SSL connection.
     /// </summary>
-    public class SslOption
+    public class SslOption:ICloneable
     {
 #if !NETFX_CORE
         private X509CertificateCollection _certificateCollection;
@@ -161,5 +161,10 @@ namespace RabbitMQ.Client
         /// </summary>
         public SslProtocols Version { get; set; }
 #endif
+
+        public Object Clone() 
+        {
+            return MemberwiseClone();
+        }
     }
 }

--- a/projects/client/RabbitMQ.Client/src/client/impl/RandomEndpointSelector.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RandomEndpointSelector.cs
@@ -6,9 +6,9 @@ using System.Threading.Tasks;
 
 namespace RabbitMQ.Client.Impl
 {
-    class RandomHostnameSelector : IHostnameSelector
+    class RandomEndpointSelector : IEndpointSelector
     {
-        string IHostnameSelector.NextFrom(IList<string> options)
+        AmqpTcpEndpoint IEndpointSelector.NextFrom(IList<AmqpTcpEndpoint> options)
         {
             return options.RandomItem();
         }

--- a/projects/client/Unit/src/unit/TestConnectionFactory.cs
+++ b/projects/client/Unit/src/unit/TestConnectionFactory.cs
@@ -44,16 +44,16 @@ using NUnit.Framework;
 namespace RabbitMQ.Client.Unit
 {
     [TestFixture]
-    class TestConnectionFactory 
+    class TestConnectionFactory
     {
         [Test]
         public void TestProperties()
         {
-            var u  = "username";
+            var u = "username";
             var pw = "password";
-            var v  = "vhost";
-            var h  = "192.168.0.1";
-            var p  = 5674;
+            var v = "vhost";
+            var h = "192.168.0.1";
+            var p = 5674;
 
             var cf = new ConnectionFactory();
             cf.UserName = u;
@@ -67,6 +67,31 @@ namespace RabbitMQ.Client.Unit
             Assert.AreEqual(cf.VirtualHost, v);
             Assert.AreEqual(cf.HostName, h);
             Assert.AreEqual(cf.Port, p);
+        }
+
+        [Test]
+        public void TestClusterConnectionFactory()
+        {
+            var u = "username";
+            var pw = "password";
+            var v = "vhost";
+            var h = "192.168.0.1";
+            var p = 5674;
+
+            var cf = new ConnectionFactory();
+            cf.Uris = new Uri[]
+            {
+                new Uri("amqp://localhost:5675/vhost"),
+                new Uri("amqp://localhost:5676/vhost"),
+                new Uri("amqp://localhost:5677/vhost")
+            };
+            // Check that the initial parameters did not change
+            Assert.AreEqual(cf.UserName, u);
+            Assert.AreEqual(cf.Password, pw);
+            Assert.AreEqual(cf.VirtualHost, v);
+            Assert.AreEqual(cf.HostName, h);
+            Assert.AreEqual(cf.Port, p);
+            
         }
     }
 }


### PR DESCRIPTION
I am currently doing integration on a private project and was in the process of building a reconnection layer over the Official driver when I saw that you had a prototype implementation on head.

In our environnement, while in production the assumption that the only changing parameter in a cluster is the FQDN, this assumption cannot hold on all our environnements, in particular in integration testing where we need to spawn an ephemeral cluster and test failure modes on a single testing factory node.

This patch adds an Urls property to the ConnectionFactory that can consume a list of amqp urls, underneath is replaces the list of hostnames with a list of AmqTcpEndpoints (going further and having different SSL policies, different login/passwords, etc.. does not seem to fit within a single ConnectionFactory and is highly non probable in a RabbitMQ cluster)

I'll keep in touch when we start doing failure mode exploration, we may find some edge cases since our IT can be a little peculiar :smile: 