### PR TITLE
add configure await in tcp client adapter

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/TcpClientAdapter.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/TcpClientAdapter.cs
@@ -32,7 +32,7 @@ namespace RabbitMQ.Client
                 throw new ArgumentException("No ip address could be resolved for " + host);
             }
             #if CORECLR
-            await sock.ConnectAsync(ep, port);
+            await sock.ConnectAsync(ep, port).ConfigureAwait(false);
             #else
             sock.Connect(ep, port);
             await Task.FromResult(false);


### PR DESCRIPTION
It seems that lack of one `.ConfigureAwait(false)` call causes deadlock in MassTransit project when running under corefx. Can we change it?
See https://github.com/MassTransit/MassTransit/issues/946. 