### PR TITLE
Removed implementation of IRecoverable from AutorecoveringConnection

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
@@ -50,7 +50,7 @@ using System.Threading.Tasks;
 
 namespace RabbitMQ.Client.Framing.Impl
 {
-    public class AutorecoveringConnection : IConnection, IRecoverable
+    public class AutorecoveringConnection : IConnection
     {
         private readonly object m_eventLock = new object();
 
@@ -263,25 +263,6 @@ namespace RabbitMQ.Client.Framing.Impl
                 lock (m_eventLock)
                 {
                     m_queueNameChange -= value;
-                }
-            }
-        }
-
-        [Obsolete("Use RecoverySucceeded instead")]
-        public event EventHandler<EventArgs> Recovery
-        {
-            add
-            {
-                lock (m_eventLock)
-                {
-                    m_recovery += value;
-                }
-            }
-            remove
-            {
-                lock (m_eventLock)
-                {
-                    m_recovery -= value;
                 }
             }
         }

--- a/projects/client/Unit/src/unit/TestConnectionRecovery.cs
+++ b/projects/client/Unit/src/unit/TestConnectionRecovery.cs
@@ -632,7 +632,7 @@ namespace RabbitMQ.Client.Unit
         public void TestRecoveryEventHandlersOnConnection()
         {
             Int32 counter = 0;
-            ((AutorecoveringConnection)Conn).Recovery += (source, ea) => Interlocked.Increment(ref counter);
+            ((AutorecoveringConnection)Conn).RecoverySucceeded += (source, ea) => Interlocked.Increment(ref counter);
 
             CloseAndWaitForRecovery();
             CloseAndWaitForRecovery();
@@ -698,7 +698,7 @@ namespace RabbitMQ.Client.Unit
 
             var latch = new ManualResetEvent(false);
             var connection = ((AutorecoveringConnection)Conn);
-            connection.Recovery += (source, ea) => latch.Set();
+            connection.RecoverySucceeded += (source, ea) => latch.Set();
             connection.QueueNameChangeAfterRecovery += (source, ea) => { nameAfter = ea.NameAfter; };
 
             CloseAndWaitForRecovery();
@@ -972,7 +972,7 @@ namespace RabbitMQ.Client.Unit
         protected ManualResetEvent PrepareForRecovery(AutorecoveringConnection conn)
         {
             var latch = new ManualResetEvent(false);
-            conn.Recovery += (source, ea) => latch.Set();
+            conn.RecoverySucceeded += (source, ea) => latch.Set();
 
             return latch;
         }


### PR DESCRIPTION
## Proposed Changes

Remove deprecated implementation of `IRecoverable` from `AutorecoveringConnection` due to it being marked obsolete.

Fixes #475 

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments
