### PR TITLE
More efficient way of publishing of batches of messages

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/IModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IModel.cs
@@ -226,6 +226,11 @@ namespace RabbitMQ.Client
         void BasicPublish(string exchange, string routingKey, bool mandatory,
             IBasicProperties basicProperties, byte[] body);
 
+        [AmqpMethodDoNotImplement(null)]
+        void BasicBatchPublish(string exchange, string routingKey, bool mandatory,
+           IEnumerable<BatchMessage> messages);
+
+
         /// <summary>
         /// Configures QoS parameters of the Basic content-class.
         /// </summary>
@@ -552,4 +557,8 @@ namespace RabbitMQ.Client
         /// </summary>
         TimeSpan ContinuationTimeout { get; set; }
     }
+    public class BatchMessage{
+        public byte[] Body { get; set; }
+        public IBasicProperties basicProperties { get; set; }
+        }
 }

--- a/projects/client/RabbitMQ.Client/src/client/api/IModelExtensions.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IModelExtensions.cs
@@ -103,6 +103,10 @@ namespace RabbitMQ.Client
         {
             model.BasicPublish(exchange, routingKey, false, basicProperties, body);
         }
+        public static void BasicBatchPublish(this IModel model, string exchange, string routingKey, IEnumerable<BatchMessage> messages)
+        {
+            model.BasicBatchPublish(exchange, routingKey, false, messages);
+        }
 
         /// <summary>
         /// (Spec method) Convenience overload of BasicPublish.

--- a/projects/client/RabbitMQ.Client/src/client/impl/ISession.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ISession.cs
@@ -39,6 +39,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 
 namespace RabbitMQ.Client.Impl
 {
@@ -79,5 +80,6 @@ namespace RabbitMQ.Client.Impl
         void HandleFrame(InboundFrame frame);
         void Notify();
         void Transmit(Command cmd);
+        void Transmit(IEnumerable<Command> cmd);
     }
 }

--- a/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
@@ -1063,12 +1063,6 @@ namespace RabbitMQ.Client.Impl
             IBasicProperties basicProperties,
             byte[] body);
 
-        //public abstract void _Private_BasicBatchPublish(string exchange,
-        //    string routingKey,
-        //    bool mandatory,
-        //    IEnumerable<BatchMessage> messages);
-
-
         public abstract void _Private_BasicRecover(bool requeue);
 
         public abstract void _Private_ChannelClose(ushort replyCode,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
@@ -1246,10 +1246,8 @@ namespace RabbitMQ.Client.Impl
                 body);
         }
 
-        public void BasicBatchPublish(string exchange,
-    string routingKey,
-    bool mandatory,
-    IEnumerable<BatchMessage> messages)
+        public void BasicBatchPublish(string exchange, 
+            string routingKey, bool mandatory, IEnumerable<BatchMessage> messages)
         {
             foreach (var message in messages)
             {
@@ -1277,11 +1275,10 @@ namespace RabbitMQ.Client.Impl
                 messages);
         }
         public void _Private_BasicBatchPublish(
-string @exchange,
-string @routingKey,
-bool @mandatory,
-//bool @immediate,
-IEnumerable<BatchMessage> messages)
+            string @exchange,
+            string @routingKey,
+            bool @mandatory,
+            IEnumerable<BatchMessage> messages)
         {
             BasicPublish __req = new BasicPublish();
             __req.m_exchange = @exchange;

--- a/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
@@ -1063,6 +1063,12 @@ namespace RabbitMQ.Client.Impl
             IBasicProperties basicProperties,
             byte[] body);
 
+        //public abstract void _Private_BasicBatchPublish(string exchange,
+        //    string routingKey,
+        //    bool mandatory,
+        //    IEnumerable<BatchMessage> messages);
+
+
         public abstract void _Private_BasicRecover(bool requeue);
 
         public abstract void _Private_ChannelClose(ushort replyCode,
@@ -1246,8 +1252,10 @@ namespace RabbitMQ.Client.Impl
                 body);
         }
 
-        public void BasicBatchPublish(string exchange, 
-            string routingKey, bool mandatory, IEnumerable<BatchMessage> messages)
+        public void BasicBatchPublish(string exchange,
+    string routingKey,
+    bool mandatory,
+    IEnumerable<BatchMessage> messages)
         {
             foreach (var message in messages)
             {
@@ -1275,10 +1283,11 @@ namespace RabbitMQ.Client.Impl
                 messages);
         }
         public void _Private_BasicBatchPublish(
-            string @exchange,
-            string @routingKey,
-            bool @mandatory,
-            IEnumerable<BatchMessage> messages)
+string @exchange,
+string @routingKey,
+bool @mandatory,
+//bool @immediate,
+IEnumerable<BatchMessage> messages)
         {
             BasicPublish __req = new BasicPublish();
             __req.m_exchange = @exchange;

--- a/projects/client/RabbitMQ.Client/src/client/impl/SessionBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SessionBase.cs
@@ -41,6 +41,7 @@
 using System;
 using RabbitMQ.Client.Exceptions;
 using RabbitMQ.Client.Framing.Impl;
+using System.Collections.Generic;
 
 namespace RabbitMQ.Client.Impl
 {
@@ -198,6 +199,10 @@ namespace RabbitMQ.Client.Impl
             // We used to transmit *inside* the lock to avoid interleaving
             // of frames within a channel.  But that is fixed in socket frame handler instead, so no need to lock.
             cmd.Transmit(ChannelNumber, Connection);
+        }
+        public virtual void Transmit(IEnumerable<Command> commands)
+        {
+            Connection.WriteFrameSet(Command.CalculateFrames(ChannelNumber, Connection, commands));
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

Batch publish allows sending multiple messages in one stream on the socket.
Sending in batches improves performance by reducing the number of TCP/IP messages sent and TCP/IP acknowledgments received.
This change compiles the commands for all publish messages into a memory buffer that is posted to the socket as a single stream.
Closing the socket/model/connection before the buffer has completed sending does not guarantee message delivery.

## Types of Changes

What types of changes does your code introduce to this project?

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments
