### PR TITLE
Added routingKey fallback to string.Empty when null is passed as its …

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
@@ -575,8 +575,12 @@ namespace RabbitMQ.Client.Impl
             IBasicProperties basicProperties,
             byte[] body)
         {
-            m_delegate._Private_BasicPublish(exchange, routingKey, mandatory,
-                basicProperties, body);
+            m_delegate._Private_BasicPublish(
+                exchange,
+                routingKey ?? string.Empty,
+                mandatory,
+                basicProperties,
+                body);
         }
 
         public void _Private_BasicRecover(bool requeue)
@@ -805,8 +809,9 @@ namespace RabbitMQ.Client.Impl
             IBasicProperties basicProperties,
             byte[] body)
         {
-            m_delegate.BasicPublish(exchange,
-                routingKey,
+            m_delegate.BasicPublish(
+                exchange,
+                routingKey ?? string.Empty,
                 mandatory,
                 basicProperties,
                 body);

--- a/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
@@ -1295,8 +1295,9 @@ namespace RabbitMQ.Client.Impl
                     NextPublishSeqNo++;
                 }
             }
-            _Private_BasicPublish(exchange,
-                routingKey,
+            _Private_BasicPublish(
+                exchange,
+                routingKey ?? string.Empty,
                 mandatory,
                 basicProperties,
                 body);


### PR DESCRIPTION
…value for BasicPublish

## Proposed Changes

Since routing key is ignored by documentation for fanout exchange, passing Null as its value should be ok when calling BasicPublish.
But such case results in exception.
That's why this change is proposed.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
