### PR TITLE
Added Local.props.example copy step to Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Pull requests is the primary place of discussing code changes.
 The process is fairly standard:
 
  * Fork the repository or repositories you plan on contributing to
+ * Copy `Local.props.example` into `Local.props` and make adjustments if necessary, otherwise the Solution won't load
  * Clone [RabbitMQ umbrella repository](https://github.com/rabbitmq/rabbitmq-public-umbrella)
  * `cd umbrella`, `make co`
  * Create a branch with a descriptive name in the relevant repositories


### PR DESCRIPTION
Added an extra, ncessary, step to `contributing.md` about copying the `Local.props.example` into `Local.props` to prevent Visual Studio from erroring while trying to load the projects