### PR TITLE
Supress exception while establishing TCP-connection with server, if task has already expired by timeout

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/ITcpClient.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ITcpClient.cs
@@ -3,6 +3,7 @@ using System;
 using System.Threading.Tasks;
 
 using System.Net.Sockets;
+using System.Threading;
 
 namespace RabbitMQ.Client
 {
@@ -18,7 +19,7 @@ namespace RabbitMQ.Client
 
         Socket Client { get; }
 
-        Task ConnectAsync(string host, int port);
+        Task ConnectAsync(string host, int port, CancellationToken cancellationToken);
 
         NetworkStream GetStream();
 


### PR DESCRIPTION
## Proposed Changes

To reproduce this issue, you'll need to use a software, which allows to block some part of TCP traffic (on our production, we used a specific HAProxy configuration, locally - i used https://jagt.github.io/clumsy/ and set it up to drop all incoming packets).
As you can see from the changes, the reason of a problem that currently used extension for task timeout limitation does nothing with source task while throwing a TimeoutException. That timeout exception is correctly thrown back to calling code, while Exception, thrown by TCPClientAdapter.ConnectAsync remains unhandled and causes an AppDomain.CurrentDomain.UnhandledException.

## Types of Changes
- [x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
