### PR TITLE
Add a static property to AmqpTcpEndpoint to specify the default SSL protocol versions and use it on ConnectionFactory.SetUri

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/AmqpTcpEndpoint.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/AmqpTcpEndpoint.cs
@@ -40,7 +40,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Security.Authentication;
 using System.Text.RegularExpressions;
 
 namespace RabbitMQ.Client
@@ -62,7 +61,6 @@ namespace RabbitMQ.Client
         /// Default Amqp ssl port.
         /// </summary>
         public const int DefaultAmqpSslPort = 5671;
-
 
         /// <summary>
         /// Indicates that the default port for the protocol should be used.
@@ -141,11 +139,6 @@ namespace RabbitMQ.Client
         }
 
         /// <summary>
-        /// The default Amqp SSL protocols.
-        /// </summary>
-        public static SslProtocols DefaultAmqpSslProtocols { get; set; } = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
-
-        /// <summary>
         /// Retrieve or set the hostname of this <see cref="AmqpTcpEndpoint"/>.
         /// </summary>
         public string HostName { get; set; }
@@ -181,7 +174,7 @@ namespace RabbitMQ.Client
         /// <summary>
         /// Used to force the address family of the endpoint
         /// </summary>
-        public System.Net.Sockets.AddressFamily AddressFamily { get; set; }
+        public System.Net.Sockets.AddressFamily AddressFamily {get; set;}
 
         /// <summary>
         /// Retrieve the SSL options for this AmqpTcpEndpoint. If not set, null is returned.
@@ -235,7 +228,7 @@ namespace RabbitMQ.Client
         /// </remarks>
         public static AmqpTcpEndpoint[] ParseMultiple(string addresses)
         {
-            string[] partsArr = addresses.Split(new[] { ',' });
+            string[] partsArr = addresses.Split(new[] {','});
             var results = new List<AmqpTcpEndpoint>();
             foreach (string partRaw in partsArr)
             {

--- a/projects/client/RabbitMQ.Client/src/client/api/AmqpTcpEndpoint.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/AmqpTcpEndpoint.cs
@@ -40,6 +40,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Security.Authentication;
 using System.Text.RegularExpressions;
 
 namespace RabbitMQ.Client
@@ -61,6 +62,7 @@ namespace RabbitMQ.Client
         /// Default Amqp ssl port.
         /// </summary>
         public const int DefaultAmqpSslPort = 5671;
+
 
         /// <summary>
         /// Indicates that the default port for the protocol should be used.
@@ -139,6 +141,11 @@ namespace RabbitMQ.Client
         }
 
         /// <summary>
+        /// The default Amqp SSL protocols.
+        /// </summary>
+        public static SslProtocols DefaultAmqpSslProtocols { get; set; } = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
+
+        /// <summary>
         /// Retrieve or set the hostname of this <see cref="AmqpTcpEndpoint"/>.
         /// </summary>
         public string HostName { get; set; }
@@ -174,7 +181,7 @@ namespace RabbitMQ.Client
         /// <summary>
         /// Used to force the address family of the endpoint
         /// </summary>
-        public System.Net.Sockets.AddressFamily AddressFamily {get; set;}
+        public System.Net.Sockets.AddressFamily AddressFamily { get; set; }
 
         /// <summary>
         /// Retrieve the SSL options for this AmqpTcpEndpoint. If not set, null is returned.
@@ -228,7 +235,7 @@ namespace RabbitMQ.Client
         /// </remarks>
         public static AmqpTcpEndpoint[] ParseMultiple(string addresses)
         {
-            string[] partsArr = addresses.Split(new[] {','});
+            string[] partsArr = addresses.Split(new[] { ',' });
             var results = new List<AmqpTcpEndpoint>();
             foreach (string partRaw in partsArr)
             {

--- a/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
@@ -45,6 +45,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Linq;
+using System.Security.Authentication;
 
 #if !NETFX_CORE
 
@@ -140,6 +141,18 @@ namespace RabbitMQ.Client
         /// </summary>
         /// <remarks> PLEASE KEEP THIS MATCHING THE DOC ABOVE.</remarks>
         public const string DefaultVHost = "/";
+
+        /// <summary>
+        /// The default AMQP URI SSL protocols.
+        /// </summary>
+        public static SslProtocols DefaultAmqpUriSslProtocols { get; set; } =
+            SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
+
+        /// <summary>
+        /// The AMQP URI SSL protocols.
+        /// </summary>
+        public SslProtocols AmqpUriSslProtocols { get; set; } =
+            DefaultAmqpUriSslProtocols;
 
         /// <summary>
         ///  Default SASL auth mechanisms to use.
@@ -517,7 +530,7 @@ namespace RabbitMQ.Client
             else if (string.Equals("amqps", uri.Scheme, StringComparison.OrdinalIgnoreCase))
             {
                 Ssl.Enabled = true;
-                Ssl.Version = AmqpTcpEndpoint.DefaultAmqpSslProtocols;
+                Ssl.Version = AmqpUriSslProtocols;
 #if !(NETFX_CORE)
                 Ssl.AcceptablePolicyErrors = SslPolicyErrors.RemoteCertificateNameMismatch;
 #endif

--- a/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
@@ -517,6 +517,7 @@ namespace RabbitMQ.Client
             else if (string.Equals("amqps", uri.Scheme, StringComparison.OrdinalIgnoreCase))
             {
                 Ssl.Enabled = true;
+                Ssl.Version = AmqpTcpEndpoint.DefaultAmqpSslProtocols;
 #if !(NETFX_CORE)
                 Ssl.AcceptablePolicyErrors = SslPolicyErrors.RemoteCertificateNameMismatch;
 #endif


### PR DESCRIPTION
## Proposed Changes

When creating a connection from an `Uri` there's no way to specify the accepted TLS versions.

Having a property  on [`AmqpTcpEndpoint`](blob/master/projects/client/RabbitMQ.Client/src/client/api/AmqpTcpEndpoint.cs) that is used by [`ConnectionFactory.SetUri`](blob/master/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs) would allow users of the library to control the default SSL protocol versions used.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
