### PR TITLE
Add ClientProvidedName to connection factories

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
@@ -337,6 +337,11 @@ namespace RabbitMQ.Client
         }
 
         /// <summary>
+        /// Default client provided name to be used for connections.
+        /// </summary>
+        public string ClientProvidedName { get; set; }
+
+        /// <summary>
         /// Given a list of mechanism names supported by the server, select a preferred mechanism,
         ///  or null if we have none in common.
         /// </summary>
@@ -364,7 +369,7 @@ namespace RabbitMQ.Client
         /// </exception>
         public virtual IConnection CreateConnection()
         {
-            return CreateConnection(this.EndpointResolverFactory(LocalEndpoints()), null);
+            return CreateConnection(this.EndpointResolverFactory(LocalEndpoints()), ClientProvidedName);
         }
 
         /// <summary>
@@ -402,7 +407,7 @@ namespace RabbitMQ.Client
         /// </exception>
         public IConnection CreateConnection(IList<string> hostnames)
         {
-            return CreateConnection(hostnames, null);
+            return CreateConnection(hostnames, ClientProvidedName);
         }
 
         /// <summary>
@@ -446,7 +451,7 @@ namespace RabbitMQ.Client
         /// </exception>
         public IConnection CreateConnection(IList<AmqpTcpEndpoint> endpoints)
         {
-            return CreateConnection(new DefaultEndpointResolver(endpoints), null);
+            return CreateConnection(new DefaultEndpointResolver(endpoints), ClientProvidedName);
         }
 
         /// <summary>

--- a/projects/client/RabbitMQ.Client/src/client/api/IConnectionFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IConnectionFactory.cs
@@ -93,6 +93,11 @@ namespace RabbitMQ.Client
         Uri Uri { get; set; }
 
         /// <summary>
+        /// Default client provided name to be used for connections.
+        /// </summary>
+        string ClientProvidedName { get; set; }
+
+        /// <summary>
         /// Given a list of mechanism names supported by the server, select a preferred mechanism,
         /// or null if we have none in common.
         /// </summary>

--- a/projects/client/Unit/src/unit/TestConnectionFactory.cs
+++ b/projects/client/Unit/src/unit/TestConnectionFactory.cs
@@ -98,6 +98,19 @@ namespace RabbitMQ.Client.Unit
         }
 
         [Test]
+        public void TestCreateConnectionWithClientProvidedNameUsesDefaultName()
+        {
+            var cf = new ConnectionFactory();
+            cf.AutomaticRecoveryEnabled = false;
+            cf.ClientProvidedName = "some_name";
+            using (var conn = cf.CreateConnection())
+            {
+                Assert.AreEqual("some_name", conn.ClientProvidedName);
+                Assert.AreEqual("some_name", conn.ClientProperties["connection_name"]);
+            }
+        }
+
+        [Test]
         public void TestCreateConnectionWithClientProvidedNameUsesName()
         {
             var cf = new ConnectionFactory();


### PR DESCRIPTION
## Proposed Changes

This would be a property om `IConnectionFactory` that is used instead of null when a client name is not provided when invoking `CreateConnection`.

Solves #437 

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

