### PR TITLE
fixed 'System.ObjectDisposedException' when closing/disposing connection

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -1012,6 +1012,8 @@ entry.ToString());
         {
             if (Heartbeat != 0)
             {
+                IsDisposedHeartBeatReadTimer = false;
+                IsDisposedHeartBeatWriteTimer = false;
 #if NETFX_CORE
                 _heartbeatWriteTimer = new Timer(HeartbeatWriteTimerCallback);
                 _heartbeatReadTimer = new Timer(HeartbeatReadTimerCallback);
@@ -1040,99 +1042,127 @@ entry.ToString());
 #endif
         }
 
+        private readonly object heartBeatReadLock = new object();
+        private readonly object heartBeatWriteLock = new object();
+        public bool IsDisposedHeartBeatReadTimer { get; set; }
+        public bool IsDisposedHeartBeatWriteTimer { get; set; }
+
         public void HeartbeatReadTimerCallback(object state)
         {
-            bool shouldTerminate = false;
-            try
+            lock (heartBeatReadLock)
             {
-                if (!m_closed)
+                if (IsDisposedHeartBeatReadTimer)
                 {
-                    if (!m_heartbeatRead.WaitOne(0))
+                    return;
+                }
+                bool shouldTerminate = false;
+                try
+                {
+                    if (!m_closed)
                     {
-                        m_missedHeartbeats++;
-                    }
-                    else
-                    {
-                        m_missedHeartbeats = 0;
+                        if (!m_heartbeatRead.WaitOne(0))
+                        {
+                            m_missedHeartbeats++;
+                        }
+                        else
+                        {
+                            m_missedHeartbeats = 0;
+                        }
+
+                        // We check against 8 = 2 * 4 because we need to wait for at
+                        // least two complete heartbeat setting intervals before
+                        // complaining, and we've set the socket timeout to a quarter
+                        // of the heartbeat setting in setHeartbeat above.
+                        if (m_missedHeartbeats > 2 * 4)
+                        {
+                            String description = String.Format("Heartbeat missing with heartbeat == {0} seconds", m_heartbeat);
+                            var eose = new EndOfStreamException(description);
+                            ESLog.Error(description, eose);
+                            m_shutdownReport.Add(new ShutdownReportEntry(description, eose));
+                            HandleMainLoopException(
+                                new ShutdownEventArgs(ShutdownInitiator.Library, 0, "End of stream", eose));
+                            shouldTerminate = true;
+                        }
                     }
 
-                    // We check against 8 = 2 * 4 because we need to wait for at
-                    // least two complete heartbeat setting intervals before
-                    // complaining, and we've set the socket timeout to a quarter
-                    // of the heartbeat setting in setHeartbeat above.
-                    if (m_missedHeartbeats > 2 * 4)
+                    if (shouldTerminate)
                     {
-                        String description = String.Format("Heartbeat missing with heartbeat == {0} seconds", m_heartbeat);
-                        var eose = new EndOfStreamException(description);
-                        ESLog.Error(description, eose);
-                        m_shutdownReport.Add(new ShutdownReportEntry(description, eose));
-                        HandleMainLoopException(
-                            new ShutdownEventArgs(ShutdownInitiator.Library, 0, "End of stream", eose));
-                        shouldTerminate = true;
+                        TerminateMainloop();
+                        FinishClose();
+                    }
+                    else if (_heartbeatReadTimer != null)
+                    {
+                        _heartbeatReadTimer.Change(Heartbeat * 1000, Timeout.Infinite);
                     }
                 }
-
-                if (shouldTerminate)
+                catch (ObjectDisposedException)
                 {
-                    TerminateMainloop();
-                    FinishClose();
+                    // timer is already disposed,
+                    // e.g. due to shutdown
                 }
-                else if (_heartbeatReadTimer != null)
+                catch (NullReferenceException)
                 {
-                    _heartbeatReadTimer.Change(Heartbeat * 1000, Timeout.Infinite);
+                    // timer has already been disposed from a different thread after null check
+                    // this event should be rare
                 }
-            }
-            catch (ObjectDisposedException)
-            {
-                // timer is already disposed,
-                // e.g. due to shutdown
-            }
-            catch (NullReferenceException)
-            {
-                // timer has already been disposed from a different thread after null check
-                // this event should be rare
             }
         }
 
         public void HeartbeatWriteTimerCallback(object state)
         {
-            bool shouldTerminate = false;
-            try
+            lock (heartBeatWriteLock)
             {
+                if (IsDisposedHeartBeatWriteTimer)
+                {
+                    return;
+                }
+                bool shouldTerminate = false;
                 try
                 {
-                    if (!m_closed)
+                    try
                     {
-                        WriteFrame(m_heartbeatFrame);
+                        if (!m_closed)
+                        {
+                            WriteFrame(m_heartbeatFrame);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        HandleMainLoopException(new ShutdownEventArgs(
+                            ShutdownInitiator.Library,
+                            0,
+                            "End of stream",
+                            e));
+                        shouldTerminate = true;
+                    }
+
+                    if (m_closed || shouldTerminate)
+                    {
+                        TerminateMainloop();
+                        FinishClose();
                     }
                 }
-                catch (Exception e)
+                catch (ObjectDisposedException)
                 {
-                    HandleMainLoopException(new ShutdownEventArgs(
-                        ShutdownInitiator.Library,
-                        0,
-                        "End of stream",
-                        e));
-                    shouldTerminate = true;
-                }
-
-                if (m_closed || shouldTerminate)
-                {
-                    TerminateMainloop();
-                    FinishClose();
-                }
-            }
-            catch (ObjectDisposedException)
-            {
-                // timer is already disposed,
-                // e.g. due to shutdown
+                    // timer is already disposed,
+                    // e.g. due to shutdown
+                } /**/
             }
         }
 
         protected void MaybeStopHeartbeatTimers()
         {
-            MaybeDisposeTimer(ref _heartbeatReadTimer);
-            MaybeDisposeTimer(ref _heartbeatWriteTimer);
+            lock (heartBeatReadLock)
+            {
+                MaybeDisposeTimer(ref _heartbeatReadTimer);
+                IsDisposedHeartBeatReadTimer = true;
+            }
+
+            lock (heartBeatWriteLock)
+            {
+                MaybeDisposeTimer(ref _heartbeatWriteTimer);
+                IsDisposedHeartBeatWriteTimer = true;
+            }
         }
 
         private void MaybeDisposeTimer(ref Timer timer)


### PR DESCRIPTION
## Proposed Changes
Lock _heartbeatWriteTimer and _heartbeatReadTimer in Connection.cs before disposing and inside the timer elapsed delegate to avoid the following exception:
   ```
System.ObjectDisposedException occurred
Message: Exception thrown: 'System.ObjectDisposedException' in mscorlib.dll
Additional information: Cannot access a disposed object.
   at System.Threading.TimerQueueTimer.Change(UInt32 dueTime, UInt32 period)
```
Please see [Issue#220](https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/220) for details.
## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x ] I have read the `CONTRIBUTING.md` document
- [ x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
