### PR TITLE
Unspecified socket family matches any single IPAddress

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/TcpClientAdapter.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/TcpClientAdapter.cs
@@ -26,8 +26,8 @@ namespace RabbitMQ.Client
         {
             AssertSocket();
             var adds = await Dns.GetHostAddressesAsync(host).ConfigureAwait(false);
-            var ep = adds.FirstOrDefault(a => a.AddressFamily == sock.AddressFamily);
-            if(ep == default(IPAddress))
+            var ep = TcpClientAdapterHelper.GetMatchingHost(adds, sock.AddressFamily);
+            if (ep == default(IPAddress))
             {
                 throw new ArgumentException("No ip address could be resolved for " + host);
             }

--- a/projects/client/RabbitMQ.Client/src/client/impl/TcpClientAdapterHelper.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/TcpClientAdapterHelper.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+
+namespace RabbitMQ.Client
+{
+    public static class TcpClientAdapterHelper
+    {
+        public static IPAddress GetMatchingHost(IReadOnlyCollection<IPAddress> addresses, AddressFamily addressFamily)
+        {
+            var ep = addresses.FirstOrDefault(a => a.AddressFamily == addressFamily);
+            if (ep == null && addresses.Count == 1 && addressFamily == AddressFamily.Unspecified)
+            {
+                return addresses.Single();
+            }
+            return ep;
+        }
+    }
+}

--- a/projects/client/Unit/src/unit/TestTcpClientAdapter.cs
+++ b/projects/client/Unit/src/unit/TestTcpClientAdapter.cs
@@ -55,7 +55,7 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void TcpClientAdapterHelperGetMatchingHostReturnNoAddressIfFamilyDoesNotMatch()
         {
-            var address = IPAddress.Parse("1.1.1.1");
+            var address = IPAddress.Parse("127.0.0.1");
             var matchingAddress = TcpClientAdapterHelper.GetMatchingHost(new[] { address }, AddressFamily.InterNetworkV6);
             Assert.IsNull(matchingAddress);
         }

--- a/projects/client/Unit/src/unit/TestTcpClientAdapter.cs
+++ b/projects/client/Unit/src/unit/TestTcpClientAdapter.cs
@@ -40,6 +40,7 @@
 
 #if !NETFX_CORE
 using System;
+using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 using NUnit.Framework;
@@ -52,14 +53,28 @@ namespace RabbitMQ.Client.Unit
     public class TestTcpClientAdapter
     {
         [Test]
-        public void ConnectAsyncThrowsArgumentExceptionWhenNoAddressForAddressFamilyCanBeFound()
+        public void TcpClientAdapterHelperGetMatchingHostReturnNoAddressIfFamilyDoesNotMatch()
         {
-            var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP);
-            var sut = new TcpClientAdapter(socket);
-            Assert.Throws<ArgumentException>(() =>
-            {
-                sut.ConnectAsync("localhost", 5672).GetAwaiter().GetResult();
-            });
+            var address = IPAddress.Parse("1.1.1.1");
+            var matchingAddress = TcpClientAdapterHelper.GetMatchingHost(new[] { address }, AddressFamily.InterNetworkV6);
+            Assert.IsNull(matchingAddress);
+        }
+
+        [Test]
+        public void TcpClientAdapterHelperGetMatchingHostReturnsSingleAddressIfFamilyIsUnspecified()
+        {
+            var address = IPAddress.Parse("1.1.1.1");
+            var matchingAddress = TcpClientAdapterHelper.GetMatchingHost(new[] { address }, AddressFamily.Unspecified);
+            Assert.AreEqual(address, matchingAddress);
+        }
+
+        [Test]
+        public void TcpClientAdapterHelperGetMatchingHostReturnNoAddressIfFamilyIsUnspecifiedAndThereIsNoSingleMatch()
+        {
+            var address = IPAddress.Parse("1.1.1.1");
+            var address2 = IPAddress.Parse("2.2.2.2");
+            var matchingAddress = TcpClientAdapterHelper.GetMatchingHost(new[] { address, address2 }, AddressFamily.Unspecified);
+            Assert.IsNull(matchingAddress);
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

Today I have spend around 10 hours trying to investigate why client is so upset and it spam me with exceptions. After some investigation I found that there is a problem that if `IPAddressType` is unspecified then `TcpClientAdapter` just fails to do anything.

This change allows to resolve single IPAddress as matching one if Socket type is `Unspecified` , Otherwise, the old behaviour sustains. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

I moved code block that makes decision about matching address into another class to make testing easier.

---

My real issue was that EasyNetQ is always creating sockets with `Unspesified` address family and it cannot be configured outside. I'm going to propose some fixes to them to make their code correctly determine address family, but I think that unspecified with single alternative is a valid change here too.