### PR TITLE
Updates to get AppVeyor tests passing again.

### DIFF
--- a/appveyor.props.in
+++ b/appveyor.props.in
@@ -7,6 +7,6 @@
     <PropBuildWinRT>$(BUILDWINRT)</PropBuildWinRT>
     <PropBuildWcf Condition="'$(PropUsingMono)' != 'true'">true</PropBuildWcf>
     <PropAssemblyVersion>$(APPVEYOR_BUILD_VERSION)</PropAssemblyVersion>
-    <PropKeyfile>c:\projects\rabbitmq-dotnet-client\rabbit.snk</PropKeyfile>
+    <PropKeyfile>$(APPVEYOR_BUILD_FOLDER)\rabbit.snk</PropKeyfile>
   </PropertyGroup>
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,6 +52,7 @@ test:
   categories:
     except:
       - RequireSMP
+      - LongRunning
 
 artifacts:
   - path: '**\*.nupkg'

--- a/projects/client/Unit/src/unit/Fixtures.cs
+++ b/projects/client/Unit/src/unit/Fixtures.cs
@@ -442,7 +442,7 @@ namespace RabbitMQ.Client.Unit
                 cmd  = ctl;
             } else {
                 cmd  = "cmd.exe";
-                args = "/c \"\"" + ctl + "\" -n rabbit@" + (Environment.GetEnvironmentVariable("COMPUTERNAME").ToLower()) + " " + args + "\"";
+                args = "/c \"\"" + ctl + "\" " + args + "\"";
             }
 
             try {

--- a/projects/client/Unit/src/unit/TestSubscription.cs
+++ b/projects/client/Unit/src/unit/TestSubscription.cs
@@ -60,7 +60,7 @@ namespace RabbitMQ.Client.Unit
             Model = Conn.CreateModel();
         }
 
-        [Test, Timeout(5000)]
+        [Test, Timeout(16000)]
         public void TestConsumerCancellationNotification()
         {
             var q = Guid.NewGuid().ToString();
@@ -70,11 +70,11 @@ namespace RabbitMQ.Client.Unit
             sub.Consumer.ConsumerCancelled += (_sender, _args) =>
             {
                 sub.Close();
-                latch.Set();
                 Conn.Close();
+                latch.Set();
             };
             this.Model.QueueDelete(q);
-            Wait(latch, TimeSpan.FromSeconds(4));
+            Wait(latch, TimeSpan.FromSeconds(8));
         }
     }
 }


### PR DESCRIPTION
I saw that the tests were failing, and thought I would fix it.  There are a couple changes:

- Use environment variable for `rabbit.snk` because the build path isn't always constant.
- don't force the node name in unit tests when calling `rabbitmqctl` because it isn't always `rabbit@...`.  I didn't see a way to find out the node name, but `rabbitmqctl` is able to connect to the correct instance if there is only one running.
- Fixed a race condition in a unit test and increased the timeouts.  The race condition is caused by the `ConsumerCancelled` event handler closing the connection after setting the latch, while the fixture teardown also check for the connection being closed then tries closing it.  Without this, the following exception was occurring (after increasing the timeouts for slow machines):

> TearDown Error : RabbitMQ.Client.Unit.TestSubscription.TestConsumerCancellationNotification
>    TearDown : System.TimeoutException : The operation has timed out.
> --TearDown
>    at RabbitMQ.Util.BlockingCell.GetValue(TimeSpan timeout) in C:\projects\rabbitmq-dotnet-client\projects\client\RabbitMQ.Client\src\util\BlockingCell.cs:line 127
>    at RabbitMQ.Client.Impl.ModelBase.Close(ShutdownEventArgs reason, Boolean abort) in C:\projects\rabbitmq-dotnet-client\projects\client\RabbitMQ.Client\src\client\impl\ModelBase.cs:line 340
>    at RabbitMQ.Client.Impl.ModelBase.Close() in C:\projects\rabbitmq-dotnet-client\projects\client\RabbitMQ.Client\src\client\impl\ModelBase.cs:line 1284
>    at RabbitMQ.Client.Unit.IntegrationFixture.Dispose() in C:\projects\rabbitmq-dotnet-client\projects\client\Unit\src\unit\Fixtures.cs:line 83