### PR TITLE
Add ObsoleteAttribuite to IConnection.AutoClose

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/IConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IConnection.cs
@@ -74,6 +74,7 @@ namespace RabbitMQ.Client
         /// DON'T set AutoClose to true before opening the first
         /// channel, because the connection will be immediately closed if you do!
         /// </remarks>
+        [Obsolete("Please explicitly close connections instead.")]
         bool AutoClose { get; set; }
 
         /// <summary>

--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
@@ -294,6 +294,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public string ClientProvidedName { get; private set; }
 
+        [Obsolete("Please explicitly close connections instead.")]
         public bool AutoClose
         {
             get { return m_delegate.AutoClose; }

--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -273,6 +273,7 @@ namespace RabbitMQ.Client.Framing.Impl
         }
         public string ClientProvidedName { get; private set; }
 
+        [Obsolete("Please explicitly close connections instead.")]
         public bool AutoClose
         {
             get { return m_sessionManager.AutoClose; }

--- a/projects/client/RabbitMQ.Client/src/client/impl/SessionManager.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SessionManager.cs
@@ -68,6 +68,7 @@ namespace RabbitMQ.Client.Impl
             Ints = new IntAllocator(1, ChannelMax);
         }
 
+        [Obsolete("Please explicitly close connections instead.")]
         public bool AutoClose
         {
             get { return m_autoClose; }


### PR DESCRIPTION
## Proposed Changes

Since `IConnection.AutoClose` is obsolete, it should be marked with the `ObsoleteAttribute`.

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

See #405
