### PR TITLE
Make uri and Uri setters in ConnectionFactory obsolete in favour of t…

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
@@ -269,6 +269,7 @@ namespace RabbitMQ.Client
         /// <summary>
         /// Set connection parameters using the amqp or amqps scheme.
         /// </summary>
+        [Obsolete("Deprecated: please use SetUri instead.")]
         public String Uri
         {
             set { SetUri(new Uri(value, UriKind.Absolute)); }
@@ -277,6 +278,7 @@ namespace RabbitMQ.Client
         /// <summary>
         /// Set connection parameters using the amqp or amqps scheme.
         /// </summary>
+        [Obsolete("Deprecated: please use SetUri instead.")]
         public Uri uri
         {
             set { SetUri(value); }
@@ -505,7 +507,7 @@ namespace RabbitMQ.Client
             return fh;
         }
 
-        private void SetUri(Uri uri)
+        public void SetUri(Uri uri)
         {
             Endpoint = new AmqpTcpEndpoint();
 


### PR DESCRIPTION
…he SetUri method

Fixes #264 

This is probably the best we can do atm for addressing this. It won't make the ConnectionFactory CLS compliant but at least it signals to users to stop using the `uri` and `Uri` setters and we can remove them completely at some later point.