### PR TITLE
Collect all exceptions when selecting an endpoint

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/IEndpointResolverExtensions.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IEndpointResolverExtensions.cs
@@ -49,7 +49,7 @@ namespace RabbitMQ.Client
         public static T SelectOne<T>(this IEndpointResolver resolver, Func<AmqpTcpEndpoint, T> selector)
         {
             var t = default(T);
-            Exception exception = null;
+            var exceptions = new List<Exception>();
             foreach(var ep in resolver.All())
             {
                 try
@@ -62,13 +62,13 @@ namespace RabbitMQ.Client
                 }
                 catch (Exception e)
                 {
-                    exception = e;
+                    exceptions.Add(e);
                 }
             }
 
-            if(Object.Equals(t, default(T)) && exception != null)
+            if(Object.Equals(t, default(T)) && exceptions.Count > 0)
             {
-                throw exception;
+                throw new AggregateException(exceptions);
             }
 
             return t;

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/BrokerUnreachableException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/BrokerUnreachableException.cs
@@ -47,8 +47,8 @@ namespace RabbitMQ.Client.Exceptions
     ///ConnectionFactory.CreateConnection attempt.</summary>
     public class BrokerUnreachableException : IOException
     {
-        ///<summary>Construct a BrokerUnreachableException. The inner exception is associated
-        ///with only one connection attempt.</summary>
+        ///<summary>Construct a BrokerUnreachableException. The inner exception is
+        ///an AggregateException holding the errors from multiple connection attempts.</summary>
         public BrokerUnreachableException(Exception Inner)
             : base("None of the specified endpoints were reachable", Inner)
         {

--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -117,17 +117,6 @@ namespace RabbitMQ.Client.Framing.Impl
                                             .InformationalVersion;
 #endif
 
-#if CORECLR
-        private static string version = typeof(Connection).GetTypeInfo().Assembly
-                                                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-                                                .InformationalVersion;
-#else
-        private static string version = typeof(Connection).Assembly
-                                            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-                                            .InformationalVersion;
-#endif
-
-
         // true if we haven't finished connection negotiation.
         // In this state socket exceptions are treated as fatal connection
         // errors, otherwise as read timeouts

--- a/projects/client/Unit/src/unit/TestIEndpointResolverExtensions.cs
+++ b/projects/client/Unit/src/unit/TestIEndpointResolverExtensions.cs
@@ -79,7 +79,8 @@ namespace RabbitMQ.Client.Unit
         public void SelectOneShouldRaiseThrownExceptionWhenThereAreOnlyInaccessibleEndpoints()
         {
             var ep = new TestEndpointResolver(new List<AmqpTcpEndpoint> { new AmqpTcpEndpoint()});
-            Assert.Throws<TestEndpointException>(() => ep.SelectOne<AmqpTcpEndpoint>((x) => { throw new TestEndpointException("bananas"); }));
+            var thrown = Assert.Throws<AggregateException>(() => ep.SelectOne<AmqpTcpEndpoint>((x) => { throw new TestEndpointException("bananas"); }));
+            Assert.That(thrown.InnerExceptions, Has.Exactly(1).TypeOf<TestEndpointException>());
         }
 
         [Test]


### PR DESCRIPTION
## Proposed Changes

This fixes #376 in the second way proposed there. It not only preserves the stack trace of the caught exception, but collects all exceptions caught while trying out endpoints, and throws them all in an AggregateException if no suitable endpoint can be found.

Note that this is a user-visible behavior change that might break some edge cases: the InnerException of the BrokerUnreachableException is now an AggregateException instead of the last exception thrown from some endpoint (such as a Client.Exceptions.ConnectFailureException).

## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue #376)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

I have run the tests with a running RabbitMQ, but not within the full umbrella test suite, so everything that needs rabbitmqctl failed locally.
