### PR TITLE
Remove deprecated IBasicProperties.SetPersistent

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/IBasicProperties.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IBasicProperties.cs
@@ -282,21 +282,5 @@ namespace RabbitMQ.Client
         /// Returns true if the <see cref="UserId"/> UserId property is present.
         /// </summary>
         bool IsUserIdPresent();
-
-        /// <summary>Sets <see cref="DeliveryMode"/> to either persistent (2) or non-persistent (1).</summary>
-        /// <remarks>
-        /// <para>
-        /// The numbers 1 and 2 for delivery mode are "magic" in that
-        /// they appear in the AMQP 0-8 and 0-9 specifications as part
-        /// of the definition of the DeliveryMode Basic-class property,
-        /// without being defined as named constants.
-        /// </para>
-        /// <para>
-        /// Calling this method causes <see cref="DeliveryMode"/> to take on a  value.
-        /// In order to reset <see cref="DeliveryMode"/> to the default empty condition, call <see cref="ClearDeliveryMode"/> .
-        /// </para>
-        /// </remarks>
-        [Obsolete("Usage of this setter method is deprecated. Use the Persistent property instead.")]
-        void SetPersistent(bool persistent);
     }
 }

--- a/projects/client/RabbitMQ.Client/src/client/impl/BasicProperties.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/BasicProperties.cs
@@ -275,25 +275,6 @@ namespace RabbitMQ.Client.Impl
         /// </summary>
         public abstract bool IsUserIdPresent();
 
-        /// <summary>Sets <see cref="DeliveryMode"/> to either persistent (2) or non-persistent (1).</summary>
-        /// <remarks>
-        /// <para>
-        /// The numbers 1 and 2 for delivery mode are "magic" in that
-        /// they appear in the AMQP 0-8 and 0-9 specifications as part
-        /// of the definition of the DeliveryMode Basic-class property,
-        /// without being defined as named constants.
-        /// </para>
-        /// <para>
-        /// Calling this method causes <see cref="DeliveryMode"/> to take on a  value.
-        /// In order to reset <see cref="DeliveryMode"/> to the default empty condition, call <see cref="ClearDeliveryMode"/> .
-        /// </para>
-        /// </remarks>
-        [Obsolete("Usage of this setter method is deprecated. Use the Persistent property instead.")]
-        public void SetPersistent(bool persistent)
-        {
-            Persistent = persistent;
-        }
-
         public override object Clone()
         {
             var clone = MemberwiseClone() as BasicProperties;

--- a/projects/client/Unit/src/unit/TestBasicProperties.cs
+++ b/projects/client/Unit/src/unit/TestBasicProperties.cs
@@ -73,37 +73,5 @@ namespace RabbitMQ.Client.Unit
             Assert.AreEqual(1, subject.DeliveryMode);
             Assert.AreEqual(false, subject.Persistent);
         }
-
-
-#pragma warning disable CS0618 // Type or member is obsolete
-        [Test]
-        public void TestSetPersistentMethodChangesDeliveryMode_PersistentTrueDelivery2()
-        {
-            // Arrange
-            var subject = new Framing.BasicProperties();
-
-            // Act
-            subject.SetPersistent(true);
-
-            // Assert
-            Assert.AreEqual(2, subject.DeliveryMode);
-            Assert.AreEqual(true, subject.Persistent);
-        }
-
-
-        [Test]
-        public void TestSetPersistentMethodChangesDeliveryMode_PersistentFalseDelivery1()
-        {
-            // Arrange
-            var subject = new Framing.BasicProperties();
-
-            // Act
-            subject.SetPersistent(false);
-
-            // Assert
-            Assert.AreEqual(1, subject.DeliveryMode);
-            Assert.AreEqual(false, subject.Persistent);
-        }
-#pragma warning restore CS0618 // Type or member is obsolete
     }
 }


### PR DESCRIPTION
## Proposed Changes

Remove deprecated `SetPersistent` method from `IBasicProperties` and its implementations.

Solves #473 

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments
