### PR TITLE
Move convenience overloads of IModel to seprate extension methods class.

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/IModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IModel.cs
@@ -38,13 +38,10 @@
 //  Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
-using RabbitMQ.Client;
 using RabbitMQ.Client.Apigen.Attributes;
 using RabbitMQ.Client.Events;
-using RabbitMQ.Client.Impl;
 using System;
 using System.Collections.Generic;
-using System.IO;
 
 namespace RabbitMQ.Client
 {
@@ -196,37 +193,9 @@ namespace RabbitMQ.Client
         void BasicCancel(string consumerTag);
 
         /// <summary>Start a Basic content-class consumer.</summary>
-        /// <remarks>
-        /// The consumer is started with noAck=false (i.e. BasicAck is required),
-        /// an empty consumer tag (i.e. the server creates and returns a fresh consumer tag),
-        /// noLocal=false and exclusive=false.
-        /// </remarks>
         [AmqpMethodDoNotImplement(null)]
-        string BasicConsume(string queue, bool noAck, IBasicConsumer consumer);
-
-        /// <summary>Start a Basic content-class consumer.</summary>
-        /// <remarks>
-        /// The consumer is started with
-        /// an empty consumer tag (i.e. the server creates and returns a fresh consumer tag),
-        /// noLocal=false and exclusive=false.
-        /// </remarks>
-        [AmqpMethodDoNotImplement(null)]
-        string BasicConsume(string queue, bool noAck, string consumerTag, IBasicConsumer consumer);
-
-        /// <summary>Start a Basic content-class consumer.</summary>
-        /// <remarks>
-        /// The consumer is started with noLocal=false and exclusive=false.
-        /// </remarks>
-        [AmqpMethodDoNotImplement(null)]
-        string BasicConsume(string queue,
-            bool noAck,
-            string consumerTag,
-            IDictionary<string, object> arguments,
-            IBasicConsumer consumer);
-
-        /// <summary>Start a Basic content-class consumer.</summary>
-        [AmqpMethodDoNotImplement(null)]
-        string BasicConsume(string queue,
+        string BasicConsume(
+            string queue,
             bool noAck,
             string consumerTag,
             bool noLocal,
@@ -246,25 +215,7 @@ namespace RabbitMQ.Client
         void BasicNack(ulong deliveryTag, bool multiple, bool requeue);
 
         /// <summary>
-        /// (Spec method) Convenience overload of BasicPublish.
-        /// </summary>
-        /// <remarks>
-        /// The publication occurs with mandatory=false and immediate=false.
-        /// </remarks>
-        [AmqpMethodDoNotImplement(null)]
-        void BasicPublish(PublicationAddress addr, IBasicProperties basicProperties, byte[] body);
-
-        /// <summary>
-        /// (Spec method) Convenience overload of BasicPublish.
-        /// </summary>
-        /// <remarks>
-        /// The publication occurs with mandatory=false
-        /// </remarks>
-        [AmqpMethodDoNotImplement(null)]
-        void BasicPublish(string exchange, string routingKey, IBasicProperties basicProperties, byte[] body);
-
-        /// <summary>
-        /// (Spec method) Convenience overload of BasicPublish.
+        /// (Spec method) Publishes a message.
         /// </summary>
         [AmqpMethodDoNotImplement(null)]
         void BasicPublish(string exchange, string routingKey, bool mandatory,
@@ -333,12 +284,6 @@ namespace RabbitMQ.Client
         void ExchangeBind(string destination, string source, string routingKey, IDictionary<string, object> arguments);
 
         /// <summary>
-        /// (Extension method) Bind an exchange to an exchange.
-        /// </summary>
-        [AmqpMethodDoNotImplement(null)]
-        void ExchangeBind(string destination, string source, string routingKey);
-
-        /// <summary>
         ///Like ExchangeBind but sets nowait to true.
         /// </summary>
         void ExchangeBindNoWait(string destination, string source, string routingKey,
@@ -352,26 +297,6 @@ namespace RabbitMQ.Client
         [AmqpMethodDoNotImplement(null)]
         void ExchangeDeclare(string exchange, string type, bool durable, bool autoDelete,
             IDictionary<string, object> arguments);
-
-        /// <summary>
-        /// (Spec method) Declare an exchange.
-        /// </summary>
-        /// <remarks>
-        /// The exchange is declared non-passive, non-autodelete, and
-        /// non-internal, with no arguments. The "nowait" option is not exercised.
-        /// </remarks>
-        [AmqpMethodDoNotImplement(null)]
-        void ExchangeDeclare(string exchange, string type, bool durable);
-
-        /// <summary>
-        /// (Spec method) Declare an exchange.
-        /// </summary>
-        /// <remarks>
-        /// The exchange is declared non-passive, non-durable, non-autodelete, and
-        /// non-internal, with no arguments. The "nowait" option is not exercised.
-        /// </remarks>
-        [AmqpMethodDoNotImplement(null)]
-        void ExchangeDeclare(string exchange, string type);
 
         /// <summary>
         /// Same as ExchangeDeclare but sets nowait to true and returns void (as there
@@ -395,13 +320,6 @@ namespace RabbitMQ.Client
         [AmqpMethodDoNotImplement(null)]
         void ExchangeDelete(string exchange, bool ifUnused);
 
-        /// <summary>(Spec method) Delete an exchange.</summary>
-        /// <remarks>
-        /// The exchange is deleted regardless of any queue bindings.
-        /// </remarks>
-        [AmqpMethodDoNotImplement(null)]
-        void ExchangeDelete(string exchange);
-
         /// <summary>
         ///Like ExchangeDelete but sets nowait to true.
         /// </summary>
@@ -417,12 +335,6 @@ namespace RabbitMQ.Client
             IDictionary<string, object> arguments);
 
         /// <summary>
-        /// (Extension method) Unbind an exchange from an exchange.
-        /// </summary>
-        [AmqpMethodDoNotImplement(null)]
-        void ExchangeUnbind(string destination, string source, string routingKey);
-
-        /// <summary>
         /// Like ExchangeUnbind but sets nowait to true.
         /// </summary>
         [AmqpMethodDoNotImplement(null)]
@@ -435,21 +347,8 @@ namespace RabbitMQ.Client
         [AmqpMethodDoNotImplement(null)]
         void QueueBind(string queue, string exchange, string routingKey, IDictionary<string, object> arguments);
 
-        /// <summary>(Spec method) Bind a queue to an exchange.</summary>
-        [AmqpMethodDoNotImplement(null)]
-        void QueueBind(string queue, string exchange, string routingKey);
-
         /// <summary>Same as QueueBind but sets nowait parameter to true.</summary>
         void QueueBindNoWait(string queue, string exchange, string routingKey, IDictionary<string, object> arguments);
-
-        /// <summary>(Spec method) Declare a queue.</summary>
-        /// <remarks>
-        /// The queue is declared non-passive, non-durable,
-        /// but exclusive and autodelete, with no arguments. The
-        /// server autogenerates a name for the queue - the generated name is the return value of this method.
-        /// </remarks>
-        [AmqpMethodDoNotImplement(null)]
-        QueueDeclareOk QueueDeclare();
 
         /// <summary>(Spec method) Declare a queue.</summary>
         [AmqpMethodDoNotImplement(null)]
@@ -460,8 +359,9 @@ namespace RabbitMQ.Client
         /// Same as QueueDeclare but sets nowait to true and returns void (as there
         /// will be no response from the server).
         /// </summary>
-        void QueueDeclareNoWait(string queue, bool durable, bool exclusive,
-            bool autoDelete, IDictionary<string, object> arguments);
+        void QueueDeclareNoWait(string queue, bool durable,
+                                bool exclusive, bool autoDelete,
+                                IDictionary<string, object> arguments);
 
         /// <summary>Declare a queue passively.</summary>
         /// <remarks>
@@ -499,15 +399,6 @@ namespace RabbitMQ.Client
         /// </remarks>
         [AmqpMethodDoNotImplement(null)]
         uint QueueDelete(string queue, bool ifUnused, bool ifEmpty);
-
-        /// <summary>
-        /// (Spec method) Delete a queue.
-        /// </summary>
-        /// <remarks>
-        ///Returns the number of messages purged during queue deletion.
-        /// </remarks>
-        [AmqpMethodDoNotImplement(null)]
-        uint QueueDelete(string queue);
 
         /// <summary>
         ///Same as QueueDelete but sets nowait parameter to true

--- a/projects/client/RabbitMQ.Client/src/client/api/IModelExtensions.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IModelExtensions.cs
@@ -1,0 +1,217 @@
+// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 1.1.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2016 Pivotal Software, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v1.1:
+//
+//---------------------------------------------------------------------------
+//  The contents of this file are subject to the Mozilla Public License
+//  Version 1.1 (the "License"); you may not use this file except in
+//  compliance with the License. You may obtain a copy of the License
+//  at http://www.mozilla.org/MPL/
+//
+//  Software distributed under the License is distributed on an "AS IS"
+//  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+//  the License for the specific language governing rights and
+//  limitations under the License.
+//
+//  The Original Code is RabbitMQ.
+//
+//  The Initial Developer of the Original Code is Pivotal Software, Inc.
+//  Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+//---------------------------------------------------------------------------
+
+using System.Collections.Generic;
+
+namespace RabbitMQ.Client
+{
+    public static class IModelExensions
+    {
+        /// <summary>Start a Basic content-class consumer.</summary>
+        public static string BasicConsume(this IModel model,
+            IBasicConsumer consumer,
+            string queue,
+            bool noAck = false,
+            string consumerTag = "",
+            bool noLocal = false,
+            bool exclusive = false,
+            IDictionary<string, object> arguments = null)
+            {
+                return model.BasicConsume(queue, noAck, consumerTag, noLocal, exclusive, arguments, consumer);
+            }
+
+        /// <summary>Start a Basic content-class consumer.</summary>
+        public static string BasicConsume(this IModel model, string queue, bool noAck, IBasicConsumer consumer)
+        {
+            return model.BasicConsume(queue, noAck, "", false, false, null, consumer);
+        }
+
+        /// <summary>Start a Basic content-class consumer.</summary>
+        public static string BasicConsume(this IModel model, string queue,
+            bool noAck,
+            string consumerTag,
+            IBasicConsumer consumer)
+        {
+            return model.BasicConsume(queue, noAck, consumerTag, false, false, null, consumer);
+        }
+
+        /// <summary>Start a Basic content-class consumer.</summary>
+        public static string BasicConsume(this IModel model, string queue,
+            bool noAck,
+            string consumerTag,
+            IDictionary<string, object> arguments,
+            IBasicConsumer consumer)
+        {
+            return model.BasicConsume(queue, noAck, consumerTag, false, false, arguments, consumer);
+        }
+
+        /// <summary>
+        /// (Extension method) Convenience overload of BasicPublish.
+        /// </summary>
+        /// <remarks>
+        /// The publication occurs with mandatory=false and immediate=false.
+        /// </remarks>
+        public static void BasicPublish(this IModel model, PublicationAddress addr, IBasicProperties basicProperties, byte[] body)
+        {
+            model.BasicPublish(addr.ExchangeName, addr.RoutingKey, basicProperties: basicProperties, body: body);
+        }
+
+        /// <summary>
+        /// (Extension method) Convenience overload of BasicPublish.
+        /// </summary>
+        /// <remarks>
+        /// The publication occurs with mandatory=false
+        /// </remarks>
+        public static void BasicPublish(this IModel model, string exchange, string routingKey, IBasicProperties basicProperties, byte[] body)
+        {
+            model.BasicPublish(exchange, routingKey, false, basicProperties, body);
+        }
+
+        /// <summary>
+        /// (Spec method) Convenience overload of BasicPublish.
+        /// </summary>
+        public static void BasicPublish(this IModel model, string exchange, string routingKey, bool mandatory = false, IBasicProperties basicProperties = null, byte[] body = null)
+        {
+            model.BasicPublish(exchange, routingKey, mandatory, basicProperties, body);
+        }
+
+        /// <summary>
+        /// (Spec method) Declare a queue.
+        /// </summary>
+        public static QueueDeclareOk QueueDeclare(this IModel model, string queue = "", bool durable = false, bool exclusive = true,
+            bool autoDelete = true, IDictionary<string, object> arguments = null)
+            {
+                return model.QueueDeclare(queue, durable, exclusive, autoDelete, arguments);
+            }
+
+        /// <summary>
+        /// (Extension method) Bind an exchange to an exchange.
+        /// </summary>
+        public static void ExchangeBind(this IModel model, string destination, string source, string routingKey, IDictionary<string, object> arguments = null)
+        {
+            model.ExchangeBind(destination, source, routingKey, arguments);
+        }
+
+        /// <summary>
+        /// (Extension method) Like exchange bind but sets nowait to true. 
+        /// </summary>
+        public static void ExchangeBindNoWait(this IModel model, string destination, string source, string routingKey, IDictionary<string, object> arguments = null)
+        {
+            model.ExchangeBindNoWait(destination, source, routingKey, arguments);
+        }
+
+        /// <summary>
+        /// (Spec method) Declare an exchange.
+        /// </summary>
+        public static void ExchangeDeclare(this IModel model, string exchange, string type, bool durable = false, bool autoDelete = false,
+            IDictionary<string, object> arguments = null)
+            {
+                model.ExchangeDeclare(exchange, type, durable, autoDelete, arguments);
+            }
+
+        /// <summary>
+        /// (Extension method) Like ExchangeDeclare but sets nowait to true. 
+        /// </summary>
+        public static void ExchangeDeclareNoWait(this IModel model, string exchange, string type, bool durable = false, bool autoDelete = false,
+            IDictionary<string, object> arguments = null)
+            {
+                model.ExchangeDeclareNoWait(exchange, type, durable, autoDelete, arguments);
+            }
+
+        /// <summary>
+        /// (Spec method) Unbinds an exchange.
+        /// </summary>
+        public static void ExchangeUnbind(this IModel model, string destination,
+            string source,
+            string routingKey,
+            IDictionary<string, object> arguments = null)
+            {
+                model.ExchangeUnbind(destination, source, routingKey, arguments);
+            }
+
+        /// <summary>
+        /// (Spec method) Deletes an exchange.
+        /// </summary>
+        public static void ExchangeDelete(this IModel model, string exchange, bool ifUnused = false)
+        {
+            model.ExchangeDelete(exchange, ifUnused);
+        }
+
+        /// <summary>
+        /// (Extension method) Like ExchangeDelete but sets nowait to true.
+        /// </summary>
+        public static void ExchangeDeleteNoWait(this IModel model, string exchange, bool ifUnused = false)
+        {
+            model.ExchangeDeleteNoWait(exchange, ifUnused);
+        }
+
+        /// <summary>
+        /// (Spec method) Binds a queue.
+        /// </summary>
+        public static void QueueBind(this IModel model, string queue, string exchange, string routingKey, IDictionary<string, object> arguments = null)
+        {
+            model.QueueBind(queue, exchange, routingKey, arguments);
+        }
+
+        /// <summary>
+        /// (Spec method) Deletes a queue.
+        /// </summary>
+        public static uint QueueDelete(this IModel model, string queue, bool ifUnused = false, bool ifEmpty = false)
+        {
+            return model.QueueDelete(queue, ifUnused, ifEmpty);
+        }
+
+        /// <summary>
+        /// (Extension method) Like QueueDelete but sets nowait to true.
+        /// </summary>
+        public static void QueueDeleteNoWait(this IModel model, string queue, bool ifUnused = false, bool ifEmpty = false)
+        {
+            model.QueueDeleteNoWait(queue, ifUnused, ifEmpty);
+        }
+
+        /// <summary>
+        /// (Spec method) Unbinds a queue.
+        /// </summary>
+        public static void QueueUnbind(this IModel model, string queue, string exchange, string routingKey, IDictionary<string, object> arguments = null)
+        {
+            model.QueueUnbind(queue, exchange, routingKey, arguments);
+        }
+    }
+}

--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
@@ -757,32 +757,8 @@ namespace RabbitMQ.Client.Impl
             m_delegate.BasicCancel(consumerTag);
         }
 
-        public string BasicConsume(string queue,
-            bool noAck,
-            IBasicConsumer consumer)
-        {
-            return BasicConsume(queue, noAck, "", consumer);
-        }
-
-        public string BasicConsume(string queue,
-            bool noAck,
-            string consumerTag,
-            IBasicConsumer consumer)
-        {
-            return BasicConsume(queue, noAck, consumerTag, null, consumer);
-        }
-
-        public string BasicConsume(string queue,
-            bool noAck,
-            string consumerTag,
-            IDictionary<string, object> arguments,
-            IBasicConsumer consumer)
-        {
-            return BasicConsume(queue, noAck, consumerTag, false, false,
-                arguments, consumer);
-        }
-
-        public string BasicConsume(string queue,
+        public string BasicConsume(
+            string queue,
             bool noAck,
             string consumerTag,
             bool noLocal,
@@ -813,27 +789,6 @@ namespace RabbitMQ.Client.Impl
             bool requeue)
         {
             m_delegate.BasicNack(deliveryTag, multiple, requeue);
-        }
-
-        public void BasicPublish(PublicationAddress addr,
-            IBasicProperties basicProperties,
-            byte[] body)
-        {
-            m_delegate.BasicPublish(addr.ExchangeName,
-                addr.RoutingKey,
-                basicProperties,
-                body);
-        }
-
-        public void BasicPublish(string exchange,
-            string routingKey,
-            IBasicProperties basicProperties,
-            byte[] body)
-        {
-            m_delegate.BasicPublish(exchange,
-                routingKey,
-                basicProperties,
-                body);
         }
 
         public void BasicPublish(string exchange,
@@ -917,13 +872,6 @@ namespace RabbitMQ.Client.Impl
 
         public void ExchangeBind(string destination,
             string source,
-            string routingKey)
-        {
-            ExchangeBind(destination, source, routingKey, null);
-        }
-
-        public void ExchangeBind(string destination,
-            string source,
             string routingKey,
             IDictionary<string, object> arguments)
         {
@@ -942,16 +890,6 @@ namespace RabbitMQ.Client.Impl
             IDictionary<string, object> arguments)
         {
             m_delegate.ExchangeBindNoWait(destination, source, routingKey, arguments);
-        }
-
-        public void ExchangeDeclare(string exchange, string type, bool durable)
-        {
-            ExchangeDeclare(exchange, type, durable, false, null);
-        }
-
-        public void ExchangeDeclare(string exchange, string type)
-        {
-            ExchangeDeclare(exchange, type, false, false, null);
         }
 
         public void ExchangeDeclare(string exchange, string type, bool durable,
@@ -995,11 +933,6 @@ namespace RabbitMQ.Client.Impl
             m_connection.DeleteRecordedExchange(exchange);
         }
 
-        public void ExchangeDelete(string exchange)
-        {
-            ExchangeDelete(exchange, false);
-        }
-
         public void ExchangeDeleteNoWait(string exchange,
             bool ifUnused)
         {
@@ -1020,13 +953,6 @@ namespace RabbitMQ.Client.Impl
             m_connection.DeleteRecordedBinding(eb);
             m_delegate.ExchangeUnbind(destination, source, routingKey, arguments);
             m_connection.MaybeDeleteRecordedAutoDeleteExchange(source);
-        }
-
-        public void ExchangeUnbind(string destination,
-            string source,
-            string routingKey)
-        {
-            ExchangeUnbind(destination, source, routingKey, null);
         }
 
         public void ExchangeUnbindNoWait(string destination,
@@ -1051,13 +977,6 @@ namespace RabbitMQ.Client.Impl
             m_delegate.QueueBind(queue, exchange, routingKey, arguments);
         }
 
-        public void QueueBind(string queue,
-            string exchange,
-            string routingKey)
-        {
-            QueueBind(queue, exchange, routingKey, null);
-        }
-
         public void QueueBindNoWait(string queue,
             string exchange,
             string routingKey,
@@ -1066,13 +985,9 @@ namespace RabbitMQ.Client.Impl
             m_delegate.QueueBind(queue, exchange, routingKey, arguments);
         }
 
-        public QueueDeclareOk QueueDeclare()
-        {
-            return QueueDeclare("", false, true, true, null);
-        }
-
-        public QueueDeclareOk QueueDeclare(string queue, bool durable, bool exclusive,
-            bool autoDelete, IDictionary<string, object> arguments)
+        public QueueDeclareOk QueueDeclare(string queue, bool durable,
+                                           bool exclusive, bool autoDelete,
+                                           IDictionary<string, object> arguments)
         {
             var result = m_delegate.QueueDeclare(queue, durable, exclusive,
                 autoDelete, arguments);
@@ -1086,8 +1001,9 @@ namespace RabbitMQ.Client.Impl
             return result;
         }
 
-        public void QueueDeclareNoWait(string queue, bool durable, bool exclusive,
-            bool autoDelete, IDictionary<string, object> arguments)
+        public void QueueDeclareNoWait(string queue, bool durable,
+                                       bool exclusive, bool autoDelete,
+                                       IDictionary<string, object> arguments)
         {
             m_delegate.QueueDeclareNoWait(queue, durable, exclusive,
                 autoDelete, arguments);
@@ -1122,11 +1038,6 @@ namespace RabbitMQ.Client.Impl
             var result = m_delegate.QueueDelete(queue, ifUnused, ifEmpty);
             m_connection.DeleteRecordedQueue(queue);
             return result;
-        }
-
-        public uint QueueDelete(string queue)
-        {
-            return QueueDelete(queue, false, false);
         }
 
         public void QueueDeleteNoWait(string queue,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
@@ -1151,28 +1151,6 @@ namespace RabbitMQ.Client.Impl
             ModelShutdown -= k.m_consumer.HandleModelShutdown;
         }
 
-        public string BasicConsume(string queue, bool noAck, IBasicConsumer consumer)
-        {
-            return BasicConsume(queue, noAck, "", consumer);
-        }
-
-        public string BasicConsume(string queue,
-            bool noAck,
-            string consumerTag,
-            IBasicConsumer consumer)
-        {
-            return BasicConsume(queue, noAck, consumerTag, null, consumer);
-        }
-
-        public string BasicConsume(string queue,
-            bool noAck,
-            string consumerTag,
-            IDictionary<string, object> arguments,
-            IBasicConsumer consumer)
-        {
-            return BasicConsume(queue, noAck, consumerTag, false, false, arguments, consumer);
-        }
-
         public string BasicConsume(string queue,
             bool noAck,
             string consumerTag,
@@ -1208,28 +1186,6 @@ namespace RabbitMQ.Client.Impl
         public abstract void BasicNack(ulong deliveryTag,
             bool multiple,
             bool requeue);
-
-        public void BasicPublish(PublicationAddress addr,
-            IBasicProperties basicProperties,
-            byte[] body)
-        {
-            BasicPublish(addr.ExchangeName,
-                addr.RoutingKey,
-                basicProperties,
-                body);
-        }
-
-        public void BasicPublish(string exchange,
-            string routingKey,
-            IBasicProperties basicProperties,
-            byte[] body)
-        {
-            BasicPublish(exchange,
-                routingKey,
-                false,
-                basicProperties,
-                body);
-        }
 
         public void BasicPublish(string exchange,
             string routingKey,
@@ -1300,12 +1256,6 @@ namespace RabbitMQ.Client.Impl
 
         public abstract IBasicProperties CreateBasicProperties();
 
-        public void ExchangeBind(string destination,
-            string source,
-            string routingKey)
-        {
-            ExchangeBind(destination, source, routingKey, null);
-        }
 
         public void ExchangeBind(string destination,
             string source,
@@ -1328,16 +1278,6 @@ namespace RabbitMQ.Client.Impl
             _Private_ExchangeDeclare(exchange, type, false, durable, autoDelete, false, false, arguments);
         }
 
-        public void ExchangeDeclare(string exchange, string type, bool durable)
-        {
-            ExchangeDeclare(exchange, type, durable, false, null);
-        }
-
-        public void ExchangeDeclare(string exchange, string type)
-        {
-            ExchangeDeclare(exchange, type, false);
-        }
-
         public void ExchangeDeclareNoWait(string exchange,
             string type,
             bool durable,
@@ -1358,11 +1298,6 @@ namespace RabbitMQ.Client.Impl
             _Private_ExchangeDelete(exchange, ifUnused, false);
         }
 
-        public void ExchangeDelete(string exchange)
-        {
-            ExchangeDelete(exchange, false);
-        }
-
         public void ExchangeDeleteNoWait(string exchange,
             bool ifUnused)
         {
@@ -1375,13 +1310,6 @@ namespace RabbitMQ.Client.Impl
             IDictionary<string, object> arguments)
         {
             _Private_ExchangeUnbind(destination, source, routingKey, false, arguments);
-        }
-
-        public void ExchangeUnbind(string destination,
-            string source,
-            string routingKey)
-        {
-            ExchangeUnbind(destination, source, routingKey, null);
         }
 
         public void ExchangeUnbindNoWait(string destination,
@@ -1400,13 +1328,6 @@ namespace RabbitMQ.Client.Impl
             _Private_QueueBind(queue, exchange, routingKey, false, arguments);
         }
 
-        public void QueueBind(string queue,
-            string exchange,
-            string routingKey)
-        {
-            QueueBind(queue, exchange, routingKey, null);
-        }
-
         public void QueueBindNoWait(string queue,
             string exchange,
             string routingKey,
@@ -1415,13 +1336,9 @@ namespace RabbitMQ.Client.Impl
             _Private_QueueBind(queue, exchange, routingKey, true, arguments);
         }
 
-        public QueueDeclareOk QueueDeclare()
-        {
-            return QueueDeclare("", false, true, true, null);
-        }
-
-        public QueueDeclareOk QueueDeclare(string queue, bool durable, bool exclusive,
-            bool autoDelete, IDictionary<string, object> arguments)
+        public QueueDeclareOk QueueDeclare(string queue, bool durable,
+                                           bool exclusive, bool autoDelete,
+                                           IDictionary<string, object> arguments)
         {
             return QueueDeclare(queue, false, durable, exclusive, autoDelete, arguments);
         }
@@ -1454,11 +1371,6 @@ namespace RabbitMQ.Client.Impl
             bool ifEmpty)
         {
             return _Private_QueueDelete(queue, ifUnused, ifEmpty, false);
-        }
-
-        public uint QueueDelete(string queue)
-        {
-            return QueueDelete(queue, false, false);
         }
 
         public void QueueDeleteNoWait(string queue,

--- a/projects/client/RabbitMQ.Client/src/client/impl/RecordedConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RecordedConsumer.cs
@@ -40,6 +40,7 @@
 
 using System;
 using System.Collections.Generic;
+using RabbitMQ.Client;
 
 namespace RabbitMQ.Client.Impl
 {


### PR DESCRIPTION
Reduce API surface of IModel
Introduce the use of optionals on extension convenience methods

Fixes #125 