### PR TITLE
Added a way to intentionally propagate exceptions through CallbackException

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
@@ -579,8 +579,11 @@ namespace RabbitMQ.Client.Impl
                     {
                         h(this, args);
                     }
-                    catch
+                    catch (Exception e)
                     {
+                        if (Object.ReferenceEquals(e, args.Exception)) {
+                            throw; // Exception was intentionally rethrown in callback -- propagate it further
+                        }
                         // Exception in
                         // Callback-exception-handler. That was the
                         // app's last chance. Swallow the exception.


### PR DESCRIPTION
Added a way to intentionally propagate exceptions through CallbackException. It gets lost otherwise; and there is no option to disable custom RabbitMQ.Client's exception handling.