### PR TITLE
Preallocate buffer of command

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/CommandAssembler.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/CommandAssembler.cs
@@ -40,6 +40,7 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
 using RabbitMQ.Client.Framing.Impl;
 using RabbitMQ.Client.Framing;
 using RabbitMQ.Util;
@@ -54,14 +55,18 @@ namespace RabbitMQ.Client.Impl
         Complete
     }
 
-
     public class CommandAssembler
     {
-        public Command m_command;
+        private const int MaxArrayOfBytesSize = 2_147_483_591;
+        
+        public MethodBase m_method;
+        public ContentHeaderBase m_header;
+        public MemoryStream m_bodyStream;
+        public byte[] m_body;
         public ProtocolBase m_protocol;
-        public ulong m_remainingBodyBytes;
+        public int m_remainingBodyBytes;
         public AssemblyState m_state;
-
+      
         public CommandAssembler(ProtocolBase protocol)
         {
             m_protocol = protocol;
@@ -78,8 +83,8 @@ namespace RabbitMQ.Client.Impl
                     {
                         throw new UnexpectedFrameException(f);
                     }
-                    m_command.Method = m_protocol.DecodeMethodFrom(f.GetReader());
-                    m_state = m_command.Method.HasContent
+                    m_method = m_protocol.DecodeMethodFrom(f.GetReader());
+                    m_state = m_method.HasContent
                         ? AssemblyState.ExpectingContentHeader
                         : AssemblyState.Complete;
                     return CompletedCommand();
@@ -91,8 +96,15 @@ namespace RabbitMQ.Client.Impl
                         throw new UnexpectedFrameException(f);
                     }
                     NetworkBinaryReader reader = f.GetReader();
-                    m_command.Header = m_protocol.DecodeContentHeaderFrom(reader);
-                    m_remainingBodyBytes = m_command.Header.ReadFrom(reader);
+                    m_header = m_protocol.DecodeContentHeaderFrom(reader);
+                    var totalBodyBytes = m_header.ReadFrom(reader);
+                    if (totalBodyBytes > MaxArrayOfBytesSize)
+                    {
+                        throw new UnexpectedFrameException(f);
+                    }
+                    m_remainingBodyBytes = (int)totalBodyBytes;
+                    m_body = new byte[m_remainingBodyBytes];
+                    m_bodyStream = new MemoryStream(m_body, true);
                     UpdateContentBodyState();
                     return CompletedCommand();
                 }
@@ -102,15 +114,15 @@ namespace RabbitMQ.Client.Impl
                     {
                         throw new UnexpectedFrameException(f);
                     }
-                    m_command.AppendBodyFragment(f.Payload);
-                    if ((ulong)f.Payload.Length > m_remainingBodyBytes)
+                    if (f.Payload.Length > m_remainingBodyBytes)
                     {
                         throw new MalformedFrameException
                             (string.Format("Overlong content body received - {0} bytes remaining, {1} bytes received",
                                 m_remainingBodyBytes,
                                 f.Payload.Length));
                     }
-                    m_remainingBodyBytes -= (ulong)f.Payload.Length;
+                    m_bodyStream.Write(f.Payload, 0, f.Payload.Length);
+                    m_remainingBodyBytes -= f.Payload.Length;
                     UpdateContentBodyState();
                     return CompletedCommand();
                 }
@@ -129,7 +141,7 @@ namespace RabbitMQ.Client.Impl
         {
             if (m_state == AssemblyState.Complete)
             {
-                Command result = m_command;
+                Command result = new Command(m_method, m_header, m_body);
                 Reset();
                 return result;
             }
@@ -142,7 +154,10 @@ namespace RabbitMQ.Client.Impl
         private void Reset()
         {
             m_state = AssemblyState.ExpectingMethod;
-            m_command = new Command();
+            m_method = null;
+            m_header = null;
+            m_body = null;
+            m_bodyStream = null;
             m_remainingBodyBytes = 0;
         }
 


### PR DESCRIPTION
This PR optimise allocations of byte arrays during receive and send of commands.

Before this change during receive of command(`CommandAssembler`):
1.  MemoryStream with zero capacity was created.
2. Body parts were received and were written to `MemoryStream` one by one(`Command. AppendBodyFragment`). It caused reallocation of arrays inside `MemoryStream` in cases of many parts or large bodies.
3. The subsequent call of `MemoryStream.ToArray()`(`Command.Body`) created yet another copy of array inside `MemoryStream`. 

After this change during receive of command:
1. MemoryStream will be created with exactly needed capacity by passing buffer of exactly needed size. 
2. Body parts will be received and will be written to `MemoryStream` one by one, but no allocation will happen, because buffer was preallocated before.
3. Instead of invoking `MemoryStream.ToArray()` to get the body of the command, buffer will be passed to command as is.

Before this change during send of command:
1. MemoryStream was allocated in constructor of `Command` with body.
2. `Command.TransmitAsSingleFrame` and `Command.CalculateFrames` invoked `Command.Body` or `Command.ConsolidateBody()` and it caused copying of command's body(`MemoryStream.ToArray()`).

After this change during send of the command:
1. No `MemoryStream` will be created.
2. `Body` will be reused as is during conversion to frames.

I also move some code from `Command` to `CommandAssembler` but there are no tests for `CommandAssembler` 😞 

Yet another annoying thing was checking of body size: by spec the size of body has `ulong` size, but in practise size of byte array cannot be greater than `2_147_483_591`, because as far as I know it's a current limitation of dotnet(https://stackoverflow.com/questions/2338778/what-is-the-maximum-length-of-an-array-in-net-on-64-bit-windows).

PS Unfortunately I cannot run all tests on my mac and I hope CI will help me 😢

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories