### PR TITLE
reduce chances of NullReference exception in MaybeStopHeartbeatTimers…

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -1114,17 +1114,23 @@ entry.ToString());
 
         private void MaybeDisposeTimer(ref Timer timer)
         {
-            if (timer != null)
+            // capture the timer to reduce chance of a null ref exception
+            var captured = timer;
+            if (captured != null)
             {
                 try
                 {
-                    timer.Change(Timeout.Infinite, Timeout.Infinite);
-                    timer.Dispose();
+                    captured.Change(Timeout.Infinite, Timeout.Infinite);
+                    captured.Dispose();
                     timer = null;
                 }
-                catch (ObjectDisposedException ignored)
+                catch (ObjectDisposedException)
                 {
                     // we are shutting down, ignore
+                }
+                catch(NullReferenceException)
+                {
+                    // this should be very rare but could occur from a race condition
                 }
             }
         }


### PR DESCRIPTION
… and add catch block

Fixes #220 

This is an additional change to fix an issue introduced in https://github.com/rabbitmq/rabbitmq-dotnet-client/pull/223