### PR TITLE
Remove deprecated IConnection.AutoClose

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/IConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IConnection.cs
@@ -67,17 +67,6 @@ namespace RabbitMQ.Client
     public interface IConnection : NetworkConnection, IDisposable
     {
         /// <summary>
-        /// If true, will close the whole connection as soon as there are no channels open on it;
-        /// if false, manual connection closure will be required.
-        /// </summary>
-        /// <remarks>
-        /// DON'T set AutoClose to true before opening the first
-        /// channel, because the connection will be immediately closed if you do!
-        /// </remarks>
-        [Obsolete("Please explicitly close connections instead.")]
-        bool AutoClose { get; set; }
-
-        /// <summary>
         /// The maximum channel number this connection supports (0 if unlimited).
         /// Usable channel numbers range from 1 to this number, inclusive.
         /// </summary>

--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
@@ -288,13 +288,6 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public string ClientProvidedName { get; private set; }
 
-        [Obsolete("Please explicitly close connections instead.")]
-        public bool AutoClose
-        {
-            get { return m_delegate.AutoClose; }
-            set { m_delegate.AutoClose = value; }
-        }
-
         public ushort ChannelMax
         {
             get { return m_delegate.ChannelMax; }

--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -273,13 +273,6 @@ namespace RabbitMQ.Client.Framing.Impl
         }
         public string ClientProvidedName { get; private set; }
 
-        [Obsolete("Please explicitly close connections instead.")]
-        public bool AutoClose
-        {
-            get { return m_sessionManager.AutoClose; }
-            set { m_sessionManager.AutoClose = value; }
-        }
-
         public ushort ChannelMax
         {
             get { return m_sessionManager.ChannelMax; }


### PR DESCRIPTION
## Proposed Changes

Remove deprecated property AutoClose from IConnection and its implementations.

Solves #471 

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments
