### PR TITLE
allow to publish array segments instead of full byte arrays

### DIFF
--- a/projects/client/Apigen/src/apigen/Apigen.cs
+++ b/projects/client/Apigen/src/apigen/Apigen.cs
@@ -1022,6 +1022,11 @@ namespace RabbitMQ.Client.Apigen
                 name = "System.Collections.Generic.IDictionary<string, object>";
             }
 
+            if (name.StartsWith("System.ArraySegment`1[[System.Byte"))
+            {
+                name = "System.ArraySegment<byte>";
+            }
+
             return name;
         }
 

--- a/projects/client/RabbitMQ.Client/src/client/api/IModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IModel.cs
@@ -228,6 +228,18 @@ namespace RabbitMQ.Client
             IBasicProperties basicProperties, byte[] body);
 
         /// <summary>
+        /// Publishes a message.
+        /// </summary>
+        /// <remarks>
+        ///   <para>
+        ///     Routing key must be shorter than 255 bytes.
+        ///   </para>
+        /// </remarks>
+        [AmqpMethodDoNotImplement(null)]
+        void BasicPublish(string exchange, string routingKey, bool mandatory,
+            IBasicProperties basicProperties, byte[] body, int offset, int count);
+
+        /// <summary>
         /// Configures QoS parameters of the Basic content-class.
         /// </summary>
         void BasicQos(uint prefetchSize, ushort prefetchCount, bool global);

--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
@@ -573,7 +573,7 @@ namespace RabbitMQ.Client.Impl
             string routingKey,
             bool mandatory,
             IBasicProperties basicProperties,
-            byte[] body)
+            ArraySegment<byte> body)
         {
             m_delegate._Private_BasicPublish(exchange, routingKey, mandatory,
                 basicProperties, body);
@@ -810,6 +810,23 @@ namespace RabbitMQ.Client.Impl
                 mandatory,
                 basicProperties,
                 body);
+        }
+
+        public void BasicPublish(string exchange,
+            string routingKey,
+            bool mandatory,
+            IBasicProperties basicProperties,
+            byte[] body,
+            int offset,
+            int count)
+        {
+            m_delegate.BasicPublish(exchange,
+                routingKey,
+                mandatory,
+                basicProperties,
+                body,
+                offset,
+                count);
         }
 
         public void BasicQos(uint prefetchSize,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ExtensionMethods.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ExtensionMethods.cs
@@ -47,6 +47,8 @@ namespace RabbitMQ.Client.Impl
 {
     public static class ExtensionMethods
     {
+        private static readonly ArraySegment<byte> m_emptyByteArray = new ArraySegment<byte>(new byte[0], 0, 0);
+
         /// <summary>
         /// Returns a random item from the list.
         /// </summary>
@@ -63,6 +65,26 @@ namespace RabbitMQ.Client.Impl
 
             var hashCode = Math.Abs(Guid.NewGuid().GetHashCode());
             return list.ElementAt<T>(hashCode % n);
+        }
+
+        internal static ArraySegment<byte> GetBufferSegment(this byte[] data)
+        {
+            if (data == null)
+            {
+                return m_emptyByteArray;
+            }
+
+            return new ArraySegment<byte>(data, 0, data.Length);
+        }
+
+        internal static ArraySegment<byte> GetBufferSegment(this byte[] data, int offset, int count)
+        {
+            if (data == null)
+            {
+                return m_emptyByteArray;
+            }
+
+            return new ArraySegment<byte>(data, offset, count);
         }
 
         internal static ArraySegment<byte> GetBufferSegment(this MemoryStream ms)

--- a/projects/client/RabbitMQ.Client/src/client/impl/IFullModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/IFullModel.cs
@@ -226,7 +226,7 @@ namespace RabbitMQ.Client.Impl
             string routingKey,
             bool mandatory,
             [AmqpContentHeaderMapping] IBasicProperties basicProperties,
-            [AmqpContentBodyMapping] byte[] body);
+            [AmqpContentBodyMapping] ArraySegment<byte> body);
 
         [AmqpForceOneWay]
         [AmqpMethodMapping(null, "basic", "recover")]


### PR DESCRIPTION
## Proposed Changes

IModel.BasicPublish currently accepts only a byte array, so the library user usually needs to copy the data to a new byte array which has the required length. It is a quite big overhead and also needs more garbage collection.

This PR adds a new BasicPublish method to the IModel interface which accepts an offset and count parameters (like .NET's Stream write, etc)

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
I can see some exceptions when I run run-test.bat, but they are not releated to my change. I've set RABBITMQ_RABBITMQCLT_PATH but still complains.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
