### PR TITLE
Byte conversion support

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/WireFormatting.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/WireFormatting.cs
@@ -138,6 +138,9 @@ namespace RabbitMQ.Client.Impl
                 case 'A':
                     value = ReadArray(reader);
                     break;
+                case 'B':
+                    value = reader.ReadByte();
+                    break;
                 case 'b':
                     value = reader.ReadSByte();
                     break;
@@ -310,7 +313,7 @@ namespace RabbitMQ.Client.Impl
                     WriteArray(writer, val);
                     break;
                 case byte val:
-                    WriteOctet(writer, (byte)'b');
+                    WriteOctet(writer, (byte)'B');
                     writer.Write(val);
                     break;
                 case sbyte val:

--- a/projects/client/Unit/src/unit/TestFieldTableFormatting.cs
+++ b/projects/client/Unit/src/unit/TestFieldTableFormatting.cs
@@ -117,17 +117,19 @@ namespace RabbitMQ.Client.Unit
         {
             NetworkBinaryWriter w = Writer();
             Hashtable t = new Hashtable();
+            t["B"] = (byte)255;
             t["b"] = (sbyte)-128;
             t["d"] = (double)123;
             t["f"] = (float)123;
             t["l"] = (long)123;
             t["s"] = (short)123;
             t["t"] = true;
-            byte[] xbytes = new byte[] { 0xaa, 0x55 };
+            byte[] xbytes = { 0xaa, 0x55 };
             t["x"] = new BinaryTableValue(xbytes);
             t["V"] = null;
             WireFormatting.WriteTable(w, t);
             IDictionary nt = (IDictionary)WireFormatting.ReadTable(Reader(Contents(w)));
+            Assert.AreEqual(typeof(byte), nt["B"].GetType()); Assert.AreEqual((byte)255, nt["B"]);
             Assert.AreEqual(typeof(sbyte), nt["b"].GetType()); Assert.AreEqual((sbyte)-128, nt["b"]);
             Assert.AreEqual(typeof(double), nt["d"].GetType()); Assert.AreEqual((double)123, nt["d"]);
             Assert.AreEqual(typeof(float), nt["f"].GetType()); Assert.AreEqual((float)123, nt["f"]);

--- a/projects/client/Unit/src/unit/TestFieldTableFormattingGeneric.cs
+++ b/projects/client/Unit/src/unit/TestFieldTableFormattingGeneric.cs
@@ -119,6 +119,7 @@ namespace RabbitMQ.Client.Unit
         {
             NetworkBinaryWriter w = Writer();
             IDictionary<string, object> t = new Dictionary<string, object>();
+            t["B"] = (byte)255;
             t["b"] = (sbyte)-128;
             t["d"] = (double)123;
             t["f"] = (float)123;
@@ -130,6 +131,7 @@ namespace RabbitMQ.Client.Unit
             t["V"] = null;
             WireFormatting.WriteTable(w, t);
             IDictionary nt = (IDictionary)WireFormatting.ReadTable(Reader(Contents(w)));
+            Assert.AreEqual(typeof(byte), nt["B"].GetType()); Assert.AreEqual((byte)255, nt["B"]);
             Assert.AreEqual(typeof(sbyte), nt["b"].GetType()); Assert.AreEqual((sbyte)-128, nt["b"]);
             Assert.AreEqual(typeof(double), nt["d"].GetType()); Assert.AreEqual((double)123, nt["d"]);
             Assert.AreEqual(typeof(float), nt["f"].GetType()); Assert.AreEqual((float)123, nt["f"]);


### PR DESCRIPTION
## Proposed Changes

I tried to add byte conversion support for arguments. but this not a final version. Solutions are:
1. Add new byte case and write as byte
2. Add new byte case and write as int/short
3. Do nothing because has int-workaround

Motivation:
RabbitMQ has `x-max-priority` for queues, `x-priority` for consumers and priority in `IBasicProperties` for producers, but for them is ok. Commonly i used them to balance messages.
Priorities is in 1...255 range and perfectly suites to byte, but when i tried wrap arguments with byte extensions i got a `WireFormattingException`(`Value cannot appear as table value`) and nothing more. Boxing int for priority works fine.

Usage: https://gist.github.com/sergeyshaykhullin/bca8964c0ebbd5a8737a559bcb0287e3

If English isn't your first language, don't worry about it and try to
communicate the problem you are trying to solve to the best of your abilities.
As long as we can understand the intent, it's all good.

## Types of Changes
- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [x] (Possible) Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments
There are possible breaking changes, f.e. new version writes 'B', but old version doesnt know about it and throws `SyntaxError`

Docs https://www.rabbitmq.com/priority.html has
For 'x-max-priority' - `This argument should be a positive integer between 1 and 255`
For `x-priority` - `The message priority field is defined as an unsigned byte, so in practice priorities should be between 0 and 255.`
IBasicProperties has `byte` priority
So maybe it can help someone in future
