### PR TITLE
avoid string concatenation

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/ShutdownEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ShutdownEventArgs.cs
@@ -107,7 +107,7 @@ namespace RabbitMQ.Client
         /// Override ToString to be useful for debugging.
         /// </summary>
         public override string ToString()
-            => $"AMQP close-reason, initiated by {Initiator}, code={ReplyCode}, text=\"{ReplyText}\"}, classId={ClassId}, methodId={MethodId}, cause={Cause}";
+            => $"AMQP close-reason, initiated by {Initiator}, code={ReplyCode}, text=\"{ReplyText}\", classId={ClassId}, methodId={MethodId}, cause={Cause}";
     }
 }
 }

--- a/projects/client/RabbitMQ.Client/src/client/api/ShutdownEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ShutdownEventArgs.cs
@@ -107,13 +107,7 @@ namespace RabbitMQ.Client
         /// Override ToString to be useful for debugging.
         /// </summary>
         public override string ToString()
-        {
-            return "AMQP close-reason, initiated by " + Initiator +
-                   ", code=" + ReplyCode +
-                   ", text=\"" + ReplyText + "\"" +
-                   ", classId=" + ClassId +
-                   ", methodId=" + MethodId +
-                   ", cause=" + Cause;
-        }
+            => $"AMQP close-reason, initiated by {Initiator}, code={ReplyCode}, text=\"{ReplyText}\"}, classId={ClassId}, methodId={MethodId}, cause={Cause}";
     }
+}
 }

--- a/projects/client/RabbitMQ.Client/src/client/api/ShutdownReportEntry.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ShutdownReportEntry.cs
@@ -66,8 +66,9 @@ namespace RabbitMQ.Client
 
         public override string ToString()
         {
-            string output = "Message: " + Description;
-            return (Exception != null) ? output + " Exception: " + Exception : output;
+            return (this.Exception != null)
+                ? $"Message: {this.Description} Exception: {this.Exception}"
+                : $"Message: {this.Description}";
         }
     }
 }

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/PacketNotRecognizedException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/PacketNotRecognizedException.cs
@@ -39,7 +39,6 @@
 //---------------------------------------------------------------------------
 
 using System;
-using System.Net;
 
 namespace RabbitMQ.Client.Exceptions
 {
@@ -58,8 +57,7 @@ namespace RabbitMQ.Client.Exceptions
             int transportLow,
             int serverMajor,
             int serverMinor)
-            : base("AMQP server protocol version " + serverMajor + "-" + serverMinor +
-                   ", transport parameters " + transportHigh + ":" + transportLow)
+            : base($"AMQP server protocol version {serverMajor}-{serverMinor}, transport parameters {transportHigh}:{transportLow}")
         {
             TransportHigh = transportHigh;
             TransportLow = transportLow;

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/ProtocolVersionMismatchException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/ProtocolVersionMismatchException.cs
@@ -39,7 +39,6 @@
 //---------------------------------------------------------------------------
 
 using System;
-using System.Net;
 
 namespace RabbitMQ.Client.Exceptions
 {
@@ -53,9 +52,7 @@ namespace RabbitMQ.Client.Exceptions
             int clientMinor,
             int serverMajor,
             int serverMinor)
-            : base("AMQP server protocol negotiation failure: server version " +
-                   positiveOrUnknown(serverMajor) + "-" + positiveOrUnknown(serverMinor) +
-                   ", client version " + positiveOrUnknown(clientMajor) + "-" + positiveOrUnknown(clientMinor))
+            : base($"AMQP server protocol negotiation failure: server version {positiveOrUnknown(serverMajor)}-{positiveOrUnknown(serverMinor)}, client version {positiveOrUnknown(clientMajor)}-{positiveOrUnknown(clientMinor)}")
         {
             ClientMajor = clientMajor;
             ClientMinor = clientMinor;

--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -1320,8 +1320,7 @@ entry.ToString());
                 AuthMechanismFactory mechanismFactory = m_factory.AuthMechanismFactory(mechanisms);
                 if (mechanismFactory == null)
                 {
-                    throw new IOException("No compatible authentication mechanism found - " +
-                                          "server offered [" + mechanismsString + "]");
+                    throw new IOException($"No compatible authentication mechanism found - server offered [{mechanismsString}]");
                 }
                 AuthMechanism mechanism = mechanismFactory.GetInstance();
                 byte[] challenge = null;

--- a/projects/client/RabbitMQ.Client/src/client/impl/Frame.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Frame.cs
@@ -39,9 +39,7 @@
 //---------------------------------------------------------------------------
 
 using RabbitMQ.Client.Exceptions;
-using RabbitMQ.Client.Framing;
 using RabbitMQ.Util;
-using System;
 using System.IO;
 
 #if NETFX_CORE
@@ -234,9 +232,7 @@ namespace RabbitMQ.Client.Impl
             if (payload.Length != payloadSize)
             {
                 // Early EOF.
-                throw new MalformedFrameException("Short frame - expected " +
-                                                  payloadSize + " bytes, got " +
-                                                  payload.Length + " bytes");
+                throw new MalformedFrameException($"Short frame - expected {payloadSize} bytes, got {payload.Length} bytes");
             }
 
             int frameEndMarker = reader.ReadByte();

--- a/projects/client/RabbitMQ.Client/src/client/impl/UnknownClassOrMethodException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/UnknownClassOrMethodException.cs
@@ -38,8 +38,6 @@
 //  Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
-using System;
-using RabbitMQ.Client.Framing;
 
 namespace RabbitMQ.Client.Impl
 {
@@ -71,11 +69,11 @@ namespace RabbitMQ.Client.Impl
         {
             if (MethodId == 0)
             {
-                return base.ToString() + "<" + ClassId + ">";
+                return $"{base.ToString()}<{ClassId}>";
             }
             else
             {
-                return base.ToString() + "<" + ClassId + "." + MethodId + ">";
+                return $"{base.ToString()}<{ClassId}.{MethodId}>";
             }
         }
     }

--- a/projects/client/RabbitMQ.Client/src/client/impl/WireFormatting.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/WireFormatting.cs
@@ -38,7 +38,6 @@
 //  Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -54,8 +53,7 @@ namespace RabbitMQ.Client.Impl
         {
             if (scale > 28)
             {
-                throw new SyntaxError("Unrepresentable AMQP decimal table field: " +
-                                      "scale=" + scale);
+                throw new SyntaxError($"Unrepresentable AMQP decimal table field: scale={scale}");
             }
             return new decimal((int)(unsignedMantissa & 0x7FFFFFFF),
                 0,
@@ -159,8 +157,7 @@ namespace RabbitMQ.Client.Impl
                     break;
 
                 default:
-                    throw new SyntaxError("Unrecognised type in table: " +
-                                          (char)discriminator);
+                    throw new SyntaxError($"Unrecognised type in table: {(char)discriminator}");
             }
             return value;
         }
@@ -180,8 +177,7 @@ namespace RabbitMQ.Client.Impl
             uint byteCount = reader.ReadUInt32();
             if (byteCount > int.MaxValue)
             {
-                throw new SyntaxError("Long string too long; " +
-                                      "byte length=" + byteCount + ", max=" + int.MaxValue);
+                throw new SyntaxError($"Long string too long; byte length={byteCount}, max={int.MaxValue}");
             }
             return reader.ReadBytes((int)byteCount);
         }
@@ -386,8 +382,7 @@ namespace RabbitMQ.Client.Impl
             int len = bytes.Length;
             if (len > 255)
             {
-                throw new WireFormattingException("Short string too long; " +
-                                                  "UTF-8 encoded length=" + len + ", max=255");
+                throw new WireFormattingException($"Short string too long; UTF-8 encoded length={len}, max=255");
             }
             writer.Write((byte)len);
             writer.Write(bytes);


### PR DESCRIPTION
## Proposed Changes

String concatenations are bad because they incur in memory allocations.

Using `string.Format` (directly or through string interpolation) uses cached `StringBuilder`s thus avoiding allocations. 

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments


