### PR TITLE
[SPIKE] Async API from Highlevel

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/IBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IBasicConsumer.cs
@@ -39,6 +39,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using RabbitMQ.Client.Events;
 
 namespace RabbitMQ.Client
@@ -67,7 +68,7 @@ namespace RabbitMQ.Client
         /// <summary>
         /// Signalled when the consumer gets cancelled.
         /// </summary>
-        event EventHandler<ConsumerEventArgs> ConsumerCancelled;
+        event AsyncEventHandler<ConsumerEventArgs> ConsumerCancelled;
 
         /// <summary>
         ///  Called when the consumer is cancelled for reasons other than by a basicCancel:
@@ -75,19 +76,19 @@ namespace RabbitMQ.Client
         ///  See <see cref="HandleBasicCancelOk"/> for notification of consumer cancellation due to basicCancel
         /// </summary>
         /// <param name="consumerTag">Consumer tag this consumer is registered.</param>
-        void HandleBasicCancel(string consumerTag);
+        Task HandleBasicCancel(string consumerTag);
 
         /// <summary>
         /// Called upon successful deregistration of the consumer from the broker.
         /// </summary>
         /// <param name="consumerTag">Consumer tag this consumer is registered.</param>
-        void HandleBasicCancelOk(string consumerTag);
+        Task HandleBasicCancelOk(string consumerTag);
 
         /// <summary>
         /// Called upon successful registration of the consumer with the broker.
         /// </summary>
         /// <param name="consumerTag">Consumer tag this consumer is registered.</param>
-        void HandleBasicConsumeOk(string consumerTag);
+        Task HandleBasicConsumeOk(string consumerTag);
 
         /// <summary>
         /// Called each time a message arrives for this consumer.
@@ -97,7 +98,7 @@ namespace RabbitMQ.Client
         /// Note that in particular, some delivered messages may require acknowledgement via <see cref="IModel.BasicAck"/>.
         /// The implementation of this method in this class does NOT acknowledge such messages.
         /// </remarks>
-        void HandleBasicDeliver(string consumerTag,
+        Task HandleBasicDeliver(string consumerTag,
             ulong deliveryTag,
             bool redelivered,
             string exchange,
@@ -110,6 +111,6 @@ namespace RabbitMQ.Client
         ///  </summary>
         ///  <param name="model"> Common AMQP model.</param>
         /// <param name="reason"> Information about the reason why a particular model, session, or connection was destroyed.</param>
-        void HandleModelShutdown(object model, ShutdownEventArgs reason);
+        Task HandleModelShutdown(object model, ShutdownEventArgs reason);
     }
 }

--- a/projects/client/RabbitMQ.Client/src/client/api/IModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IModel.cs
@@ -45,9 +45,13 @@ using RabbitMQ.Client.Impl;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace RabbitMQ.Client
 {
+    public delegate Task AsyncEventHandler<in TEventArgs>(object sender, TEventArgs args)
+        where TEventArgs : EventArgs;
+
     /// <summary>
     /// Common AMQP model, spanning the union of the
     /// functionality offered by versions 0-8, 0-8qpid, 0-9 and 0-9-1 of AMQP.
@@ -152,7 +156,7 @@ namespace RabbitMQ.Client
         /// If the model is already destroyed at the time an event
         /// handler is added to this event, the event handler will be fired immediately.
         /// </remarks>
-        event EventHandler<ShutdownEventArgs> ModelShutdown;
+        event AsyncEventHandler<ShutdownEventArgs> ModelShutdown;
 
         /// <summary>
         /// Abort this session.
@@ -449,11 +453,11 @@ namespace RabbitMQ.Client
         /// server autogenerates a name for the queue - the generated name is the return value of this method.
         /// </remarks>
         [AmqpMethodDoNotImplement(null)]
-        QueueDeclareOk QueueDeclare();
+        Task<QueueDeclareOk> QueueDeclare();
 
         /// <summary>(Spec method) Declare a queue.</summary>
         [AmqpMethodDoNotImplement(null)]
-        QueueDeclareOk QueueDeclare(string queue, bool durable, bool exclusive,
+        Task<QueueDeclareOk> QueueDeclare(string queue, bool durable, bool exclusive,
             bool autoDelete, IDictionary<string, object> arguments);
 
         /// <summary>
@@ -599,7 +603,7 @@ namespace RabbitMQ.Client
         /// OperationInterrupedException exception immediately.
         /// </remarks>
         [AmqpMethodDoNotImplement(null)]
-        void WaitForConfirmsOrDie();
+        Task WaitForConfirmsOrDie();
 
         /// <summary>
         /// Wait until all published messages have been confirmed.
@@ -610,7 +614,7 @@ namespace RabbitMQ.Client
         /// elapses, throws an OperationInterrupedException exception immediately.
         /// </remarks>
         [AmqpMethodDoNotImplement(null)]
-        void WaitForConfirmsOrDie(TimeSpan timeout);
+        Task WaitForConfirmsOrDie(TimeSpan timeout);
 
         /// <summary>
         /// Amount of time protocol  operations (e.g. <code>queue.declare</code>) are allowed to take before

--- a/projects/client/RabbitMQ.Client/src/client/api/IQueueingBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IQueueingBasicConsumer.cs
@@ -39,6 +39,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using RabbitMQ.Util;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
@@ -58,9 +59,9 @@ namespace RabbitMQ.Client
     ///</remarks>
     public interface IQueueingBasicConsumer
     {
-        void HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered,
+        Task HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered,
             string exchange, string routingKey, IBasicProperties properties, byte[] body);
-        void OnCancel();
+        Task OnCancel();
         SharedQueue<BasicDeliverEventArgs> Queue { get; }
     }
 }

--- a/projects/client/RabbitMQ.Client/src/client/api/QueueingBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/QueueingBasicConsumer.cs
@@ -39,7 +39,7 @@
 //---------------------------------------------------------------------------
 
 using System;
-
+using System.Threading.Tasks;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Util;
@@ -128,7 +128,7 @@ namespace RabbitMQ.Client
         /// Overrides <see cref="DefaultBasicConsumer"/>'s  <see cref="HandleBasicDeliver"/> implementation,
         ///  building a <see cref="BasicDeliverEventArgs"/> instance and placing it in the Queue.
         /// </summary>
-        public override void HandleBasicDeliver(string consumerTag,
+        public override Task HandleBasicDeliver(string consumerTag,
             ulong deliveryTag,
             bool redelivered,
             string exchange,
@@ -147,15 +147,16 @@ namespace RabbitMQ.Client
                 Body = body
             };
             Queue.Enqueue(eventArgs);
+            return _doneTask;
         }
 
         /// <summary>
         /// Overrides <see cref="DefaultBasicConsumer"/>'s OnCancel implementation,
         ///  extending it to call the Close() method of the <see cref="SharedQueue"/>.
         /// </summary>
-        public override void OnCancel()
+        public override async Task OnCancel()
         {
-            base.OnCancel();
+            await base.OnCancel().ConfigureAwait(false);
             Queue.Close();
         }
     }

--- a/projects/client/RabbitMQ.Client/src/client/impl/RecordedQueue.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RecordedQueue.cs
@@ -99,7 +99,7 @@ namespace RabbitMQ.Client.Impl
         {
             QueueDeclareOk ok = ModelDelegate.QueueDeclare(NameToUseForRecovery, durable,
                 exclusive, IsAutoDelete,
-                arguments);
+                arguments).GetAwaiter().GetResult();
             Name = ok.QueueName;
         }
 

--- a/projects/client/RabbitMQ.Client/src/client/messagepatterns/SimpleRpcClient.cs
+++ b/projects/client/RabbitMQ.Client/src/client/messagepatterns/SimpleRpcClient.cs
@@ -413,7 +413,7 @@ namespace RabbitMQ.Client.MessagePatterns
         {
             if (Subscription == null)
             {
-                string queueName = Model.QueueDeclare();
+                string queueName = Model.QueueDeclare().GetAwaiter().GetResult();
                 Subscription = new Subscription(Model, queueName);
             }
         }

--- a/projects/client/RabbitMQ.Client/src/client/messagepatterns/Subscription.cs
+++ b/projects/client/RabbitMQ.Client/src/client/messagepatterns/Subscription.cs
@@ -41,7 +41,7 @@
 using System;
 using System.Collections;
 using System.IO;
-
+using System.Threading.Tasks;
 #if NETFX_CORE || NET4  // For Windows 8 Store, but could be .NET 4.0 and greater
 using System.Threading.Tasks;
 #endif
@@ -475,13 +475,14 @@ namespace RabbitMQ.Client.MessagePatterns
             }
         }
 
-        private void HandleConsumerCancelled(object sender, ConsumerEventArgs e)
+        private Task HandleConsumerCancelled(object sender, ConsumerEventArgs e)
         {
             lock (m_eventLock)
             {
                 m_consumer = null;
                 MutateLatestEvent(null);
             }
+            return Task.FromResult(0);
         }
     }
 }

--- a/projects/client/Unit.WinRT/RabbitMQ.Client.Unit.WinRT.csproj
+++ b/projects/client/Unit.WinRT/RabbitMQ.Client.Unit.WinRT.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Warning! This file contains important customizations. Using Visual Studio to edit project's properties might break things. -->
   <!-- Props file -->
@@ -81,12 +81,6 @@
   <ItemGroup>
     <Compile Include="properties\AssemblyInfo.cs" />
     <Compile Include="..\Unit\src\unit\**\*.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\RabbitMQ.Client.WinRT\RabbitMQ.Client.WinRT.csproj">
-      <Project>{61D29F90-5B1C-4748-89FC-9FD2937F09C6}</Project>
-      <Name>RabbitMQ.Client</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/projects/client/Unit/RabbitMQ.Client.Unit.csproj.DotSettings
+++ b/projects/client/Unit/RabbitMQ.Client.Unit.csproj.DotSettings
@@ -1,2 +1,2 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp40</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp50</s:String></wpf:ResourceDictionary>

--- a/projects/client/Unit/src/unit/TestConnectionShutdown.cs
+++ b/projects/client/Unit/src/unit/TestConnectionShutdown.cs
@@ -40,6 +40,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 using RabbitMQ.Client.Impl;
@@ -54,8 +55,10 @@ namespace RabbitMQ.Client.Unit
         {
             var latch = new ManualResetEvent(false);
 
-            this.Model.ModelShutdown += (model, args) => {
+            this.Model.ModelShutdown += (model, args) =>
+            {
                 latch.Set();
+                return Task.FromResult(0);
             };
             Conn.Close();
 
@@ -71,6 +74,7 @@ namespace RabbitMQ.Client.Unit
             this.Model.ModelShutdown += (model, args) =>
             {
                 latch.Set();
+                return Task.FromResult(0);
             };
             Assert.IsFalse(m.ConsumerDispatcher.IsShutdown, "dispatcher should NOT be shut down before Close");
             Conn.Close();

--- a/projects/client/Unit/src/unit/TestConnectionWithBackgroundThreads.cs
+++ b/projects/client/Unit/src/unit/TestConnectionWithBackgroundThreads.cs
@@ -44,7 +44,7 @@ using System;
 using System.IO;
 using System.Text;
 using System.Collections;
-
+using System.Threading.Tasks;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Impl;
 using RabbitMQ.Client.Exceptions;
@@ -57,7 +57,7 @@ namespace RabbitMQ.Client.Unit
     {
 
         [Test]
-        public void TestWithBackgroundThreadsEnabled()
+        public async Task TestWithBackgroundThreadsEnabled()
         {
             ConnectionFactory connFactory = new ConnectionFactory();
             connFactory.UseBackgroundThreadsForIO = true;
@@ -66,7 +66,7 @@ namespace RabbitMQ.Client.Unit
             IModel ch = conn.CreateModel();
 
             // sanity check
-            string q = ch.QueueDeclare();
+            string q = await ch.QueueDeclare();
             ch.QueueDelete(q);
 
             ch.Close();

--- a/projects/client/Unit/src/unit/TestConsumerCancelNotify.cs
+++ b/projects/client/Unit/src/unit/TestConsumerCancelNotify.cs
@@ -42,6 +42,7 @@ using NUnit.Framework;
 using RabbitMQ.Client.Events;
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace RabbitMQ.Client.Unit
 {
@@ -91,7 +92,7 @@ namespace RabbitMQ.Client.Unit
                 }
             }
 
-            public override void HandleBasicCancel(string consumerTag)
+            public override Task HandleBasicCancel(string consumerTag)
             {
                 if (!EventMode)
                 {
@@ -101,16 +102,17 @@ namespace RabbitMQ.Client.Unit
                         Monitor.PulseAll(testClass.lockObject);
                     }
                 }
-                base.HandleBasicCancel(consumerTag);
+                return base.HandleBasicCancel(consumerTag);
             }
 
-            private void Cancelled(object sender, ConsumerEventArgs arg)
+            private Task Cancelled(object sender, ConsumerEventArgs arg)
             {
                 lock (testClass.lockObject)
                 {
                     testClass.notifiedEvent = true;
                     Monitor.PulseAll(testClass.lockObject);
                 }
+                return Task.FromResult(0);
             }
         }
     }

--- a/projects/client/Unit/src/unit/TestConsumerExceptions.cs
+++ b/projects/client/Unit/src/unit/TestConsumerExceptions.cs
@@ -40,6 +40,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace RabbitMQ.Client.Unit
@@ -53,7 +54,7 @@ namespace RabbitMQ.Client.Unit
             {
             }
 
-            public override void HandleBasicDeliver(string consumerTag,
+            public override Task HandleBasicDeliver(string consumerTag,
                 ulong deliveryTag,
                 bool redelivered,
                 string exchange,
@@ -71,7 +72,7 @@ namespace RabbitMQ.Client.Unit
             {
             }
 
-            public override void HandleBasicCancel(string consumerTag)
+            public override Task HandleBasicCancel(string consumerTag)
             {
                 throw new SystemException("oops");
             }
@@ -83,7 +84,7 @@ namespace RabbitMQ.Client.Unit
             {
             }
 
-            public override void HandleModelShutdown(object model, ShutdownEventArgs reason)
+            public override Task HandleModelShutdown(object model, ShutdownEventArgs reason)
             {
                 throw new SystemException("oops");
             }
@@ -95,7 +96,7 @@ namespace RabbitMQ.Client.Unit
             {
             }
 
-            public override void HandleBasicConsumeOk(string consumerTag)
+            public override Task HandleBasicConsumeOk(string consumerTag)
             {
                 throw new SystemException("oops");
             }
@@ -107,7 +108,7 @@ namespace RabbitMQ.Client.Unit
             {
             }
 
-            public override void HandleBasicCancelOk(string consumerTag)
+            public override Task HandleBasicCancelOk(string consumerTag)
             {
                 throw new SystemException("oops");
             }
@@ -118,7 +119,7 @@ namespace RabbitMQ.Client.Unit
         {
             var o = new object();
             bool notified = false;
-            string q = Model.QueueDeclare();
+            string q = Model.QueueDeclare().GetAwaiter().GetResult();
 
 
             Model.CallbackException += (m, evt) =>

--- a/projects/client/Unit/src/unit/TestEventingConsumer.cs
+++ b/projects/client/Unit/src/unit/TestEventingConsumer.cs
@@ -44,7 +44,7 @@ using System;
 using System.Text;
 using System.Threading;
 using System.Diagnostics;
-
+using System.Threading.Tasks;
 using RabbitMQ.Client.Events;
 
 namespace RabbitMQ.Client.Unit {
@@ -52,9 +52,9 @@ namespace RabbitMQ.Client.Unit {
     public class TestEventingConsumer : IntegrationFixture {
 
         [Test]
-        public void TestEventingConsumerRegistrationEvents()
+        public async Task TestEventingConsumerRegistrationEvents()
         {
-            string q = Model.QueueDeclare();
+            string q = await Model.QueueDeclare();
 
             var registeredLatch = new ManualResetEvent(false);
             object registeredSender = null;
@@ -66,12 +66,14 @@ namespace RabbitMQ.Client.Unit {
             {
                 registeredSender = s;
                 registeredLatch.Set();
+                return Task.FromResult(0);
             };
 
             ec.Unregistered += (s, args) =>
             {
                 unregisteredSender = s;
                 unregisteredLatch.Set();
+                return Task.FromResult(0);
             };
 
             string tag = Model.BasicConsume(q, false, ec);
@@ -89,9 +91,9 @@ namespace RabbitMQ.Client.Unit {
         }
 
         [Test]
-        public void TestEventingConsumerDeliveryEvents()
+        public async Task TestEventingConsumerDeliveryEvents()
         {
-            string q = Model.QueueDeclare();
+            string q = await Model.QueueDeclare();
             object o = new Object ();
 
             bool receivedInvoked = false;
@@ -104,6 +106,7 @@ namespace RabbitMQ.Client.Unit {
                 receivedSender = s;
 
                 Monitor.PulseAll(o);
+                return Task.FromResult(0);
             };
 
             Model.BasicConsume(q, true, ec);
@@ -124,6 +127,7 @@ namespace RabbitMQ.Client.Unit {
                 shutdownSender = s;
 
                 Monitor.PulseAll(o);
+                return Task.FromResult(0);
             };
 
             Model.Close();

--- a/projects/client/Unit/src/unit/TestExtensions.cs
+++ b/projects/client/Unit/src/unit/TestExtensions.cs
@@ -39,6 +39,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace RabbitMQ.Client.Unit
@@ -64,13 +65,13 @@ namespace RabbitMQ.Client.Unit
         }
 
         [Test]
-        public void TestExchangeBinding()
+        public async Task TestExchangeBinding()
         {
             Model.ConfirmSelect();
 
             Model.ExchangeDeclare("src", ExchangeType.Direct, false, false, null);
             Model.ExchangeDeclare("dest", ExchangeType.Direct, false, false, null);
-            string queue = Model.QueueDeclare();
+            string queue = await Model.QueueDeclare();
 
             Model.ExchangeBind("dest", "src", String.Empty);
             Model.QueueBind(queue, "dest", String.Empty);

--- a/projects/client/Unit/src/unit/TestInvalidAck.cs
+++ b/projects/client/Unit/src/unit/TestInvalidAck.cs
@@ -44,7 +44,7 @@ using System;
 using System.Text;
 using System.Threading;
 using System.Diagnostics;
-
+using System.Threading.Tasks;
 using RabbitMQ.Client.Events;
 
 namespace RabbitMQ.Client.Unit {
@@ -62,6 +62,7 @@ namespace RabbitMQ.Client.Unit {
                 shutdownFired = true;
                 shutdownArgs = args;
                 Monitor.PulseAll(o);
+                return Task.FromResult(0);
             };
 
             Model.BasicAck(123456, false);

--- a/projects/client/Unit/src/unit/TestMainLoop.cs
+++ b/projects/client/Unit/src/unit/TestMainLoop.cs
@@ -42,7 +42,7 @@ using NUnit.Framework;
 
 using System;
 using System.Threading;
-
+using System.Threading.Tasks;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Exceptions;
 
@@ -54,7 +54,7 @@ namespace RabbitMQ.Client.Unit {
         {
             public FaultyConsumer(IModel model) : base(model) {}
 
-            public override void HandleBasicDeliver(string consumerTag,
+            public override Task HandleBasicDeliver(string consumerTag,
                                                ulong deliveryTag,
                                                bool redelivered,
                                                string exchange,

--- a/projects/client/Unit/src/unit/TestMessagePatternsSubscription.cs
+++ b/projects/client/Unit/src/unit/TestMessagePatternsSubscription.cs
@@ -45,6 +45,7 @@ using RabbitMQ.Client.MessagePatterns;
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace RabbitMQ.Client.Unit
 {
@@ -57,7 +58,7 @@ namespace RabbitMQ.Client.Unit
             {
                 {Headers.XMessageTTL, 5000}
             };
-            string queueDeclare = Model.QueueDeclare("", false, true, false, args);
+            string queueDeclare = Model.QueueDeclare("", false, true, false, args).GetAwaiter().GetResult();
             var subscription = new Subscription(Model, queueDeclare, false);
 
             PreparedQueue(queueDeclare);
@@ -80,7 +81,7 @@ namespace RabbitMQ.Client.Unit
             {
                 {Headers.XMessageTTL, 5000}
             };
-            string queueDeclare = Model.QueueDeclare("", false, true, false, args);
+            string queueDeclare = Model.QueueDeclare("", false, true, false, args).GetAwaiter().GetResult();
             var subscription = new Subscription(Model, queueDeclare, false);
 
             PreparedQueue(queueDeclare);
@@ -92,7 +93,7 @@ namespace RabbitMQ.Client.Unit
         private void TestSubscriptionAction(Action<Subscription> action)
         {
             Model.BasicQos(0, 1, false);
-            string queueDeclare = Model.QueueDeclare();
+            string queueDeclare = Model.QueueDeclare().GetAwaiter().GetResult();
             var subscription = new Subscription(Model, queueDeclare, false);
 
             Model.BasicPublish("", queueDeclare, null, encoding.GetBytes("a message"));
@@ -158,9 +159,9 @@ namespace RabbitMQ.Client.Unit
         }
 
         [Test]
-        public void TestChannelClosureIsObservableOnSubscription()
+        public async Task TestChannelClosureIsObservableOnSubscription()
         {
-            string q = Model.QueueDeclare();
+            string q = await Model.QueueDeclare();
             var sub = new Subscription(Model, q, true);
 
             BasicDeliverEventArgs r1;

--- a/projects/client/Unit/src/unit/TestModelShutdown.cs
+++ b/projects/client/Unit/src/unit/TestModelShutdown.cs
@@ -42,6 +42,7 @@ using NUnit.Framework;
 using RabbitMQ.Client.Impl;
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace RabbitMQ.Client.Unit
 {
@@ -57,6 +58,7 @@ namespace RabbitMQ.Client.Unit
             this.Model.ModelShutdown += (model, args) =>
             {
                 latch.Set();
+                return Task.FromResult(0);
             };
             Assert.IsFalse(m.ConsumerDispatcher.IsShutdown, "dispatcher should NOT be shut down before Close");
             Model.Close();

--- a/projects/client/Unit/src/unit/TestPublisherConfirms.cs
+++ b/projects/client/Unit/src/unit/TestPublisherConfirms.cs
@@ -41,6 +41,7 @@
 using NUnit.Framework;
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using RabbitMQ.Client;
 
 namespace RabbitMQ.Client.Unit
@@ -67,12 +68,12 @@ namespace RabbitMQ.Client.Unit
         }
 
         [Test]
-        public void TestWaitForConfirmsWithEvents()
+        public async Task TestWaitForConfirmsWithEvents()
         {
             var ch = Conn.CreateModel();
             ch.ConfirmSelect();
 
-            var q = ch.QueueDeclare().QueueName;
+            var q = (await ch.QueueDeclare()).QueueName;
             var n = 200;
             // number of event handler invocations
             var c = 0;
@@ -108,7 +109,7 @@ namespace RabbitMQ.Client.Unit
             var ch = Conn.CreateModel();
             ch.ConfirmSelect();
 
-            var q = ch.QueueDeclare().QueueName;
+            var q = ch.QueueDeclare().GetAwaiter().GetResult().QueueName;
 
             for (int i = 0; i < numberOfMessagesToPublish; i++)
             {

--- a/projects/client/Unit/src/unit/TestRecoverAfterCancel.cs
+++ b/projects/client/Unit/src/unit/TestRecoverAfterCancel.cs
@@ -69,7 +69,7 @@ namespace RabbitMQ.Client.Unit
         {
             Connection = new ConnectionFactory().CreateConnection();
             Channel = Connection.CreateModel();
-            Queue = Channel.QueueDeclare("", false, true, false, null);
+            Queue = Channel.QueueDeclare("", false, true, false, null).GetAwaiter().GetResult();
         }
 
         [TearDown] public void Disconnect()

--- a/projects/client/Unit/src/unit/TestSsl.cs
+++ b/projects/client/Unit/src/unit/TestSsl.cs
@@ -57,7 +57,7 @@ namespace RabbitMQ.Client.Unit
                 IModel ch = conn.CreateModel();
 
                 ch.ExchangeDeclare("Exchange_TestSslEndPoint", ExchangeType.Direct);
-                String qName = ch.QueueDeclare();
+                String qName = ch.QueueDeclare().GetAwaiter().GetResult();
                 ch.QueueBind(qName, "Exchange_TestSslEndPoint", "Key_TestSslEndpoint", null);
 
                 string message = "Hello C# SSL Client World";

--- a/projects/client/Unit/src/unit/TestSubscription.cs
+++ b/projects/client/Unit/src/unit/TestSubscription.cs
@@ -40,6 +40,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 using RabbitMQ.Client.MessagePatterns;
@@ -72,6 +73,7 @@ namespace RabbitMQ.Client.Unit
                 sub.Close();
                 latch.Set();
                 Conn.Close();
+                return Task.FromResult(0);
             };
             this.Model.QueueDelete(q);
             Wait(latch, TimeSpan.FromSeconds(4));

--- a/projects/wcf/RabbitMQ.ServiceModel/src/serviceModel/RabbitMQInputChannel.cs
+++ b/projects/wcf/RabbitMQ.ServiceModel/src/serviceModel/RabbitMQInputChannel.cs
@@ -144,7 +144,7 @@ namespace RabbitMQ.ServiceModel
             DebugHelper.Start();
 #endif
             //Create a queue for messages destined to this service, bind it to the service URI routing key
-            string queue = m_model.QueueDeclare();
+            string queue = m_model.QueueDeclare().GetAwaiter().GetResult();
             m_model.QueueBind(queue, Exchange, base.LocalAddress.Uri.PathAndQuery, null);
 
             //Listen to the queue


### PR DESCRIPTION
DO NOT MERGE

Opposed to #149 this PR aims to explore an async API from a high level perspective first. Instead of changing low level infrastructure like `NetworBinaryWriter` it starts from `IModel`.

The idea of this spike is to show that we can stay as true as possible to the current API design and "just" make it async enabled without requiring a whole lot of new API design changes

@michaelklishin thoughts?