### PR TITLE
Dispose method should not throw an exception

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/IModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IModel.cs
@@ -163,7 +163,7 @@ namespace RabbitMQ.Client
         /// operation to complete. This method will not return to the
         /// caller until the shutdown is complete.
         /// In comparison to normal <see cref="Close()"/> method, <see cref="Abort()"/> will not throw
-        /// <see cref="Exceptions.AlreadyClosedException"/> or <see cref="IOException"/> during closing model.
+        /// <see cref="Exceptions.AlreadyClosedException"/> or <see cref="IOException"/> or any other <see cref="Exception"/> during closing model.
         /// </remarks>
         [AmqpMethodDoNotImplement(null)]
         void Abort();

--- a/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
@@ -300,18 +300,25 @@ namespace RabbitMQ.Client.Impl
                 k.Wait();
                 ConsumerDispatcher.Shutdown(this);
             }
-            catch (AlreadyClosedException ace)
+            catch (AlreadyClosedException)
             {
                 if (!abort)
                 {
-                    throw ace;
+                    throw;
                 }
             }
-            catch (IOException ioe)
+            catch (IOException)
             {
                 if (!abort)
                 {
-                    throw ioe;
+                    throw;
+                }
+            }
+            catch (Exception)
+            {
+                if (!abort)
+                {
+                    throw;
                 }
             }
         }
@@ -673,7 +680,7 @@ namespace RabbitMQ.Client.Impl
 
         void IDisposable.Dispose()
         {
-            Close();
+            Abort();
         }
 
         public abstract void ConnectionTuneOk(ushort channelMax,


### PR DESCRIPTION
I've also added a comment to specify that now any kind of exception are in fact not thrown by `Abort()`

Fixes #119 