### PR TITLE
Limited the capacity of ConsumerWorkService's WorkPools

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
@@ -142,6 +142,12 @@ namespace RabbitMQ.Client
         public const string DefaultVHost = "/";
 
         /// <summary>
+        /// Default capacity of the work pool buffer, with zero meaning unlimited (value: 100).
+        /// </summary>
+        /// <remarks> PLEASE KEEP THIS MATCHING THE DOC ABOVE.</remarks>
+        public const int DefaultWorkPoolCapacity = 100;
+
+        /// <summary>
         ///  Default SASL auth mechanisms to use.
         /// </summary>
         public static readonly IList<AuthMechanismFactory> DefaultAuthMechanisms =
@@ -187,6 +193,11 @@ namespace RabbitMQ.Client
             get { return m_continuationTimeout; }
             set { m_continuationTimeout = value; }
         }
+
+        /// <summary>
+        /// Amount of pending messages that can be buffered by the consumer work service before blocking.
+        /// </summary>
+        public int WorkPoolCapacity { get; set; } = DefaultWorkPoolCapacity;
 
         /// <summary>
         /// Factory function for creating the <see cref="IEndpointResolver"/>

--- a/projects/client/RabbitMQ.Client/src/client/api/IConnectionFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IConnectionFactory.cs
@@ -147,5 +147,10 @@ namespace RabbitMQ.Client
         /// timing out.
         /// </summary>
         TimeSpan ContinuationTimeout { get; set; }
+
+        /// <summary>
+        /// Amount of pending messages that can be buffered by the consumer work service before blocking.
+        /// </summary>
+        int WorkPoolCapacity { get; set; }
     }
 }

--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -120,7 +120,7 @@ namespace RabbitMQ.Client.Framing.Impl
             FrameMax = 0;
             m_factory = factory;
             m_frameHandler = frameHandler;
-            ConsumerWorkService = new ConsumerWorkService();
+            ConsumerWorkService = new ConsumerWorkService(factory.WorkPoolCapacity);
 
             m_sessionManager = new SessionManager(this, 0);
             m_session0 = new MainSession(this) { Handler = NotifyReceivedCloseOk };


### PR DESCRIPTION
A proposed fix for #301 

I've replaced the ConcurrentQueue inside WorkPool with a BlockingCollection in order to be able to limit the amount of work that a WorkPool can contain, and made it configurable.
Every call to AddWork when the pool is full will block.