### PR TITLE
fix turkish I problem during code generation

### DIFF
--- a/projects/client/Apigen/src/apigen/Apigen.cs
+++ b/projects/client/Apigen/src/apigen/Apigen.cs
@@ -133,7 +133,7 @@ namespace RabbitMQ.Client.Apigen {
         public static string MangleClass(string name) {
             StringBuilder sb = new StringBuilder();
             foreach (String s in IdentifierParts(name)) {
-                sb.Append(Char.ToUpper(s[0]) + s.Substring(1).ToLower());
+                sb.Append(Char.ToUpperInvariant(s[0]) + s.Substring(1).ToLowerInvariant());
             }
             return sb.ToString();
         }
@@ -143,9 +143,9 @@ namespace RabbitMQ.Client.Apigen {
             bool useUpper = false;
             foreach (String s in IdentifierParts(name)) {
                 if (useUpper) {
-                    sb.Append(Char.ToUpper(s[0]) + s.Substring(1).ToLower());
+                    sb.Append(Char.ToUpperInvariant(s[0]) + s.Substring(1).ToLowerInvariant());
                 } else {
-                    sb.Append(s.ToLower());
+                    sb.Append(s.ToLowerInvariant());
                     useUpper = true;
                 }
             }


### PR DESCRIPTION
If project is compiled with Turkish Regional Settings, generated identifiers have Turkish I problem. It causes compilation errors as follows:

```
error CS0115: 'RabbitMQ.Client.Framing.BasicProperties.Correlationİd': no suitable method found to override
```

Notice İ in `Correlationİd`

This commit fixes it.
