### PR TITLE
Do not duplicate consumer shutdown event.

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
@@ -1181,7 +1181,6 @@ namespace RabbitMQ.Client.Impl
             IDictionary<string, object> arguments,
             IBasicConsumer consumer)
         {
-            ModelShutdown += consumer.HandleModelShutdown;
 
             var k = new BasicConsumerRpcContinuation { m_consumer = consumer };
 


### PR DESCRIPTION
Fixes #144 
Consumer shutdown event handler is not added to channel shutdown event handler anymore.

