### PR TITLE
Use self describing event source format for .NET core only

### DIFF
--- a/projects/client/RabbitMQ.Client/RabbitMQ.Client.csproj
+++ b/projects/client/RabbitMQ.Client/RabbitMQ.Client.csproj
@@ -32,7 +32,6 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.EventSource.Redist" Version="1.1.*" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/projects/client/RabbitMQ.Client/src/logging/RabbitMqClientEventSource.cs
+++ b/projects/client/RabbitMQ.Client/src/logging/RabbitMqClientEventSource.cs
@@ -41,11 +41,7 @@
 namespace RabbitMQ.Client.Logging
 {
     using System;
-#if NET451
-    using Microsoft.Diagnostics.Tracing;
-#else
     using System.Diagnostics.Tracing;
-#endif
 
     [EventSource(Name="rabbitmq-dotnet-client")]
     public sealed class RabbitMqClientEventSource : EventSource
@@ -54,10 +50,16 @@ namespace RabbitMQ.Client.Logging
         {
             public const EventKeywords Log = (EventKeywords)1;
         }
+#if NET451
+        public RabbitMqClientEventSource() : base()
+        {
 
+        }
+#else
         public RabbitMqClientEventSource() : base(EventSourceSettings.EtwSelfDescribingEventFormat)
         {
         }
+#endif
 
         public static RabbitMqClientEventSource Log = new RabbitMqClientEventSource ();
 
@@ -74,18 +76,31 @@ namespace RabbitMQ.Client.Logging
             if(IsEnabled())
                 this.WriteEvent(2, message);
         }
-
+#if NET451
+        [Event(3, Message = "ERROR", Keywords = Keywords.Log, Level = EventLevel.Error)]
+        public void Error(string message, string detail)
+        {
+            if(IsEnabled())
+                this.WriteEvent(3, message, detail);
+        }
+#else
         [Event(3, Message = "ERROR", Keywords = Keywords.Log, Level = EventLevel.Error)]
         public void Error(string message,  RabbitMqExceptionDetail ex)
         {
             if(IsEnabled())
                 this.WriteEvent(3, message, ex);
         }
+#endif
 
         [NonEvent]
         public void Error(string message, Exception ex)
         {
+
+#if NET451
+            Error(message, ex.ToString());
+#else
             Error(message, new RabbitMqExceptionDetail(ex));
+#endif
         }
     }
 }

--- a/projects/client/RabbitMQ.Client/src/logging/RabbitMqConsoleEventListener.cs
+++ b/projects/client/RabbitMQ.Client/src/logging/RabbitMqConsoleEventListener.cs
@@ -42,11 +42,7 @@ namespace RabbitMQ.Client.Logging
 {
     using System;
     using System.Collections.Generic;
-#if NET451
-    using Microsoft.Diagnostics.Tracing;
-#else
     using System.Diagnostics.Tracing;
-#endif
 
     public sealed class RabbitMqConsoleEventListener : EventListener, IDisposable
     {

--- a/projects/client/RabbitMQ.Client/src/logging/RabbitMqExceptionDetail.cs
+++ b/projects/client/RabbitMQ.Client/src/logging/RabbitMqExceptionDetail.cs
@@ -42,13 +42,12 @@ namespace RabbitMQ.Client.Logging
 {
     using System;
     using System.Collections.Generic;
-#if NET451
-    using Microsoft.Diagnostics.Tracing;
-#else
     using System.Diagnostics.Tracing;
-#endif
 
-    [EventData]
+#if NET451
+#else
+[EventData]
+#endif
     public class RabbitMqExceptionDetail
     {
         public RabbitMqExceptionDetail(Exception ex)


### PR DESCRIPTION
Only simple error logging is supported for net451

Remove Microsoft.Diagnostics.Tracing.EventSource.Redist dependency for net451