### PR TITLE
noAck -> autoAck

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/IModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IModel.cs
@@ -196,7 +196,7 @@ namespace RabbitMQ.Client
         [AmqpMethodDoNotImplement(null)]
         string BasicConsume(
             string queue,
-            bool noAck,
+            bool autoAck,
             string consumerTag,
             bool noLocal,
             bool exclusive,
@@ -209,7 +209,7 @@ namespace RabbitMQ.Client
         /// no messages are currently available. See also <see cref="IModel.BasicAck"/>.
         /// </summary>
         [AmqpMethodDoNotImplement(null)]
-        BasicGetResult BasicGet(string queue, bool noAck);
+        BasicGetResult BasicGet(string queue, bool autoAck);
 
         /// <summary>Reject one or more delivered message(s).</summary>
         void BasicNack(ulong deliveryTag, bool multiple, bool requeue);

--- a/projects/client/RabbitMQ.Client/src/client/api/IModelExtensions.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IModelExtensions.cs
@@ -48,38 +48,38 @@ namespace RabbitMQ.Client
         public static string BasicConsume(this IModel model,
             IBasicConsumer consumer,
             string queue,
-            bool noAck = false,
+            bool autoAck = false,
             string consumerTag = "",
             bool noLocal = false,
             bool exclusive = false,
             IDictionary<string, object> arguments = null)
             {
-                return model.BasicConsume(queue, noAck, consumerTag, noLocal, exclusive, arguments, consumer);
+                return model.BasicConsume(queue, autoAck, consumerTag, noLocal, exclusive, arguments, consumer);
             }
 
         /// <summary>Start a Basic content-class consumer.</summary>
-        public static string BasicConsume(this IModel model, string queue, bool noAck, IBasicConsumer consumer)
+        public static string BasicConsume(this IModel model, string queue, bool autoAck, IBasicConsumer consumer)
         {
-            return model.BasicConsume(queue, noAck, "", false, false, null, consumer);
+            return model.BasicConsume(queue, autoAck, "", false, false, null, consumer);
         }
 
         /// <summary>Start a Basic content-class consumer.</summary>
         public static string BasicConsume(this IModel model, string queue,
-            bool noAck,
+            bool autoAck,
             string consumerTag,
             IBasicConsumer consumer)
         {
-            return model.BasicConsume(queue, noAck, consumerTag, false, false, null, consumer);
+            return model.BasicConsume(queue, autoAck, consumerTag, false, false, null, consumer);
         }
 
         /// <summary>Start a Basic content-class consumer.</summary>
         public static string BasicConsume(this IModel model, string queue,
-            bool noAck,
+            bool autoAck,
             string consumerTag,
             IDictionary<string, object> arguments,
             IBasicConsumer consumer)
         {
-            return model.BasicConsume(queue, noAck, consumerTag, false, false, arguments, consumer);
+            return model.BasicConsume(queue, autoAck, consumerTag, false, false, arguments, consumer);
         }
 
         /// <summary>

--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
@@ -542,7 +542,7 @@ namespace RabbitMQ.Client.Impl
         public void _Private_BasicConsume(string queue,
             string consumerTag,
             bool noLocal,
-            bool noAck,
+            bool autoAck,
             bool exclusive,
             bool nowait,
             IDictionary<string, object> arguments)
@@ -550,15 +550,15 @@ namespace RabbitMQ.Client.Impl
             m_delegate._Private_BasicConsume(queue,
                 consumerTag,
                 noLocal,
-                noAck,
+                autoAck,
                 exclusive,
                 nowait,
                 arguments);
         }
 
-        public void _Private_BasicGet(string queue, bool noAck)
+        public void _Private_BasicGet(string queue, bool autoAck)
         {
-            m_delegate._Private_BasicGet(queue, noAck);
+            m_delegate._Private_BasicGet(queue, autoAck);
         }
 
         public void _Private_BasicPublish(string exchange,
@@ -759,29 +759,29 @@ namespace RabbitMQ.Client.Impl
 
         public string BasicConsume(
             string queue,
-            bool noAck,
+            bool autoAck,
             string consumerTag,
             bool noLocal,
             bool exclusive,
             IDictionary<string, object> arguments,
             IBasicConsumer consumer)
         {
-            var result = m_delegate.BasicConsume(queue, noAck, consumerTag, noLocal,
+            var result = m_delegate.BasicConsume(queue, autoAck, consumerTag, noLocal,
                 exclusive, arguments, consumer);
             RecordedConsumer rc = new RecordedConsumer(this, queue).
                 WithConsumerTag(result).
                 WithConsumer(consumer).
                 WithExclusive(exclusive).
-                WithAutoAck(noAck).
+                WithAutoAck(autoAck).
                 WithArguments(arguments);
             m_connection.RecordConsumer(result, rc);
             return result;
         }
 
         public BasicGetResult BasicGet(string queue,
-            bool noAck)
+            bool autoAck)
         {
-            return m_delegate.BasicGet(queue, noAck);
+            return m_delegate.BasicGet(queue, autoAck);
         }
 
         public void BasicNack(ulong deliveryTag,

--- a/projects/client/RabbitMQ.Client/src/client/impl/IFullModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/IFullModel.cs
@@ -204,7 +204,7 @@ namespace RabbitMQ.Client.Impl
         void _Private_BasicConsume(string queue,
             string consumerTag,
             bool noLocal,
-            bool noAck,
+            bool autoAck,
             bool exclusive,
             bool nowait,
             IDictionary<string, object> arguments);
@@ -216,7 +216,7 @@ namespace RabbitMQ.Client.Impl
         [AmqpForceOneWay]
         [AmqpMethodMapping(null, "basic", "get")]
         void _Private_BasicGet(string queue,
-            bool noAck);
+            bool autoAck);
 
         ///<summary>Used to send a Basic.Publish method. Called by the
         ///public publish method after potential null-reference issues

--- a/projects/client/RabbitMQ.Client/src/client/impl/IFullModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/IFullModel.cs
@@ -204,7 +204,7 @@ namespace RabbitMQ.Client.Impl
         void _Private_BasicConsume(string queue,
             string consumerTag,
             bool noLocal,
-            bool autoAck,
+            [AmqpFieldMapping(null, "noAck")] bool autoAck,
             bool exclusive,
             bool nowait,
             IDictionary<string, object> arguments);
@@ -216,7 +216,7 @@ namespace RabbitMQ.Client.Impl
         [AmqpForceOneWay]
         [AmqpMethodMapping(null, "basic", "get")]
         void _Private_BasicGet(string queue,
-            bool autoAck);
+            [AmqpFieldMapping(null, "noAck")] bool autoAck);
 
         ///<summary>Used to send a Basic.Publish method. Called by the
         ///public publish method after potential null-reference issues

--- a/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
@@ -1029,13 +1029,13 @@ namespace RabbitMQ.Client.Impl
         public abstract void _Private_BasicConsume(string queue,
             string consumerTag,
             bool noLocal,
-            bool noAck,
+            bool autoAck,
             bool exclusive,
             bool nowait,
             IDictionary<string, object> arguments);
 
         public abstract void _Private_BasicGet(string queue,
-            bool noAck);
+            bool autoAck);
 
         public abstract void _Private_BasicPublish(string exchange,
             string routingKey,
@@ -1152,7 +1152,7 @@ namespace RabbitMQ.Client.Impl
         }
 
         public string BasicConsume(string queue,
-            bool noAck,
+            bool autoAck,
             string consumerTag,
             bool noLocal,
             bool exclusive,
@@ -1165,7 +1165,7 @@ namespace RabbitMQ.Client.Impl
             Enqueue(k);
             // Non-nowait. We have an unconventional means of getting
             // the RPC response, but a response is still expected.
-            _Private_BasicConsume(queue, consumerTag, noLocal, noAck, exclusive,
+            _Private_BasicConsume(queue, consumerTag, noLocal, autoAck, exclusive,
                 /*nowait:*/ false, arguments);
             k.GetReply(this.ContinuationTimeout);
             string actualConsumerTag = k.m_consumerTag;
@@ -1174,11 +1174,11 @@ namespace RabbitMQ.Client.Impl
         }
 
         public BasicGetResult BasicGet(string queue,
-            bool noAck)
+            bool autoAck)
         {
             var k = new BasicGetRpcContinuation();
             Enqueue(k);
-            _Private_BasicGet(queue, noAck);
+            _Private_BasicGet(queue, autoAck);
             k.GetReply(this.ContinuationTimeout);
             return k.m_result;
         }

--- a/projects/client/RabbitMQ.Client/src/client/messagepatterns/ISubscription.cs
+++ b/projects/client/RabbitMQ.Client/src/client/messagepatterns/ISubscription.cs
@@ -65,7 +65,7 @@ namespace RabbitMQ.Client.MessagePatterns
         void Nack(bool requeue);
         BasicDeliverEventArgs Next();
         bool Next(int millisecondsTimeout, out BasicDeliverEventArgs result);
-        bool NoAck { get; }
+        bool AutoAck { get; }
         string QueueName { get; }
     }
 }

--- a/projects/client/Unit/project.json
+++ b/projects/client/Unit/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "NUnit": "3.4.1",
     "RabbitMQ.Client": "*",
-    "dotnet-test-nunit": "3.4.0-beta-2"
+    "dotnet-test-nunit": "3.4.0-beta-3"
   },
   "testRunner": "nunit",
   "frameworks": {

--- a/projects/client/Unit/src/unit/TestConsumerOperationDispatch.cs
+++ b/projects/client/Unit/src/unit/TestConsumerOperationDispatch.cs
@@ -123,7 +123,7 @@ namespace RabbitMQ.Client.Unit
                 queues.Add(q);
                 var cons = new CollectingConsumer(ch);
                 consumers.Add(cons);
-                ch.BasicConsume(queue: q, noAck: false, consumer: cons);
+                ch.BasicConsume(queue: q, autoAck: false, consumer: cons);
             }
 
             for (int i = 0; i < n; i++)
@@ -207,7 +207,7 @@ namespace RabbitMQ.Client.Unit
             var q = this.Model.QueueDeclare().QueueName;
             var c = new ShutdownLatchConsumer(latch, duplicateLatch);
 
-            this.Model.BasicConsume(queue: q, noAck: true, consumer: c);
+            this.Model.BasicConsume(queue: q, autoAck: true, consumer: c);
             this.Model.Close();
             Wait(latch, TimeSpan.FromSeconds(5));
             Assert.IsFalse(duplicateLatch.WaitOne(TimeSpan.FromSeconds(5)),

--- a/projects/client/Unit/src/unit/TestSsl.cs
+++ b/projects/client/Unit/src/unit/TestSsl.cs
@@ -64,8 +64,8 @@ namespace RabbitMQ.Client.Unit
                 byte[] msgBytes = System.Text.Encoding.UTF8.GetBytes(message);
                 ch.BasicPublish("Exchange_TestSslEndPoint", "Key_TestSslEndpoint", null, msgBytes);
 
-                bool noAck = false;
-                BasicGetResult result = ch.BasicGet(qName, noAck);
+                bool autoAck = false;
+                BasicGetResult result = ch.BasicGet(qName, autoAck);
                 byte[] body = result.Body;
                 string resultMessage = System.Text.Encoding.UTF8.GetString(body);
 


### PR DESCRIPTION
Fixes #255

This renames the `noAck` parameter to `autoAck`.

Before we release this change we need to update `rabbitmq-website` and `rabbitmq-tutorials` with the new name.

