### PR TITLE
Added explicit exception when Null is provided as a value for routing…

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
@@ -575,6 +575,11 @@ namespace RabbitMQ.Client.Impl
             IBasicProperties basicProperties,
             byte[] body)
         {
+            if (routingKey)
+            {
+                throw new ArgumentNullException("routingKey");
+            }
+
             m_delegate._Private_BasicPublish(exchange, routingKey, mandatory,
                 basicProperties, body);
         }
@@ -805,6 +810,11 @@ namespace RabbitMQ.Client.Impl
             IBasicProperties basicProperties,
             byte[] body)
         {
+            if (routingKey)
+            {
+                throw new ArgumentNullException("routingKey");
+            }
+
             m_delegate.BasicPublish(exchange,
                 routingKey,
                 mandatory,

--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
@@ -575,7 +575,7 @@ namespace RabbitMQ.Client.Impl
             IBasicProperties basicProperties,
             byte[] body)
         {
-            if (routingKey)
+            if (routingKey == null)
             {
                 throw new ArgumentNullException("routingKey");
             }
@@ -810,7 +810,7 @@ namespace RabbitMQ.Client.Impl
             IBasicProperties basicProperties,
             byte[] body)
         {
-            if (routingKey)
+            if (routingKey == null)
             {
                 throw new ArgumentNullException("routingKey");
             }

--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
@@ -577,7 +577,7 @@ namespace RabbitMQ.Client.Impl
         {
             if (routingKey == null)
             {
-                throw new ArgumentNullException("routingKey");
+                throw new ArgumentNullException(nameof(routingKey));
             }
 
             m_delegate._Private_BasicPublish(exchange, routingKey, mandatory,
@@ -812,7 +812,7 @@ namespace RabbitMQ.Client.Impl
         {
             if (routingKey == null)
             {
-                throw new ArgumentNullException("routingKey");
+                throw new ArgumentNullException(nameof(routingKey));
             }
 
             m_delegate.BasicPublish(exchange,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
@@ -1280,7 +1280,7 @@ namespace RabbitMQ.Client.Impl
             IBasicProperties basicProperties,
             byte[] body)
         {
-            if (routingKey)
+            if (routingKey == null)
             {
                 throw new ArgumentNullException("routingKey");
             }

--- a/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
@@ -1282,7 +1282,7 @@ namespace RabbitMQ.Client.Impl
         {
             if (routingKey == null)
             {
-                throw new ArgumentNullException("routingKey");
+                throw new ArgumentNullException(nameof(routingKey));
             }
 
             if (basicProperties == null)

--- a/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
@@ -1280,6 +1280,11 @@ namespace RabbitMQ.Client.Impl
             IBasicProperties basicProperties,
             byte[] body)
         {
+            if (routingKey)
+            {
+                throw new ArgumentNullException("routingKey");
+            }
+
             if (basicProperties == null)
             {
                 basicProperties = CreateBasicProperties();


### PR DESCRIPTION
…Key in BasicPublish

## Proposed Changes

When Null is provided as a value for routingKey in BasicPublish, some vague exception is thrown down the callstack.
Explicit ArgumentNullException is added to make things clear for such cases.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
