### PR TITLE
URL Cleanup

### DIFF
--- a/dist.sh
+++ b/dist.sh
@@ -61,7 +61,7 @@ fi
 ### Overrideable vars
 test "$KEYFILE" || KEYFILE=rabbit-mock.snk
 test "$RABBIT_VSN" || RABBIT_VSN=0.0.0.0
-test "$WEB_URL" || WEB_URL=http://stage.rabbitmq.com/
+test "$WEB_URL" || WEB_URL=https://stage.rabbitmq.com/
 test "$UNOFFICIAL_RELEASE" || UNOFFICIAL_RELEASE=
 test "$MONO_DIST" || MONO_DIST=
 test "$BUILD_WINRT" || BUILD_WINRT=false

--- a/tools/download-docs.sh
+++ b/tools/download-docs.sh
@@ -3,5 +3,5 @@
 OUTPUT_DIR=../releases/rabbitmq-dotnet-client/v1.6.0
 
 mkdir -p $OUTPUT_DIR
-(cd $OUTPUT_DIR; wget http://www.rabbitmq.com/releases/rabbitmq-dotnet-client/v1.6.0/rabbitmq-dotnet-client-1.6.0-user-guide.pdf)
-(cd $OUTPUT_DIR; wget http://www.rabbitmq.com/releases/rabbitmq-dotnet-client/v1.6.0/rabbitmq-dotnet-client-1.6.0-api-guide.pdf)
+(cd $OUTPUT_DIR; wget https://www.rabbitmq.com/releases/rabbitmq-dotnet-client/v1.6.0/rabbitmq-dotnet-client-1.6.0-user-guide.pdf)
+(cd $OUTPUT_DIR; wget https://www.rabbitmq.com/releases/rabbitmq-dotnet-client/v1.6.0/rabbitmq-dotnet-client-1.6.0-api-guide.pdf)


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://stage.rabbitmq.com/ (UnknownHostException) with 1 occurrences migrated to:  
  https://stage.rabbitmq.com/ ([https](https://stage.rabbitmq.com/) result UnknownHostException).
* http://www.rabbitmq.com/releases/rabbitmq-dotnet-client/v1.6.0/rabbitmq-dotnet-client-1.6.0-api-guide.pdf (404) with 1 occurrences migrated to:  
  https://www.rabbitmq.com/releases/rabbitmq-dotnet-client/v1.6.0/rabbitmq-dotnet-client-1.6.0-api-guide.pdf ([https](https://www.rabbitmq.com/releases/rabbitmq-dotnet-client/v1.6.0/rabbitmq-dotnet-client-1.6.0-api-guide.pdf) result 404).
* http://www.rabbitmq.com/releases/rabbitmq-dotnet-client/v1.6.0/rabbitmq-dotnet-client-1.6.0-user-guide.pdf (404) with 1 occurrences migrated to:  
  https://www.rabbitmq.com/releases/rabbitmq-dotnet-client/v1.6.0/rabbitmq-dotnet-client-1.6.0-user-guide.pdf ([https](https://www.rabbitmq.com/releases/rabbitmq-dotnet-client/v1.6.0/rabbitmq-dotnet-client-1.6.0-user-guide.pdf) result 404).