### PR TITLE
Deprecate QueueingBasicConsumer and reduce its use by other components

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/DefaultBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/DefaultBasicConsumer.cs
@@ -51,9 +51,7 @@ namespace RabbitMQ.Client
     /// <remarks>
     /// Note that the "Handle*" methods run in the connection's thread!
     /// Consider using <see cref="EventingBasicConsumer"/>,  which exposes
-    /// events that can be subscribed to consumer messages, or RabbitMQ.Client.MessagePatterns.Subscription,
-    ///  which manages resource declaration and binding in addition to providing a
-    /// thread-safe interface.
+    /// events that can be subscribed to consumer messages.
     /// </remarks>
     public class DefaultBasicConsumer : IBasicConsumer
     {

--- a/projects/client/RabbitMQ.Client/src/client/api/DefaultBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/DefaultBasicConsumer.cs
@@ -50,9 +50,8 @@ namespace RabbitMQ.Client
     /// </summary>
     /// <remarks>
     /// Note that the "Handle*" methods run in the connection's thread!
-    /// Consider using <see cref="QueueingBasicConsumer"/>,  which uses a
-    /// <see cref="SharedQueue"/> instance to safely pass received messages across
-    /// to user threads, or  RabbitMQ.Client.MessagePatterns.Subscription,
+    /// Consider using <see cref="EventingBasicConsumer"/>,  which exposes
+    /// events that can be subscribed to consumer messages, or RabbitMQ.Client.MessagePatterns.Subscription,
     ///  which manages resource declaration and binding in addition to providing a
     /// thread-safe interface.
     /// </remarks>

--- a/projects/client/RabbitMQ.Client/src/client/api/QueueingBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/QueueingBasicConsumer.cs
@@ -90,6 +90,7 @@ namespace RabbitMQ.Client
     /// }
     /// </code></example>
     /// </remarks>
+    [Obsolete("Deprecated. Use EventingBasicConsumer or Subscription instead")]
     public class QueueingBasicConsumer : DefaultBasicConsumer, IQueueingBasicConsumer
     {
         /// <summary>

--- a/projects/client/RabbitMQ.Client/src/client/api/QueueingBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/QueueingBasicConsumer.cs
@@ -90,7 +90,7 @@ namespace RabbitMQ.Client
     /// }
     /// </code></example>
     /// </remarks>
-    [Obsolete("Deprecated. Use EventingBasicConsumer or Subscription instead")]
+    [Obsolete("Deprecated. Use EventingBasicConsumer or a different consumer interface implementation instead")]
     public class QueueingBasicConsumer : DefaultBasicConsumer, IQueueingBasicConsumer
     {
         /// <summary>


### PR DESCRIPTION
    - re-implement behaviour from SharedQueue inside Subscription to ensure NextAsync works
    - signal closure to pending tasks

Fixes: #13 