### PR TITLE
Reduce Rpc Continuation Queue Locking

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/RpcContinuationQueue.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RpcContinuationQueue.cs
@@ -65,7 +65,7 @@ namespace RabbitMQ.Client.Impl
             }
         }
         static readonly EmptyRpcContinuation tmp = new EmptyRpcContinuation();
-        public IRpcContinuation m_outstandingRpc = tmp;
+        IRpcContinuation m_outstandingRpc = tmp;
 
         ///<summary>Enqueue a continuation, marking a pending RPC.</summary>
         ///<remarks>
@@ -97,7 +97,7 @@ namespace RabbitMQ.Client.Impl
         ///</remarks>
         public void HandleModelShutdown(ShutdownEventArgs reason)
         {
-            Next()?.HandleModelShutdown(reason);
+            Next().HandleModelShutdown(reason);
         }
 
         ///<summary>Retrieve the next waiting continuation.</summary>

--- a/projects/client/Unit/src/unit/TestRpcContinuationQueue.cs
+++ b/projects/client/Unit/src/unit/TestRpcContinuationQueue.cs
@@ -45,7 +45,8 @@ using System;
 namespace RabbitMQ.Client.Unit
 {
     [TestFixture]
-    public class TestRpcContinuationQueue {
+    public class TestRpcContinuationQueue
+    {
         [Test]
         public void TestRpcContinuationQueueEnqueueAndRelease()
         {
@@ -55,6 +56,7 @@ namespace RabbitMQ.Client.Unit
             var outputContinuation = queue.Next();
             Assert.AreEqual(outputContinuation, inputContinuation);
         }
+
         [Test]
         public void TestRpcContinuationQueueEnqueueAndRelease2()
         {
@@ -66,6 +68,7 @@ namespace RabbitMQ.Client.Unit
             var outputContinuation1 = queue.Next();
             Assert.AreNotEqual(outputContinuation1, inputContinuation);
         }
+
         [Test]
         public void TestRpcContinuationQueueEnqueue2()
         {
@@ -73,12 +76,11 @@ namespace RabbitMQ.Client.Unit
             var inputContinuation = new SimpleBlockingRpcContinuation();
             var inputContinuation1 = new SimpleBlockingRpcContinuation();
             queue.Enqueue(inputContinuation);
-            Assert.Throws(typeof(NotSupportedException), () => {
+            Assert.Throws(typeof(NotSupportedException), () => 
+            {
                 queue.Enqueue(inputContinuation1);
             });
         }
-
-
 
     }
 }

--- a/projects/client/Unit/src/unit/TestRpcContinuationQueue.cs
+++ b/projects/client/Unit/src/unit/TestRpcContinuationQueue.cs
@@ -1,0 +1,84 @@
+// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 1.1.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2016 Pivotal Software, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v1.1:
+//
+//---------------------------------------------------------------------------
+//  The contents of this file are subject to the Mozilla Public License
+//  Version 1.1 (the "License"); you may not use this file except in
+//  compliance with the License. You may obtain a copy of the License
+//  at http://www.mozilla.org/MPL/
+//
+//  Software distributed under the License is distributed on an "AS IS"
+//  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+//  the License for the specific language governing rights and
+//  limitations under the License.
+//
+//  The Original Code is RabbitMQ.
+//
+//  The Initial Developer of the Original Code is Pivotal Software, Inc.
+//  Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+//---------------------------------------------------------------------------
+
+using NUnit.Framework;
+using RabbitMQ.Client.Impl;
+using System;
+
+namespace RabbitMQ.Client.Unit
+{
+    [TestFixture]
+    public class TestRpcContinuationQueue {
+        [Test]
+        public void TestRpcContinuationQueueEnqueueAndRelease()
+        {
+            RpcContinuationQueue queue = new RpcContinuationQueue();
+            var inputContinuation = new SimpleBlockingRpcContinuation();
+            queue.Enqueue(inputContinuation);
+            var outputContinuation = queue.Next();
+            Assert.AreEqual(outputContinuation, inputContinuation);
+        }
+        [Test]
+        public void TestRpcContinuationQueueEnqueueAndRelease2()
+        {
+            RpcContinuationQueue queue = new RpcContinuationQueue();
+            var inputContinuation = new SimpleBlockingRpcContinuation();
+            queue.Enqueue(inputContinuation);
+            var outputContinuation = queue.Next();
+            Assert.AreEqual(outputContinuation, inputContinuation);
+            var outputContinuation1 = queue.Next();
+            Assert.AreNotEqual(outputContinuation1, inputContinuation);
+        }
+        [Test]
+        public void TestRpcContinuationQueueEnqueue2()
+        {
+            RpcContinuationQueue queue = new RpcContinuationQueue();
+            var inputContinuation = new SimpleBlockingRpcContinuation();
+            var inputContinuation1 = new SimpleBlockingRpcContinuation();
+            queue.Enqueue(inputContinuation);
+            Assert.Throws(typeof(NotSupportedException), () => {
+                queue.Enqueue(inputContinuation1);
+            });
+        }
+
+
+
+    }
+}


### PR DESCRIPTION
## Proposed Changes

- Updated RpcContinuationQueue.cs.
- Removed locking and replaced with an atomic operation.
- This reduces memory and mean time to execute.
- Also making the variable that is being locked private.
- Also removes the chance of a null exception in code, where the output of Next() is not checked.
- Added tests.
- Benchmark test code and outcome added to comments below.

## Types of Changes

What types of changes does your code introduce to this project?

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)
- [X] Performance Update  

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in related repositories

## Further Comments

```
BenchmarkDotNet=v0.10.14, OS=Windows 10.0.17134
Intel Core i5-6200U CPU 2.30GHz (Skylake), 1 CPU, 4 logical and 2 physical cores
Frequency=2343750 Hz, Resolution=426.6667 ns, Timer=TSC
  [Host]     : .NET Framework 4.6.1 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.3132.0  [AttachedDebugger]
  Job-JWVBYN : .NET Framework 4.6.1 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.3132.0
Runtime=Clr  IsBaseline=True  
Method     Mean        Error           StdDev       Scaled      Rank       Gen 0        Allocated
RpcNew    26.94 ns    0.3565 ns    0.3334 ns   1.00          1             0.0076      12 B
RpcOld      73.05 ns    2.7595 ns    3.1779 ns   1.00          1             0.0178      28 B
```

Bench mark code:
[bench.cs.txt](https://github.com/rabbitmq/rabbitmq-dotnet-client/files/2364570/bench.cs.txt)