### PR TITLE
Fix redundant creation of MemoryStream

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/Command.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Command.cs
@@ -66,12 +66,10 @@ namespace RabbitMQ.Client.Impl
 
         public Command() : this(null, null, null)
         {
-            m_body = new MemoryStream();
         }
 
         public Command(MethodBase method) : this(method, null, null)
         {
-            m_body = new MemoryStream();
         }
 
         public Command(MethodBase method, ContentHeaderBase header, byte[] body)


### PR DESCRIPTION
## Proposed Changes

There are two unnecessary allocations of MemoryStream in constructors of Command class, because they invoke another constructor which sets `m_body` field.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories