### PR TITLE
RabbitMQ.Client.csproj: add support for targeting 4.6.2 framework

### DIFF
--- a/projects/client/RabbitMQ.Client/RabbitMQ.Client.csproj
+++ b/projects/client/RabbitMQ.Client/RabbitMQ.Client.csproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <Description>The RabbitMQ .NET client is the official client library for C# (and, implicitly, other .NET languages)</Description>
     <VersionPrefix>5.0.0</VersionPrefix>
-    <TargetFrameworks>net451;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net451;net462;netstandard1.5</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -35,6 +35,10 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.EventSource.Redist" Version="1.1.*" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+    <Reference Include="System" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">


### PR DESCRIPTION
RabbitMQ added a new dependency on an obsolete Microsoft assembly
(Microsoft.Diagnostics.Tracing.EventSource 1.1.28). It is described as a "stop
gap" solution by Microsoft
(https://www.nuget.org/packages/Microsoft.Diagnostics.Tracing.EventSource) This
functionality is provided in the framework as of .NET 4.6, so providing a
version of the RabbitMQ dotnet client targeted to the 4.6.2 framework
(Microsoft's currently recommended framework) allows deployment of the RabbitMQ
dotnet client without having to redistribute the stop gap Microsoft assembly.

Signed-off-by: Keenan Forbes <keenan.forbes@ni.com>

## Proposed Changes

see description

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x ] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.

We were able to build the net462 version of the RabbitMQ.Client.dll successfully with this change (adding appropriate "-f net462" and "-c Release" to the dotnet command; however, without the signing key we're unable to fully verify or generate the final output (and don't know how to generate a version of the actual NuGet package)