### PR TITLE
Use ConcurrentDictionary.TryAdd instead of IDictionary.Add

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
@@ -73,7 +73,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         protected List<AutorecoveringModel> m_models = new List<AutorecoveringModel>();
 
-        protected IDictionary<RecordedBinding, byte> m_recordedBindings =
+        protected ConcurrentDictionary<RecordedBinding, byte> m_recordedBindings =
             new ConcurrentDictionary<RecordedBinding, byte>();
 
         protected List<EventHandler<ConnectionBlockedEventArgs>> m_recordedBlockedEventHandlers =
@@ -463,7 +463,7 @@ namespace RabbitMQ.Client.Framing.Impl
         {
             lock (m_recordedEntitiesLock)
             {
-                m_recordedBindings.Remove(rb);
+                ((IDictionary<RecordedBinding, int>)m_recordedBindings).Remove(rb);
             }
         }
 
@@ -493,7 +493,7 @@ namespace RabbitMQ.Client.Framing.Impl
                 var bs = m_recordedBindings.Keys.Where(b => name.Equals(b.Destination));
                 foreach (RecordedBinding b in bs)
                 {
-                    m_recordedBindings.Remove(b);
+                    DeleteRecordedBinding(b);
                     MaybeDeleteRecordedAutoDeleteExchange(b.Source);
                 }
             }
@@ -509,7 +509,7 @@ namespace RabbitMQ.Client.Framing.Impl
                 var bs = m_recordedBindings.Keys.Where(b => name.Equals(b.Destination));
                 foreach (RecordedBinding b in bs)
                 {
-                    m_recordedBindings.Remove(b);
+                    DeleteRecordedBinding(b);
                     MaybeDeleteRecordedAutoDeleteExchange(b.Source);
                 }
             }
@@ -568,7 +568,7 @@ namespace RabbitMQ.Client.Framing.Impl
         {
             lock (m_recordedEntitiesLock)
             {
-                m_recordedBindings.Add(rb, 0);
+                m_recordedBindings.TryAdd(rb, 0);
             }
         }
 


### PR DESCRIPTION
when recording bindings.

Fixes: #314 

Looking at the code however there are more places we could remove locking and just use the concurrent dictionary APIs instead. 