### PR TITLE
Dispose method should not throw an exception

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
@@ -304,18 +304,25 @@ namespace RabbitMQ.Client.Impl
                 k.Wait();
                 ConsumerDispatcher.Shutdown(this);
             }
-            catch (AlreadyClosedException ace)
+            catch (AlreadyClosedException)
             {
                 if (!abort)
                 {
-                    throw ace;
+                    throw;
                 }
             }
-            catch (IOException ioe)
+            catch (IOException)
             {
                 if (!abort)
                 {
-                    throw ioe;
+                    throw;
+                }
+            }
+            catch (Exception)
+            {
+                if (!abort)
+                {
+                    throw;
                 }
             }
         }
@@ -677,7 +684,7 @@ namespace RabbitMQ.Client.Impl
 
         void IDisposable.Dispose()
         {
-            Close();
+            Abort();
         }
 
         public abstract void ConnectionTuneOk(ushort channelMax,


### PR DESCRIPTION
What about just calling `Abort` instead of `Close`?

I've also change the `throw ex` into just `throw`, I don't know if the wanted behavior was to reset the stacktrace, because `throw ex` it does exactly that, it resets the stacktrace and that is not so kind when debugging, in other words you don't know which method generated the exception.

I've also added the catch of all generic Exception, and probably here I'm pushing too far :smile: probably that kind of try-catch should be moved in the Dispose itself, just tracing any exception without throwing up.

fixes #119 