### PR TITLE
In AutorecoveringModel, each time the QueueBind method is called, a n…

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/RecordedBinding.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RecordedBinding.cs
@@ -53,23 +53,31 @@ namespace RabbitMQ.Client.Impl
         public string Destination { get; set; }
         public string RoutingKey { get; protected set; }
         public string Source { get; protected set; }
+		
+		public bool Equals(RecordedBinding other)
+		{
+            return other != null && 
+				   (Source.Equals(other.Source)) &&
+                   (Destination.Equals(other.Destination)) &&
+                   (RoutingKey.Equals(other.RoutingKey)) &&
+                   (Arguments == other.Arguments);
+		}
 
-        public bool Equals(RecordedBinding other)
+        public override bool Equals(object obj)
         {
-            if (ReferenceEquals(other, null))
+            if (ReferenceEquals(obj, null))
             {
                 return false;
             }
 
-            if (ReferenceEquals(this, other))
+            if (ReferenceEquals(this, obj))
             {
                 return true;
             }
 
-            return (Source.Equals(other.Source)) &&
-                   (Destination.Equals(other.Destination)) &&
-                   (RoutingKey.Equals(other.RoutingKey)) &&
-                   (Arguments == other.Arguments);
+			var other = obj as RecordedBinding;
+			
+			return Equals(other);
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
In `AutorecoveringModel`, each time the `QueueBind` method is called, a new `RecordedQueueBinding` object is created and passed to the `RecordBinding` method of the `AutorecoveringConnection` class.

That `RecordBinding` method of the `AutorecoveringConnection` class expects a single parameter of type `RecordedBinding`, which `RecordedQueueBinding` extends, and that `RecordedBinding` is added to the protected `m_recordedBindings` variable that's declared as type `HashSet<RecordedBinding>`.

Ideally, a `HashSet<T>` ensures that it keeps no duplicate instances of `T`, and, if one looks at the change made in the commit of 2014-09-30 with SHA-1 of 5db2f4407418832a6f51940a59313a1e8e6107b6, one can see that the reason for using a `HashSet` for `m_recordedBindings` is, indeed, to ensure that no duplicate bindings are retained.

In that commit, in the `AutorecoveringConnection` class, the type for `m_recordedBindings` was changed from `List<RecordedBinding>` to `HashSet<RecordedBinding>`, and the `RecordBinding` method was changed from the following:

        public void RecordBinding(RecordedBinding rb)
        {
            lock(this.m_recordedEntitiesLock)
            {
                // TODO: this operation is O(n)
                if(!m_recordedBindings.Contains(rb))
                {
                    m_recordedBindings.Add(rb);
                }
            }
        }

to this:

        public void RecordBinding(RecordedBinding rb)
        {
            lock(this.m_recordedEntitiesLock)
            {
                m_recordedBindings.Add(rb);
            }
        }

Notice that the check for whether or not the `RecordedBinding` is in the collection has been removed.

Why?

Because, again, using `HashSet<RecordedBinding>` should ensure that the collection contains no duplicates of `RecordedBinding`.

However, for that to be true, one must override both the `GetHashCode()` method and the `Equals(object obj)` method of `RecordedBinding`.

Unfortunately, while `RecordedBinding` had overridden the `GetHashCode()` method, the only custom `Equals` method defined had the following signature:

    bool Equals(RecordedBinding other)

Thus, because the `Equals(object obj)` method was not overridden, every call to `QueueBind` has resulted in a new object being added to `m_recordedBindings` in `AutorecoveringConnection`, and when one needs to *guarantee* that the queue binding is in place before publishing each message, with messages being published every second, one can see that this memory leak will cause problems quickly.