### PR TITLE
Adding option to enforce CRL checks for server certificates.

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/SslHelper.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/SslHelper.cs
@@ -74,7 +74,7 @@ namespace RabbitMQ.Client
 
             var sslStream = new SslStream(tcpStream, false, remoteCertValidator, localCertSelector);
 
-            sslStream.AuthenticateAsClientAsync(sslOption.ServerName, sslOption.Certs, sslOption.Version, false).GetAwaiter().GetResult();
+            sslStream.AuthenticateAsClientAsync(sslOption.ServerName, sslOption.Certs, sslOption.Version, sslOption.EnforceCertificateRevocationListValidation).GetAwaiter().GetResult();
 
             return sslStream;
         }

--- a/projects/client/RabbitMQ.Client/src/client/api/SslOption.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/SslOption.cs
@@ -38,7 +38,6 @@
 //  Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
-using System;
 
 #if !NETFX_CORE
 using System.Net.Security;
@@ -142,6 +141,12 @@ namespace RabbitMQ.Client
             }
             set { _certificateCollection = value; }
         }
+
+        /// <summary>
+        /// Attempts to enforce CRL validation for the certificate. Default is false. True if CRL should be validated, false otherwise.
+        /// </summary>
+        /// <remarks>Uses the built-in .NET mechanics for validation the certificates against the CRL.</remarks>
+        public bool EnforceCertificateRevocationListValidation { get; set; }
 #endif
 
         /// <summary>


### PR DESCRIPTION
Changed it so the consumers of the library can decided if they want CRL validation on the stream without having to write custom code to handle it in the validation callback.

Note if I am in wrong place: I am a 20+ year TFS guy, first github commit, so I could be checking in the entirely wrong place as the vernacular is confusing as hell.