### PR TITLE
Remove redundant allocations

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
@@ -238,7 +238,10 @@ namespace RabbitMQ.Client.Impl
         {
             var ms = new MemoryStream();
             var nbw = new NetworkBinaryWriter(ms);
-            foreach (var f in frames) f.WriteTo(nbw);
+            for (var i = 0; i < frames.Count; ++i)
+            {
+                frames[i].WriteTo(nbw);
+            }
             m_socket.Client.Poll(m_writeableStateTimeout, SelectMode.SelectWrite);
             Write(ms.GetBufferSegment());
         }

--- a/projects/client/RabbitMQ.Client/src/util/NetworkBinaryReader.cs
+++ b/projects/client/RabbitMQ.Client/src/util/NetworkBinaryReader.cs
@@ -38,7 +38,6 @@
 //  Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
-using System;
 using System.IO;
 using System.Text;
 
@@ -55,6 +54,8 @@ namespace RabbitMQ.Util
     /// </remarks>
     public class NetworkBinaryReader : BinaryReader
     {
+        private static readonly Encoding encoding = new UTF8Encoding();
+
         // Not particularly efficient. To be more efficient, we could
         // reuse BinaryReader's implementation details: m_buffer and
         // FillBuffer, if they weren't private
@@ -65,7 +66,7 @@ namespace RabbitMQ.Util
         /// <summary>
         /// Construct a NetworkBinaryReader over the given input stream.
         /// </summary>
-        public NetworkBinaryReader(Stream input) : base(input)
+        public NetworkBinaryReader(Stream input) : base(input, encoding)
         {
         }
 

--- a/projects/client/RabbitMQ.Client/src/util/NetworkBinaryWriter.cs
+++ b/projects/client/RabbitMQ.Client/src/util/NetworkBinaryWriter.cs
@@ -38,7 +38,6 @@
 //  Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
-using System;
 using System.IO;
 using System.Text;
 
@@ -57,10 +56,12 @@ namespace RabbitMQ.Util
     /// </remarks>
     public class NetworkBinaryWriter : BinaryWriter
     {
+        private static readonly Encoding encoding = new UTF8Encoding(false, true);
+
         /// <summary>
         /// Construct a NetworkBinaryWriter over the given input stream.
         /// </summary>
-        public NetworkBinaryWriter(Stream output) : base(output)
+        public NetworkBinaryWriter(Stream output) : base(output, encoding)
         {
         }
 


### PR DESCRIPTION
## Proposed Changes

This PR removes several unneccessary allocations:
1. Enumerator of `List`.
2. Encoding inside `BinaryReader` and `BinaryWriter`.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related reposi
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
tories

## Further Comments
`Producer.cs`
```
    public static class EntryPoint
    {
        public static void Main(string[] args)
        {
            var connectionFactory = new ConnectionFactory();
            using (var connection = connectionFactory.CreateConnection())
            {
                using (var model = connection.CreateModel())
                {
                    model.ExchangeDeclare("Exchange", "direct", true);
                    for (var i = 0; i < 10000; ++i)
                    {
                        model.BasicPublish("Exchange", "#", body: new byte[100000]);
                    }
                }
            }   

            Console.ReadKey();
        }
    }
```
![Before](https://user-images.githubusercontent.com/664889/45803488-2c2bf600-bcd3-11e8-8340-db6333a1e6f4.PNG)
[Before.zip](https://github.com/rabbitmq/rabbitmq-dotnet-client/files/2400230/Before.zip)

![After](https://user-images.githubusercontent.com/664889/45803510-38b04e80-bcd3-11e8-934f-a4b8ab591b6d.PNG)
[After.zip](https://github.com/rabbitmq/rabbitmq-dotnet-client/files/2400227/After.zip)

As you can see, after this change amount of allocated objects dropped by 1/4. Also it seems the next major improvement can be a replace of `NetworkBinaryReader` and `NetworkBinaryWriter`, which will not allocate so much trash 😜 