### PR TITLE
Add tests for publisher confirms API in IModel

### DIFF
--- a/projects/client/Unit/RabbitMQ.Client.Unit.csproj
+++ b/projects/client/Unit/RabbitMQ.Client.Unit.csproj
@@ -124,6 +124,7 @@
     <Compile Include="src\unit\TestPassiveDeclare.cs" />
     <Compile Include="src\unit\TestPropertiesClone.cs" />
     <Compile Include="src\unit\TestPublicationAddress.cs" />
+    <Compile Include="src\unit\TestPublisherConfirms.cs" />
     <Compile Include="src\unit\TestQueueDeclare.cs" />
     <Compile Include="src\unit\TestRecoverAfterCancel.cs" />
     <Compile Include="src\unit\TestSharedQueue.cs" />

--- a/projects/client/Unit/src/unit/TestPublisherConfirms.cs
+++ b/projects/client/Unit/src/unit/TestPublisherConfirms.cs
@@ -1,0 +1,67 @@
+﻿// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 1.1.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (C) 2007-2015 Pivotal Software, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v1.1:
+//
+//---------------------------------------------------------------------------
+//  The contents of this file are subject to the Mozilla Public License
+//  Version 1.1 (the "License"); you may not use this file except in
+//  compliance with the License. You may obtain a copy of the License
+//  at http://www.mozilla.org/MPL/
+//
+//  Software distributed under the License is distributed on an "AS IS"
+//  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+//  the License for the specific language governing rights and
+//  limitations under the License.
+//
+//  The Original Code is RabbitMQ.
+//
+//  The Initial Developer of the Original Code is GoPivotal, Inc.
+//  Copyright (c) 2007-2015 Pivotal Software, Inc.  All rights reserved.
+//---------------------------------------------------------------------------
+
+using NUnit.Framework;
+using System;
+using RabbitMQ.Client;
+
+namespace RabbitMQ.Client.Unit
+{
+    [TestFixture]
+    public class TestPublisherConfirms : IntegrationFixture
+    {
+        [Test]
+        public void TestWaitForConfirmsWithoutTimeout()
+        {
+            var ch = Conn.CreateModel();
+            ch.ConfirmSelect();
+
+            var q = ch.QueueDeclare().QueueName;
+
+            for (int i = 0; i < 200; i++)
+            {
+                ch.BasicPublish("", q, null, encoding.GetBytes("msg"));
+            }
+            Assert.IsTrue(ch.WaitForConfirms());
+            ch.QueueDelete(q);
+            ch.Close();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #116 (the implementation part was already there).