### PR TITLE
Fixed typo causing broken link on changelog

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ### Async consumers
 
-GitHub PR: [rabbitmq-dotnet-client#307](https://github.com/rabbitmq/rabbitmq-dotnet-client/pulls/307)
+GitHub PR: [rabbitmq-dotnet-client#307](https://github.com/rabbitmq/rabbitmq-dotnet-client/pull/307)
 
 ### Enable connection recovery by default
 


### PR DESCRIPTION
The link for the pull request of Async consumers was broken