### PR TITLE
Ensures connection recovery does not keep going after the connection …

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/IConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IConnection.cs
@@ -194,7 +194,7 @@ namespace RabbitMQ.Client
         /// <remarks>
         /// Note that all active channels, sessions, and models will be closed if this method is called.
         /// In comparison to normal <see cref="Close()"/> method, <see cref="Abort()"/> will not throw
-        /// <see cref="AlreadyClosedException"/> or <see cref="IOException"/> during closing connection.
+        /// <see cref="IOException"/> during closing connection.
         ///This method waits infinitely for the in-progress close operation to complete.
         /// </remarks>
         void Abort();
@@ -206,7 +206,7 @@ namespace RabbitMQ.Client
         /// The method behaves in the same way as <see cref="Abort()"/>, with the only
         /// difference that the connection is closed with the given connection close code and message.
         /// <para>
-        /// The close code (See under "Reply Codes" in the AMQP specification)
+        /// The close code (See under "Reply Codes" in the AMQP 0-9-1 specification)
         /// </para>
         /// <para>
         /// A message indicating the reason for closing the connection
@@ -253,7 +253,7 @@ namespace RabbitMQ.Client
         /// closed if this method is called. It will wait for the in-progress
         /// close operation to complete. This method will not return to the caller
         /// until the shutdown is complete. If the connection is already closed
-        /// (or closing), then this method will throw <see cref="AlreadyClosedException"/>.
+        /// (or closing), then this method will do nothing.
         /// It can also throw <see cref="IOException"/> when socket was closed unexpectedly.
         /// </remarks>
         void Close();
@@ -281,7 +281,7 @@ namespace RabbitMQ.Client
         /// Note that all active channels, sessions, and models will be
         /// closed if this method is called. It will wait for the in-progress
         /// close operation to complete with a timeout. If the connection is
-        /// already closed (or closing), then this method will throw <see cref="AlreadyClosedException"/>.
+        /// already closed (or closing), then this method will do nothing.
         /// It can also throw <see cref="IOException"/> when socket was closed unexpectedly.
         /// If timeout is reached and the close operations haven't finished, then socket is forced to close.
         /// <para>
@@ -298,7 +298,7 @@ namespace RabbitMQ.Client
         /// The method behaves in the same way as <see cref="Close(int)"/>, with the only
         /// difference that the connection is closed with the given connection close code and message.
         /// <para>
-        /// The close code (See under "Reply Codes" in the AMQP specification).
+        /// The close code (See under "Reply Codes" in the AMQP 0-9-1 specification).
         /// </para>
         /// <para>
         /// A message indicating the reason for closing the connection.

--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
@@ -750,21 +750,13 @@ namespace RabbitMQ.Client.Framing.Impl
             {
                 Abort();
             }
+            catch(Exception)
+            {
+                // TODO: log
+            }
             finally
             {
                 m_models.Clear();
-            }
-            if (ShutdownReport.Count > 0)
-            {
-                foreach (ShutdownReportEntry entry in ShutdownReport)
-                {
-                    if (entry.Exception != null)
-                    {
-                        throw entry.Exception;
-                    }
-                }
-
-                throw new OperationInterruptedException(null);
             }
         }
 

--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
@@ -397,14 +397,14 @@ namespace RabbitMQ.Client.Framing.Impl
 
                     recoveryTaskFactory.StartNew(() =>
                     {
-                        if(!self.ManuallyClosed)
+                        if (!self.ManuallyClosed)
                         {
                             try
                             {
 #if NETFX_CORE
-                            System.Threading.Tasks.Task.Delay(m_factory.NetworkRecoveryInterval).Wait();
+                                System.Threading.Tasks.Task.Delay(m_factory.NetworkRecoveryInterval).Wait();
 #else
-                            Thread.Sleep(m_factory.NetworkRecoveryInterval);
+                                Thread.Sleep(m_factory.NetworkRecoveryInterval);
 #endif
                                 self.PerformAutomaticRecovery();
                             }
@@ -422,19 +422,21 @@ namespace RabbitMQ.Client.Framing.Impl
         {
             lock (recoveryLockTarget)
             {
-                RecoverConnectionDelegate();
-                RecoverConnectionShutdownHandlers();
-                RecoverConnectionBlockedHandlers();
-                RecoverConnectionUnblockedHandlers();
-
-                RecoverModels();
-                if (m_factory.TopologyRecoveryEnabled)
+                if (RecoverConnectionDelegate())
                 {
-                    RecoverEntities();
-                    RecoverConsumers();
-                }
+                    RecoverConnectionShutdownHandlers();
+                    RecoverConnectionBlockedHandlers();
+                    RecoverConnectionUnblockedHandlers();
 
-                RunRecoveryEventHandlers();
+                    RecoverModels();
+                    if (m_factory.TopologyRecoveryEnabled)
+                    {
+                        RecoverEntities();
+                        RecoverConsumers();
+                    }
+
+                    RunRecoveryEventHandlers();
+                }
             }
         }
 
@@ -659,56 +661,64 @@ namespace RabbitMQ.Client.Framing.Impl
         public void Abort()
         {
             this.ManuallyClosed = true;
-            m_delegate.Abort();
+            if(m_delegate.IsOpen)
+                m_delegate.Abort();
         }
 
         ///<summary>API-side invocation of connection abort.</summary>
         public void Abort(ushort reasonCode, string reasonText)
         {
             this.ManuallyClosed = true;
-            m_delegate.Abort(reasonCode, reasonText);
+            if (m_delegate.IsOpen)
+                m_delegate.Abort(reasonCode, reasonText);
         }
 
         ///<summary>API-side invocation of connection abort with timeout.</summary>
         public void Abort(int timeout)
         {
             this.ManuallyClosed = true;
-            m_delegate.Abort(timeout);
+            if (m_delegate.IsOpen)
+                m_delegate.Abort(timeout);
         }
 
         ///<summary>API-side invocation of connection abort with timeout.</summary>
         public void Abort(ushort reasonCode, string reasonText, int timeout)
         {
             this.ManuallyClosed = true;
-            m_delegate.Abort(reasonCode, reasonText, timeout);
+            if (m_delegate.IsOpen)
+                m_delegate.Abort(reasonCode, reasonText, timeout);
         }
 
         ///<summary>API-side invocation of connection.close.</summary>
         public void Close()
         {
             this.ManuallyClosed = true;
-            m_delegate.Close();
+            if (m_delegate.IsOpen)
+                m_delegate.Close();
         }
 
         ///<summary>API-side invocation of connection.close.</summary>
         public void Close(ushort reasonCode, string reasonText)
         {
             this.ManuallyClosed = true;
-            m_delegate.Close(reasonCode, reasonText);
+            if (m_delegate.IsOpen)
+                m_delegate.Close(reasonCode, reasonText);
         }
 
         ///<summary>API-side invocation of connection.close with timeout.</summary>
         public void Close(int timeout)
         {
             this.ManuallyClosed = true;
-            m_delegate.Close(timeout);
+            if (m_delegate.IsOpen)
+                m_delegate.Close(timeout);
         }
 
         ///<summary>API-side invocation of connection.close with timeout.</summary>
         public void Close(ushort reasonCode, string reasonText, int timeout)
         {
             this.ManuallyClosed = true;
-            m_delegate.Close(reasonCode, reasonText, timeout);
+            if (m_delegate.IsOpen)
+                m_delegate.Close(reasonCode, reasonText, timeout);
         }
 
         public IModel CreateModel()
@@ -736,7 +746,8 @@ namespace RabbitMQ.Client.Framing.Impl
 
         void IDisposable.Dispose()
         {
-            try {
+            try
+            {
                 Abort();
             }
             finally
@@ -752,6 +763,7 @@ namespace RabbitMQ.Client.Framing.Impl
                         throw entry.Exception;
                     }
                 }
+
                 throw new OperationInterruptedException(null);
             }
         }
@@ -826,16 +838,15 @@ namespace RabbitMQ.Client.Framing.Impl
             }
         }
 
-        protected void RecoverConnectionDelegate()
+        protected bool RecoverConnectionDelegate()
         {
-            bool recovering = true;
-            while (recovering)
+            while (!ManuallyClosed)
             {
                 try
                 {
                     var fh = endpoints.SelectOne(m_factory.CreateFrameHandler);
                     m_delegate = new Connection(m_factory, false, fh, this.ClientProvidedName);
-                    recovering = false;
+                    return true;
                 }
                 catch (Exception e)
                 {
@@ -866,6 +877,8 @@ namespace RabbitMQ.Client.Framing.Impl
                     // TODO: provide a way to handle these exceptions
                 }
             }
+
+            return false;
         }
 
         protected void RecoverConnectionShutdownHandlers()

--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -1240,9 +1240,9 @@ entry.ToString());
 
         void IDisposable.Dispose()
         {
-            MaybeStopHeartbeatTimers();
             try
             {
+                MaybeStopHeartbeatTimers();
                 Abort();
             }
             catch (OperationInterruptedException)


### PR DESCRIPTION
…has been manually closed.

Fixes #294 

So this involved more changes than I initially thought. `Close` and `Abort` now first checks if the connection `IsOpen` before attempting to close it. This is needed as otherwise `Close` would just throw if it was called during recovery which seems unnecessary to me unless this is semantics we want to keep?