### PR TITLE
Reduce outbound frame allocations

### DIFF
--- a/projects/client/RabbitMQ.Client/RabbitMQ.Client.csproj
+++ b/projects/client/RabbitMQ.Client/RabbitMQ.Client.csproj
@@ -40,6 +40,10 @@
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.5'">
+    <DefineConstants>$(DefineConstants);CORECLR15</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)' == 'SignedRelease' ">
     <DelaySign>true</DelaySign>
     <OutputType>Library</OutputType>

--- a/projects/client/RabbitMQ.Client/src/client/impl/ExtensionMethods.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ExtensionMethods.cs
@@ -65,7 +65,7 @@ namespace RabbitMQ.Client.Impl
             return list.ElementAt<T>(hashCode % n);
         }
 
-        public static ArraySegment<byte> GetBufferSegment(this MemoryStream ms)
+        internal static ArraySegment<byte> GetBufferSegment(this MemoryStream ms)
         {
 #if CORECLR15
             var payload = ms.ToArray();

--- a/projects/client/RabbitMQ.Client/src/client/impl/ExtensionMethods.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ExtensionMethods.cs
@@ -40,6 +40,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace RabbitMQ.Client.Impl
@@ -62,6 +63,17 @@ namespace RabbitMQ.Client.Impl
 
             var hashCode = Math.Abs(Guid.NewGuid().GetHashCode());
             return list.ElementAt<T>(hashCode % n);
+        }
+
+        public static ArraySegment<byte> GetBufferSegment(this MemoryStream ms)
+        {
+#if CORECLR15
+            var payload = ms.ToArray();
+            return new ArraySegment<byte>(payload, 0, payload.Length);
+#else
+            var buffer = ms.GetBuffer();
+            return new ArraySegment<byte>(buffer, 0, (int)ms.Position);
+#endif
         }
     }
 }

--- a/projects/client/RabbitMQ.Client/src/client/impl/Frame.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Frame.cs
@@ -73,15 +73,9 @@ namespace RabbitMQ.Client.Impl
             nw.Write(header.ProtocolClassId);
             header.WriteTo(nw, (ulong)bodyLength);
 
-#if CORECLR15
-            var payload = ms.ToArray();
-            writer.Write((uint)payload.Length);
-            writer.Write(payload);
-#else
-            var buffer = ms.GetBuffer();
-            writer.Write((uint)ms.Position);
-            writer.Write(buffer, 0, (int)ms.Position);
-#endif
+            var bufferSegment = ms.GetBufferSegment();
+            writer.Write((uint)bufferSegment.Count);
+            writer.Write(bufferSegment.Array, bufferSegment.Offset, bufferSegment.Count);
         }
     }
 
@@ -126,15 +120,9 @@ namespace RabbitMQ.Client.Impl
             method.WriteArgumentsTo(argWriter);
             argWriter.Flush();
 
-#if CORECLR15
-            var payload = ms.ToArray();
-            writer.Write((uint)payload.Length);
-            writer.Write(payload);
-#else
-            var buffer = ms.GetBuffer();
-            writer.Write((uint)ms.Position);
-            writer.Write(buffer, 0, (int)ms.Position);
-#endif
+            var bufferSegment = ms.GetBufferSegment();
+            writer.Write((uint)bufferSegment.Count);
+            writer.Write(bufferSegment.Array, bufferSegment.Offset, bufferSegment.Count);
         }
     }
 

--- a/projects/client/RabbitMQ.Client/src/client/impl/Frame.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Frame.cs
@@ -56,98 +56,115 @@ namespace RabbitMQ.Client.Impl
 {
     public class HeaderOutboundFrame : OutboundFrame
     {
+        private readonly ContentHeaderBase header;
+        private readonly int bodyLength;
+
         public HeaderOutboundFrame(int channel, ContentHeaderBase header, int bodyLength) : base(FrameType.FrameHeader, channel)
         {
-            NetworkBinaryWriter writer = base.GetWriter();
+            this.header = header;
+            this.bodyLength = bodyLength;
+        }
 
-            writer.Write(header.ProtocolClassId);
-            header.WriteTo(writer, (ulong)bodyLength);
+        public override void WritePayload(NetworkBinaryWriter writer)
+        {
+            var ms = new MemoryStream();
+            var nw = new NetworkBinaryWriter(ms);
+
+            nw.Write(header.ProtocolClassId);
+            header.WriteTo(nw, (ulong)bodyLength);
+
+#if CORECLR15
+            var payload = ms.ToArray();
+            writer.Write((uint)payload.Length);
+            writer.Write(payload);
+#else
+            var buffer = ms.GetBuffer();
+            writer.Write((uint)ms.Position);
+            writer.Write(buffer, 0, (int)ms.Position);
+#endif
         }
     }
 
     public class BodySegmentOutboundFrame : OutboundFrame
     {
+        private readonly byte[] body;
+        private readonly int offset;
+        private readonly int count;
+
         public BodySegmentOutboundFrame(int channel, byte[] body, int offset, int count) : base(FrameType.FrameBody, channel)
         {
-            NetworkBinaryWriter writer = base.GetWriter();
+            this.body = body;
+            this.offset = offset;
+            this.count = count;
+        }
 
+        public override void WritePayload(NetworkBinaryWriter writer)
+        {
+            writer.Write((uint)count);
             writer.Write(body, offset, count);
         }
     }
 
     public class MethodOutboundFrame : OutboundFrame
     {
+        private readonly MethodBase method;
+
         public MethodOutboundFrame(int channel, MethodBase method) : base(FrameType.FrameMethod, channel)
         {
-            NetworkBinaryWriter writer = base.GetWriter();
+            this.method = method;
+        }
 
-            writer.Write(method.ProtocolClassId);
-            writer.Write(method.ProtocolMethodId);
+        public override void WritePayload(NetworkBinaryWriter writer)
+        {
+            var ms = new MemoryStream();
+            var nw = new NetworkBinaryWriter(ms);
 
-            var argWriter = new MethodArgumentWriter(writer);
+            nw.Write(method.ProtocolClassId);
+            nw.Write(method.ProtocolMethodId);
 
+            var argWriter = new MethodArgumentWriter(nw);
             method.WriteArgumentsTo(argWriter);
-
             argWriter.Flush();
+
+#if CORECLR15
+            var payload = ms.ToArray();
+            writer.Write((uint)payload.Length);
+            writer.Write(payload);
+#else
+            var buffer = ms.GetBuffer();
+            writer.Write((uint)ms.Position);
+            writer.Write(buffer, 0, (int)ms.Position);
+#endif
         }
     }
 
     public class EmptyOutboundFrame : OutboundFrame
     {
-        private static readonly byte[] m_emptyByteArray = new byte[0];
-
         public EmptyOutboundFrame() : base(FrameType.FrameHeartbeat, 0)
         {
-            base.GetWriter().Write(m_emptyByteArray);
         }
 
-        public override string ToString()
+        public override void WritePayload(NetworkBinaryWriter writer)
         {
-            return base.ToString() + string.Format("(type={0}, channel={1}, {2} bytes of payload)",
-                Type,
-                Channel,
-                Payload == null
-                    ? "(null)"
-                    : Payload.Length.ToString());
+            writer.Write((uint)0);
         }
     }
 
-    public class OutboundFrame : Frame
+    public abstract class OutboundFrame : Frame
     {
-        private readonly MemoryStream m_accumulator;
-        private readonly NetworkBinaryWriter writer;
-
         public OutboundFrame(FrameType type, int channel) : base(type, channel)
         {
-            m_accumulator = new MemoryStream();
-            writer = new NetworkBinaryWriter(m_accumulator);
-        }
-
-        public NetworkBinaryWriter GetWriter()
-        {
-            return writer;
-        }
-
-        public override string ToString()
-        {
-            return base.ToString() + string.Format("(type={0}, channel={1}, {2} bytes of payload)",
-                Type,
-                Channel,
-                Payload == null
-                    ? "(null)"
-                    : Payload.Length.ToString());
         }
 
         public void WriteTo(NetworkBinaryWriter writer)
         {
-            var payload = m_accumulator.ToArray();
-
             writer.Write((byte)Type);
             writer.Write((ushort)Channel);
-            writer.Write((uint)payload.Length);
-            writer.Write(payload);
+            WritePayload(writer);
             writer.Write((byte)Constants.FrameEnd);
         }
+
+        public abstract void WritePayload(NetworkBinaryWriter writer);
     }
 
     public class InboundFrame : Frame
@@ -252,16 +269,6 @@ namespace RabbitMQ.Client.Impl
         {
             return new NetworkBinaryReader(new MemoryStream(base.Payload));
         }
-
-        public override string ToString()
-        {
-            return base.ToString() + string.Format("(type={0}, channel={1}, {2} bytes of payload)",
-                base.Type,
-                base.Channel,
-                base.Payload == null
-                    ? "(null)"
-                    : base.Payload.Length.ToString());
-        }
     }
 
     public class Frame
@@ -288,7 +295,7 @@ namespace RabbitMQ.Client.Impl
 
         public override string ToString()
         {
-            return base.ToString() + string.Format("(type={0}, channel={1}, {2} bytes of payload)",
+            return string.Format("(type={0}, channel={1}, {2} bytes of payload)",
                 Type,
                 Channel,
                 Payload == null

--- a/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
@@ -222,7 +222,7 @@ namespace RabbitMQ.Client.Impl
                 nbw.Write((byte)Endpoint.Protocol.MajorVersion);
                 nbw.Write((byte)Endpoint.Protocol.MinorVersion);
             }
-            Write(ms.ToArray());
+            Write(ms.GetBufferSegment());
         }
 
         public void WriteFrame(OutboundFrame frame)
@@ -231,7 +231,7 @@ namespace RabbitMQ.Client.Impl
             var nbw = new NetworkBinaryWriter(ms);
             frame.WriteTo(nbw);
             m_socket.Client.Poll(m_writeableStateTimeout, SelectMode.SelectWrite);
-            Write(ms.ToArray());
+            Write(ms.GetBufferSegment());
         }
 
         public void WriteFrameSet(IList<OutboundFrame> frames)
@@ -240,21 +240,21 @@ namespace RabbitMQ.Client.Impl
             var nbw = new NetworkBinaryWriter(ms);
             foreach (var f in frames) f.WriteTo(nbw);
             m_socket.Client.Poll(m_writeableStateTimeout, SelectMode.SelectWrite);
-            Write(ms.ToArray());
+            Write(ms.GetBufferSegment());
         }
 
-        private void Write(byte [] buffer)
+        private void Write(ArraySegment<byte> bufferSegment)
         {
             if(_ssl)
             {
                 lock (_sslStreamLock)
                 {
-                    m_writer.Write(buffer);
+                    m_writer.Write(bufferSegment.Array, bufferSegment.Offset, bufferSegment.Count);
                 }
             }
             else
             {
-                m_writer.Write(buffer);
+                m_writer.Write(bufferSegment.Array, bufferSegment.Offset, bufferSegment.Count);
             }
         }
 


### PR DESCRIPTION
## Proposed Changes

This PR continues work on allocations(see #442). 
Before PR:
1. `OutboundFrame` and its inheritants allocate  `MemoryStream`, `NetworkBinaryStream` in constructor and call `MemoryStream.ToArray` in `OutboundFrame.WriteTo`.
2. `SocketFrameHandler` allocates `MemoryStream` and calls `MemoryStream.ToArray` in`WriteFrameSet`, `WriteFrame` and `SendHeader`.
After PR:
1. `OutboundFrame` and its inheritants try not to allocate where possible and write directly to  `NetworkBinaryStream`. In other case instead of calling `MemoryStream.ToArray` they try to use internal buffer of  `MemoryStream` (but it is not possible in netstandart1.5, but possible in netstandart2.0).
2. `SocketFrameHandler` still allocates `MemoryStream`, but instead of calling `MemoryStream.ToArray` it tries to use internal buffer of  `MemoryStream` (but it is not possible in netstandart1.5, but possible in netstandart2.0)

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

`Producer.cs`
```
    public static class EntryPoint
    {
        public static void Main(string[] args)
        {
            var connectionFactory = new ConnectionFactory();
            using (var connection = connectionFactory.CreateConnection())
            {
                using (var model = connection.CreateModel())
                {
                    model.ExchangeDeclare("Exchange", "direct", true);
                    for (var i = 0; i < 10000; ++i)
                    {
                        model.BasicPublish("Exchange", "#", body: new byte[100000]);
                    }
                }
            }   

            Console.ReadKey();
        }
    }
```

Before PR:
![image](https://user-images.githubusercontent.com/664889/45154310-92534c00-b1f0-11e8-9005-37191c6de30c.png)
[Before.zip](https://github.com/rabbitmq/rabbitmq-dotnet-client/files/2356982/Before.zip) - dotMemory Workspace

After PR:
![image](https://user-images.githubusercontent.com/664889/45154327-a4cd8580-b1f0-11e8-8803-0c344ddce301.png)
[After.zip](https://github.com/rabbitmq/rabbitmq-dotnet-client/files/2356980/After.zip) - dotMemory Workspace

As I see now, the next step can be pooling of the `MemoryStream`(https://github.com/Microsoft/Microsoft.IO.RecyclableMemoryStream). What do you think about it @michaelklishin @kjnilsson?