### PR TITLE
Removed obsoleted TaskScheduler from IConnectionFactory.

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
@@ -254,13 +254,6 @@ namespace RabbitMQ.Client
         public bool TopologyRecoveryEnabled { get; set; } = true;
 
         /// <summary>
-        /// Task scheduler connections created by this factory will use when
-        /// dispatching consumer operations, such as message deliveries.
-        /// </summary>
-        [Obsolete("This scheduler is no longer used for dispatching consumer operations and will be removed in the next major version.", false)]
-        public TaskScheduler TaskScheduler { get; set; } = TaskScheduler.Default;
-
-        /// <summary>
         /// Construct a fresh instance, with all fields set to their respective defaults.
         /// </summary>
         public ConnectionFactory()

--- a/projects/client/RabbitMQ.Client/src/client/api/IConnectionFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IConnectionFactory.cs
@@ -175,14 +175,6 @@ namespace RabbitMQ.Client
         IConnection CreateConnection(IList<AmqpTcpEndpoint> endpoints, string clientProvidedName);
 
         /// <summary>
-        /// Advanced option.
-        ///
-        /// What task scheduler should consumer dispatcher use.
-        /// </summary>
-        [Obsolete("This scheduler is no longer used for dispatching consumer operations and will be removed in the next major version.", false)]
-        TaskScheduler TaskScheduler { get; set; }
-
-        /// <summary>
         /// Amount of time protocol handshake operations are allowed to take before
         /// timing out.
         /// </summary>


### PR DESCRIPTION
## Proposed Changes

Since

> This scheduler is no longer used for dispatching consumer operations and will be removed in the next major version.

Just remove it!

Fixes #463 

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments
