### PR TITLE
Handle the case where a dns lookup returns an address for an

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/TcpClientAdapter.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/TcpClientAdapter.cs
@@ -1,16 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net.Sockets;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
+
 namespace RabbitMQ.Client
 {
-
-
     /// <summary>
-    /// Simple wrapper around TcpClient. 
+    /// Simple wrapper around TcpClient.
     /// </summary>
     public class TcpClientAdapter : ITcpClient
     {
@@ -20,14 +17,18 @@ namespace RabbitMQ.Client
         {
             if (socket == null)
                 throw new InvalidOperationException("socket must not be null");
-        
+
             this.sock = socket;
         }
 
         public virtual async Task ConnectAsync(string host, int port)
         {
             var adds = await Dns.GetHostAddressesAsync(host).ConfigureAwait(false);
-            var ep = adds.First();
+            var ep = adds.FirstOrDefault(a => a.AddressFamily == sock.AddressFamily);
+            if(ep == default(IPAddress))
+            {
+                throw new ArgumentException("No ip address could be resolved for " + host);
+            }
             #if CORECLR
             await sock.ConnectAsync(ep, port);
             #else

--- a/projects/client/Unit/src/unit/TestConnectionFactory.cs
+++ b/projects/client/Unit/src/unit/TestConnectionFactory.cs
@@ -39,6 +39,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using RabbitMQ.Client.Exceptions;
 
@@ -107,7 +108,7 @@ namespace RabbitMQ.Client.Unit
                 Assert.AreEqual("some_name", conn.ClientProperties["connection_name"]);
             }
         }
-        
+
         [Test]
         public void TestCreateConnectionWithClientProvidedNameAndAutorecoveryUsesName()
         {
@@ -185,6 +186,15 @@ namespace RabbitMQ.Client.Unit
                     {
                         using(var conn = cf.CreateConnection(new System.Collections.Generic.List<AmqpTcpEndpoint> { ep })) {}
                     }, Throws.TypeOf<BrokerUnreachableException>());
+        }
+
+        [Test]
+        public void TestCreateConnectioUsesValidEndpointWhenMultipleSupplied()
+        {
+            var cf = new ConnectionFactory();
+            var invalidEp = new AmqpTcpEndpoint("not_localhost");
+            var ep = new AmqpTcpEndpoint("localhost");
+            using(var conn = cf.CreateConnection(new List<AmqpTcpEndpoint> { invalidEp, ep })) {};
         }
     }
 }

--- a/projects/client/Unit/src/unit/TestTcpClientAdapter.cs
+++ b/projects/client/Unit/src/unit/TestTcpClientAdapter.cs
@@ -1,0 +1,64 @@
+// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 1.1.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2016 Pivotal Software, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v1.1:
+//
+//---------------------------------------------------------------------------
+//  The contents of this file are subject to the Mozilla Public License
+//  Version 1.1 (the "License"); you may not use this file except in
+//  compliance with the License. You may obtain a copy of the License
+//  at http://www.mozilla.org/MPL/
+//
+//  Software distributed under the License is distributed on an "AS IS"
+//  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+//  the License for the specific language governing rights and
+//  limitations under the License.
+//
+//  The Original Code is RabbitMQ.
+//
+//  The Initial Developer of the Original Code is Pivotal Software, Inc.
+//  Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+//---------------------------------------------------------------------------
+
+using System;
+using System.Net.Sockets;
+using System.Threading;
+using NUnit.Framework;
+
+using RabbitMQ.Client;
+
+namespace RabbitMQ.Client.Unit
+{
+    [TestFixture]
+    public class TestTcpClientAdapter
+    {
+        [Test]
+        public void ConnectAsyncThrowsArgumentExceptionWhenNoAddressForAddressFamilyCanBeFound()
+        {
+            var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP);
+            var sut = new TcpClientAdapter(socket);
+            Assert.Throws<ArgumentException>(() =>
+            {
+                sut.ConnectAsync("localhost", 5672).GetAwaiter().GetResult();
+            });
+        }
+    }
+}


### PR DESCRIPTION
AddressFamily different to how the socket is configured

Fixes: #244 