### PR TITLE
Fix stale delivery tags in RecoveryAwareModel

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/RecoveryAwareModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RecoveryAwareModel.cs
@@ -86,7 +86,7 @@ namespace RabbitMQ.Client.Impl
             bool multiple)
         {
             ulong realTag = deliveryTag - ActiveDeliveryTagOffset;
-            if (realTag > 0)
+            if (realTag > 0 && realTag <= deliveryTag)
             {
                 base.BasicAck(realTag, multiple);
             }
@@ -97,7 +97,7 @@ namespace RabbitMQ.Client.Impl
             bool requeue)
         {
             ulong realTag = deliveryTag - ActiveDeliveryTagOffset;
-            if (realTag > 0)
+            if (realTag > 0 && realTag <= deliveryTag)
             {
                 base.BasicNack(realTag, multiple, requeue);
             }
@@ -107,7 +107,7 @@ namespace RabbitMQ.Client.Impl
             bool requeue)
         {
             ulong realTag = deliveryTag - ActiveDeliveryTagOffset;
-            if (realTag > 0)
+            if (realTag > 0 && realTag <= deliveryTag)
             {
                 base.BasicReject(realTag, requeue);
             }


### PR DESCRIPTION
Fixes #200.

`RecoveryAwareModel` was attempting to prevent acking of stale delivery tags by checking if the un-adjusted tag was > 0.  However, the tag is a `ulong`, not a `long`, so it will always be >= 0.  This change compares the un-adjusted tag to the adjusted tag to ensure it hasn't wrapped around to a higher number.