### PR TITLE
Implement logging using an EventSource

### DIFF
--- a/projects/client/RabbitMQ.Client/project.json
+++ b/projects/client/RabbitMQ.Client/project.json
@@ -34,7 +34,11 @@
   },
   "dependencies": {},
   "frameworks": {
-    "net451": {},
+    "net451": {
+      "dependencies": {
+        "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.*"
+      }
+    },
     "netstandard1.5": {
       "buildOptions": {
         "define": [
@@ -46,6 +50,7 @@
         "System.Collections.Concurrent": "4.0.12",
         "System.Console": "4.0.0",
         "System.Diagnostics.Debug": "4.0.11",
+        "System.Diagnostics.Tracing": "4.1.0",
         "System.IO": "4.1.0",
         "System.Linq": "4.1.0",
         "System.Net.NameResolution": "4.0.0",

--- a/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
@@ -352,7 +352,6 @@ namespace RabbitMQ.Client
         /// </exception>
         public virtual IConnection CreateConnection()
         {
-            ESLog.Info("CreateConnection");
             return CreateConnection(this.EndpointResolverFactory(LocalEndpoints()), null);
         }
 

--- a/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
@@ -352,6 +352,7 @@ namespace RabbitMQ.Client
         /// </exception>
         public virtual IConnection CreateConnection()
         {
+            ESLog.Info("CreateConnection");
             return CreateConnection(this.EndpointResolverFactory(LocalEndpoints()), null);
         }
 

--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -563,12 +563,12 @@ namespace RabbitMQ.Client.Framing.Impl
             if (!SetCloseReason(reason))
             {
                 LogCloseError("Unexpected Main Loop Exception while closing: "
-                              + reason, null);
+                              + reason, new Exception(reason.ToString()));
                 return;
             }
 
             OnShutdown();
-            LogCloseError("Unexpected connection closure: " + reason, null);
+            LogCloseError("Unexpected connection closure: " + reason, new Exception(reason.ToString()));
         }
 
         public bool HardProtocolExceptionHandler(HardProtocolException hpe)
@@ -616,6 +616,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public void LogCloseError(String error, Exception ex)
         {
+            ESLog.Error(error, ex);
             m_shutdownReport.Add(new ShutdownReportEntry(error, ex));
         }
 
@@ -1049,6 +1050,7 @@ entry.ToString());
                     {
                         String description = String.Format("Heartbeat missing with heartbeat == {0} seconds", m_heartbeat);
                         var eose = new EndOfStreamException(description);
+                        ESLog.Error(description, eose);
                         m_shutdownReport.Add(new ShutdownReportEntry(description, eose));
                         HandleMainLoopException(
                             new ShutdownEventArgs(ShutdownInitiator.Library, 0, "End of stream", eose));

--- a/projects/client/RabbitMQ.Client/src/logging/ESLog.cs
+++ b/projects/client/RabbitMQ.Client/src/logging/ESLog.cs
@@ -1,0 +1,78 @@
+// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 1.1.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2016 Pivotal Software, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v1.1:
+//
+//---------------------------------------------------------------------------
+//  The contents of this file are subject to the Mozilla Public License
+//  Version 1.1 (the "License"); you may not use this file except in
+//  compliance with the License. You may obtain a copy of the License
+//  at http://www.mozilla.org/MPL/
+//
+//  Software distributed under the License is distributed on an "AS IS"
+//  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+//  the License for the specific language governing rights and
+//  limitations under the License.
+//
+//  The Original Code is RabbitMQ.
+//
+//  The Initial Developer of the Original Code is Pivotal Software, Inc.
+//  Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+//---------------------------------------------------------------------------
+
+namespace RabbitMQ.Client
+{
+    public static class ESLog
+    {
+        public static void Info(string message)
+        {
+            Logging.RabbitMqClientEventSource.Log.Info(message);
+        }
+
+        public static void Info(string message, params object[] args)
+        {
+            var msg = string.Format(message, args);
+            Info(msg);
+        }
+
+        public static void Warn(string message)
+        {
+            Logging.RabbitMqClientEventSource.Log.Warn(message);
+        }
+
+        public static void Warn(string message, params object[] args)
+        {
+            var msg = string.Format(message, args);
+            Warn(msg);
+        }
+
+        public static void Error(string message, System.Exception ex)
+        {
+            Logging.RabbitMqClientEventSource.Log.Error(message, ex);
+        }
+
+        public static void Error(string message, System.Exception ex, params object[] args)
+        {
+            var msg = string.Format(message, args);
+            Error(msg, ex);
+        }
+    }
+}

--- a/projects/client/RabbitMQ.Client/src/logging/RabbitMqClientEventSource.cs
+++ b/projects/client/RabbitMQ.Client/src/logging/RabbitMqClientEventSource.cs
@@ -1,0 +1,91 @@
+// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 1.1.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2016 Pivotal Software, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v1.1:
+//
+//---------------------------------------------------------------------------
+//  The contents of this file are subject to the Mozilla Public License
+//  Version 1.1 (the "License"); you may not use this file except in
+//  compliance with the License. You may obtain a copy of the License
+//  at http://www.mozilla.org/MPL/
+//
+//  Software distributed under the License is distributed on an "AS IS"
+//  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+//  the License for the specific language governing rights and
+//  limitations under the License.
+//
+//  The Original Code is RabbitMQ.
+//
+//  The Initial Developer of the Original Code is Pivotal Software, Inc.
+//  Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+//---------------------------------------------------------------------------
+
+namespace RabbitMQ.Client.Logging
+{
+    using System;
+#if NET451
+    using Microsoft.Diagnostics.Tracing;
+#else
+    using System.Diagnostics.Tracing;
+#endif
+
+    [EventSource(Name="rabbitmq-dotnet-client")]
+    public sealed class RabbitMqClientEventSource : EventSource
+    {
+        public class Keywords
+        {
+            public const EventKeywords Log = (EventKeywords)1;
+        }
+
+        public RabbitMqClientEventSource() : base(EventSourceSettings.EtwSelfDescribingEventFormat)
+        {
+        }
+
+        public static RabbitMqClientEventSource Log = new RabbitMqClientEventSource ();
+
+        [Event(1, Message = "INFO", Keywords = Keywords.Log, Level = EventLevel.Informational)]
+        public void Info(string message)
+        {
+            if(IsEnabled())
+                this.WriteEvent(1, message);
+        }
+
+        [Event(2, Message = "WARN", Keywords = Keywords.Log, Level = EventLevel.Warning)]
+        public void Warn(string message)
+        {
+            if(IsEnabled())
+                this.WriteEvent(2, message);
+        }
+
+        [Event(3, Message = "ERROR", Keywords = Keywords.Log, Level = EventLevel.Error)]
+        public void Error(string message,  RabbitMqExceptionDetail ex)
+        {
+            if(IsEnabled())
+                this.WriteEvent(3, message, ex);
+        }
+
+        [NonEvent]
+        public void Error(string message, Exception ex)
+        {
+            Error(message, new RabbitMqExceptionDetail(ex));
+        }
+    }
+}

--- a/projects/client/RabbitMQ.Client/src/logging/RabbitMqConsoleEventListener.cs
+++ b/projects/client/RabbitMQ.Client/src/logging/RabbitMqConsoleEventListener.cs
@@ -1,0 +1,80 @@
+// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 1.1.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2016 Pivotal Software, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v1.1:
+//
+//---------------------------------------------------------------------------
+//  The contents of this file are subject to the Mozilla Public License
+//  Version 1.1 (the "License"); you may not use this file except in
+//  compliance with the License. You may obtain a copy of the License
+//  at http://www.mozilla.org/MPL/
+//
+//  Software distributed under the License is distributed on an "AS IS"
+//  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+//  the License for the specific language governing rights and
+//  limitations under the License.
+//
+//  The Original Code is RabbitMQ.
+//
+//  The Initial Developer of the Original Code is Pivotal Software, Inc.
+//  Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+//---------------------------------------------------------------------------
+
+namespace RabbitMQ.Client.Logging
+{
+    using System;
+    using System.Collections.Generic;
+#if NET451
+    using Microsoft.Diagnostics.Tracing;
+#else
+    using System.Diagnostics.Tracing;
+#endif
+
+    public sealed class RabbitMqConsoleEventListener : EventListener, IDisposable
+    {
+        public RabbitMqConsoleEventListener()
+        {
+            this.EnableEvents(RabbitMqClientEventSource.Log, EventLevel.Informational, RabbitMqClientEventSource.Keywords.Log);
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            foreach(var pl in eventData.Payload)
+            {
+                var dict = pl as IDictionary<string, object>;
+                if(dict != null)
+                {
+                    var rex = new RabbitMqExceptionDetail(dict);
+                    Console.WriteLine("{0}: {1}", eventData.Level, rex.ToString());
+                }
+                else
+                {
+                    Console.WriteLine("{0}: {1}", eventData.Level, pl.ToString());
+                }
+            }
+        }
+
+        public override void Dispose()
+        {
+            this.DisableEvents(RabbitMqClientEventSource.Log);
+        }
+    }
+}

--- a/projects/client/RabbitMQ.Client/src/logging/RabbitMqExceptionDetail.cs
+++ b/projects/client/RabbitMQ.Client/src/logging/RabbitMqExceptionDetail.cs
@@ -1,0 +1,87 @@
+// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 1.1.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2016 Pivotal Software, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v1.1:
+//
+//---------------------------------------------------------------------------
+//  The contents of this file are subject to the Mozilla Public License
+//  Version 1.1 (the "License"); you may not use this file except in
+//  compliance with the License. You may obtain a copy of the License
+//  at http://www.mozilla.org/MPL/
+//
+//  Software distributed under the License is distributed on an "AS IS"
+//  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+//  the License for the specific language governing rights and
+//  limitations under the License.
+//
+//  The Original Code is RabbitMQ.
+//
+//  The Initial Developer of the Original Code is Pivotal Software, Inc.
+//  Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+//---------------------------------------------------------------------------
+
+namespace RabbitMQ.Client.Logging
+{
+    using System;
+    using System.Collections.Generic;
+#if NET451
+    using Microsoft.Diagnostics.Tracing;
+#else
+    using System.Diagnostics.Tracing;
+#endif
+
+    [EventData]
+    public class RabbitMqExceptionDetail
+    {
+        public RabbitMqExceptionDetail(Exception ex)
+        {
+            this.Type = ex.GetType().FullName;
+            this.Message = ex.Message;
+            this.StackTrace = ex.StackTrace;
+            if(ex.InnerException != null)
+            {
+                this.InnerException = ex.InnerException.ToString();
+            }
+        }
+
+        public RabbitMqExceptionDetail(IDictionary<string, object> ex)
+        {
+            this.Type = ex["Type"].ToString();
+            this.Message = ex["Message"].ToString();
+            this.StackTrace = ex["StackTrace"].ToString();
+            object inner;
+            if(ex.TryGetValue("InnerException", out inner))
+            {
+                this.InnerException = inner.ToString();
+            }
+        }
+
+        public string Type { get; private set; }
+        public string Message { get; private set; }
+        public string StackTrace { get; private set; }
+        public string InnerException { get; private set; }
+
+        public override string ToString()
+        {
+            return String.Format("Exception: {0}\r\n{1}\r\n\r\n{2}\r\nInnerException:\r\n{3}", Type, Message, StackTrace, InnerException);
+        }
+    }
+}

--- a/projects/client/Unit/project.json
+++ b/projects/client/Unit/project.json
@@ -20,6 +20,10 @@
         "System.Collections.NonGeneric": "4.0.1"
       }
     },
-    "net451": {}
+    "net451": {
+      "dependencies": {
+        "Microsoft.Diagnostics.Tracing.EventSource.Redist": "1.1.*"
+      }
+    }
   }
 }

--- a/projects/client/Unit/src/unit/TestAmqpUri.cs
+++ b/projects/client/Unit/src/unit/TestAmqpUri.cs
@@ -147,12 +147,13 @@ namespace RabbitMQ.Client.Unit
         private void ParseFailWith<T>(string uri)
         {
             var cf = new ConnectionFactory();
-            Assert.That(() => cf.Uri = uri, Throws.TypeOf<T>());
+            Assert.That(() => cf.SetUri(new Uri(uri)), Throws.TypeOf<T>());
         }
 
         private void ParseSuccess(string uri, string user, string password, string host, int port, string vhost)
         {
-            var factory = new ConnectionFactory { Uri = uri };
+            var factory = new ConnectionFactory();
+            factory.SetUri(new Uri(uri));
             AssertUriPartEquivalence(user, password, port, vhost, factory);
             Assert.AreEqual(host, factory.HostName);
         }
@@ -160,7 +161,8 @@ namespace RabbitMQ.Client.Unit
         private void ParseSuccess(string uri, string user, string password,
             string[] hosts, int port, string vhost)
         {
-            var factory = new ConnectionFactory { Uri = uri };
+            var factory = new ConnectionFactory();
+            factory.SetUri(new Uri(uri));
             AssertUriPartEquivalence(user, password, port, vhost, factory);
             Assert.IsTrue((Array.IndexOf(hosts, factory.HostName)) != -1);
         }

--- a/projects/client/Unit/src/unit/TestConnectionFactory.cs
+++ b/projects/client/Unit/src/unit/TestConnectionFactory.cs
@@ -185,7 +185,7 @@ namespace RabbitMQ.Client.Unit
             var ep = new AmqpTcpEndpoint("localhost");
             ep.AddressFamily = System.Net.Sockets.AddressFamily.InterNetwork;
             cf.Endpoint = ep;
-            using(var conn = cf.CreateConnection());
+            using(var conn = cf.CreateConnection()){};
         }
 
         [Test]


### PR DESCRIPTION
This replaces Console.WriteLines with a custom [EventSource](https://msdn.microsoft.com/en-us/library/system.diagnostics.tracing.eventsource(v=vs.110).aspx). Sinks can be implemented using EventListeners

This also includes an sample EventListener that prints logs to stdout.

See [this](https://msdn.microsoft.com/en-us/library/dn774985(v=pandp.20).aspx) for more details on the .NET `EventSource` API. `EventSource` can also be used for other diagnostics and metrics.

Fixes #94 and possibly also #254 