### PR TITLE
Make IAsyncConnectionFactory public

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/IAsyncConnectionFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IAsyncConnectionFactory.cs
@@ -1,7 +1,55 @@
+// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 1.1.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2016 Pivotal Software, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v1.1:
+//
+//---------------------------------------------------------------------------
+//  The contents of this file are subject to the Mozilla Public License
+//  Version 1.1 (the "License"); you may not use this file except in
+//  compliance with the License. You may obtain a copy of the License
+//  at http://www.mozilla.org/MPL/
+//
+//  Software distributed under the License is distributed on an "AS IS"
+//  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+//  the License for the specific language governing rights and
+//  limitations under the License.
+//
+//  The Original Code is RabbitMQ.
+//
+//  The Initial Developer of the Original Code is Pivotal Software, Inc.
+//  Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+//---------------------------------------------------------------------------
+
 namespace RabbitMQ.Client
 {
-    internal interface IAsyncConnectionFactory : IConnectionFactory
+    /// <summary>
+    /// Defines a connection factory capable of using an asynchronous consumer dispatcher which is compatible with <see cref="IAsyncBasicConsumer"/>.
+    /// </summary>
+    /// <seealso cref="IConnectionFactory" />
+    public interface IAsyncConnectionFactory : IConnectionFactory
     {
+        /// <summary>
+        /// Gets or sets a value indicating whether an asynchronous consumer dispatcher which is compatible with <see cref="IAsyncBasicConsumer"/> is used.
+        /// </summary>
+        /// <value><see langword="true" /> if an asynchronous consumer dispatcher which is compatible with <see cref="IAsyncBasicConsumer"/> is used; otherwise, <see langword="false" />.</value>
         bool DispatchConsumersAsync { get; set; }
     }
 }


### PR DESCRIPTION
## Proposed Changes

While the API for creating asynchronous connections is not the best approach, it is what we have and it's impossible to rely on interfaces only to create asynchronous connections.

This would be immediately solved if `IAsyncConnectionFactory` was public.

Fixes #482 

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

I don't think this would be a breaking change for the next minor version.