### PR TITLE
add events for connection recovery errors and connection success.

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/IConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IConnection.cs
@@ -170,6 +170,9 @@ namespace RabbitMQ.Client
         /// of those event handlers throws an exception, as well.
         /// </remarks>
         event EventHandler<CallbackExceptionEventArgs> CallbackException;
+        event EventHandler<EventArgs> RecoverySucceeded;
+        event EventHandler<ConnectionRecoveryErrorEventArgs> ConnectionRecoveryError;
+
 
         event EventHandler<ConnectionBlockedEventArgs> ConnectionBlocked;
 

--- a/projects/client/RabbitMQ.Client/src/client/events/ConnectionRecoveryErrorEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/ConnectionRecoveryErrorEventArgs.cs
@@ -1,0 +1,54 @@
+// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 1.1.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2016 Pivotal Software, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v1.1:
+//
+//---------------------------------------------------------------------------
+//  The contents of this file are subject to the Mozilla Public License
+//  Version 1.1 (the "License"); you may not use this file except in
+//  compliance with the License. You may obtain a copy of the License
+//  at http://www.mozilla.org/MPL/
+//
+//  Software distributed under the License is distributed on an "AS IS"
+//  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+//  the License for the specific language governing rights and
+//  limitations under the License.
+//
+//  The Original Code is RabbitMQ.
+//
+//  The Initial Developer of the Original Code is Pivotal Software, Inc.
+//  Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+//---------------------------------------------------------------------------
+
+using System;
+
+namespace RabbitMQ.Client.Events
+{
+    public sealed class ConnectionRecoveryErrorEventArgs : EventArgs
+    {
+        public ConnectionRecoveryErrorEventArgs(Exception ex)
+        {
+            Exception = ex;
+        }
+
+        public Exception Exception { get; private set; }
+    }
+}

--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -57,7 +57,6 @@ using System.Net;
 using System.Net.Sockets;
 #endif
 
-using System.Reflection;
 using System.Text;
 using System.Threading;
 
@@ -72,6 +71,8 @@ namespace RabbitMQ.Client.Framing.Impl
 
         private ManualResetEvent m_appContinuation = new ManualResetEvent(false);
         private EventHandler<CallbackExceptionEventArgs> m_callbackException;
+        private EventHandler<EventArgs> m_recoverySucceeded;
+        private EventHandler<ConnectionRecoveryErrorEventArgs> connectionRecoveryFailure;
 
         private IDictionary<string, object> m_clientProperties;
 
@@ -81,6 +82,7 @@ namespace RabbitMQ.Client.Framing.Impl
         private EventHandler<ConnectionBlockedEventArgs> m_connectionBlocked;
         private EventHandler<ShutdownEventArgs> m_connectionShutdown;
         private EventHandler<EventArgs> m_connectionUnblocked;
+
         private IConnectionFactory m_factory;
         private IFrameHandler m_frameHandler;
 
@@ -129,6 +131,24 @@ namespace RabbitMQ.Client.Framing.Impl
         }
 
         public Guid Id { get { return m_id; } }
+
+        public event EventHandler<EventArgs> RecoverySucceeded
+        {
+            add
+            {
+                lock (m_eventLock)
+                {
+                    m_recoverySucceeded += value;
+                }
+            }
+            remove
+            {
+                lock (m_eventLock)
+                {
+                    m_recoverySucceeded -= value;
+                }
+            }
+        }
 
         public event EventHandler<CallbackExceptionEventArgs> CallbackException
         {
@@ -211,6 +231,23 @@ namespace RabbitMQ.Client.Framing.Impl
             }
         }
 
+        public event EventHandler<ConnectionRecoveryErrorEventArgs> ConnectionRecoveryError
+        {
+            add
+            {
+                lock (m_eventLock)
+                {
+                    connectionRecoveryFailure += value;
+                }
+            }
+            remove
+            {
+                lock (m_eventLock)
+                {
+                    connectionRecoveryFailure -= value;
+                }
+            }
+        }
         public string ClientProvidedName { get; private set; }
 
         public bool AutoClose

--- a/projects/client/Unit/src/unit/TestConnectionRecovery.cs
+++ b/projects/client/Unit/src/unit/TestConnectionRecovery.cs
@@ -163,7 +163,7 @@ namespace RabbitMQ.Client.Unit
         {
             using(var c = CreateAutorecoveringConnection(
                         new List<AmqpTcpEndpoint> 
-                        { 
+                        {
                             new AmqpTcpEndpoint("127.0.0.1"), 
                             new AmqpTcpEndpoint("localhost") 
                         }))
@@ -172,6 +172,21 @@ namespace RabbitMQ.Client.Unit
                             CloseAndWaitForRecovery(c);
                             Assert.IsTrue(c.IsOpen);
                         }
+        }
+
+        [Test]
+        public void TestBasicConnectionRecoveryErrorEvent()
+        {
+            Assert.IsTrue(Conn.IsOpen);
+            using(var c = CreateAutorecoveringConnection())
+            {
+                var latch = new AutoResetEvent(false);
+                c.ConnectionRecoveryError += (o, _args) => latch.Set();
+                StopRabbitMQ();
+                latch.WaitOne(30000);
+                StartRabbitMQ();
+                WaitForRecovery(c);
+            }
         }
 
         [Test]


### PR DESCRIPTION
Fixes #156 

Raised against master as it extends `IConnection` as well as making more sense with auto recovery as the default.

`ConnectionRecoveryError` is raised after each failed connection recovery attempt.

`ConnectionRecoverySucceeded` is raise once after all the recovery has completed.