### PR TITLE
Fixing race condition with models in AutorecoveringConnection

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
@@ -539,7 +539,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public void UnregisterModel(AutorecoveringModel model)
         {
-            lock (this)
+            lock (m_models)
             {
                 m_models.Remove(model);
             }
@@ -640,7 +640,7 @@ namespace RabbitMQ.Client.Framing.Impl
             AutorecoveringModel m;
             m = new AutorecoveringModel(this,
                 CreateNonRecoveringModel());
-            lock (this)
+            lock (m_models)
             {
                 m_models.Add(m);
             }


### PR DESCRIPTION
`CreateModel` and `UnregisterModel` methods lock on `this`, instead of using `m_models`, which is used by `RecoverModels` method. This creates a race condition, where `m_models` collection can be modified while models are being recovered, resulting in _"Collection was modified; enumeration operation may not execute"_ exception in `RecoverModels`.
