### PR TITLE
Stop Heartbeat timers before disposing them

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -1094,10 +1094,12 @@ entry.ToString());
         {
             if(_heartbeatReadTimer != null)
             {
+                _heartbeatReadTimer.Change(Timeout.Infinite, Timeout.Infinite);
                 _heartbeatReadTimer.Dispose();
             }
             if(_heartbeatWriteTimer != null)
             {
+                _heartbeatWriteTimer.Change(Timeout.Infinite, Timeout.Infinite);
                 _heartbeatWriteTimer.Dispose();
             }
         }


### PR DESCRIPTION
To prevent any further callbacks and allow background threads to exit
