### PR TITLE
Fixed link formatting for 'API Documentation'

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ as archives.
 
  * [Tutorials](http://www.rabbitmq.com/getstarted.html)
  * [Documentation guide](http://www.rabbitmq.com/dotnet.html)
- * [API Documentation](https://rabbitmq.github.io/rabbitmq-dotnet-client/index.html
+ * [API Documentation](https://rabbitmq.github.io/rabbitmq-dotnet-client/index.html)
 
 
 ## Supported Platforms and .NET Releases


### PR DESCRIPTION
## Proposed Changes

Fixed a link on the readme

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

