### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE-APACHE2
+++ b/LICENSE-APACHE2
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Apigen/properties/AssemblyInfo.cs
+++ b/projects/client/Apigen/properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Apigen/src/apigen/AmqpClass.cs
+++ b/projects/client/Apigen/src/apigen/AmqpClass.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Apigen/src/apigen/AmqpEntity.cs
+++ b/projects/client/Apigen/src/apigen/AmqpEntity.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Apigen/src/apigen/AmqpField.cs
+++ b/projects/client/Apigen/src/apigen/AmqpField.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Apigen/src/apigen/AmqpMethod.cs
+++ b/projects/client/Apigen/src/apigen/AmqpMethod.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Apigen/src/apigen/Apigen.cs
+++ b/projects/client/Apigen/src/apigen/Apigen.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -407,7 +407,7 @@ namespace RabbitMQ.Client.Apigen
             EmitLine("//   you may not use this file except in compliance with the License.");
             EmitLine("//   You may obtain a copy of the License at");
             EmitLine("//");
-            EmitLine("//       http://www.apache.org/licenses/LICENSE-2.0");
+            EmitLine("//       https://www.apache.org/licenses/LICENSE-2.0");
             EmitLine("//");
             EmitLine("//   Unless required by applicable law or agreed to in writing, software");
             EmitLine("//   distributed under the License is distributed on an \"AS IS\" BASIS,");

--- a/projects/client/ApigenBootstrap/properties/AssemblyInfo.cs
+++ b/projects/client/ApigenBootstrap/properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client.WinRT/src/client/impl/SocketFrameHandlerWinRT.cs
+++ b/projects/client/RabbitMQ.Client.WinRT/src/client/impl/SocketFrameHandlerWinRT.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client.WinRT/src/tokenized/AssemblyInfo.cs.in
+++ b/projects/client/RabbitMQ.Client.WinRT/src/tokenized/AssemblyInfo.cs.in
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client.WinRT/src/util/ICloneable.cs
+++ b/projects/client/RabbitMQ.Client.WinRT/src/util/ICloneable.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client.WinRT/src/util/MetroEventSource.cs
+++ b/projects/client/RabbitMQ.Client.WinRT/src/util/MetroEventSource.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client.WinRT/src/util/SerializableAttribute.cs
+++ b/projects/client/RabbitMQ.Client.WinRT/src/util/SerializableAttribute.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client.WinRT/src/util/Timer.cs
+++ b/projects/client/RabbitMQ.Client.WinRT/src/util/Timer.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/AmqpTcpEndpoint.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/AmqpTcpEndpoint.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/AmqpTimestamp.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/AmqpTimestamp.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/AmqpVersion.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/AmqpVersion.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/AuthMechanism.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/AuthMechanism.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/AuthMechanismFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/AuthMechanismFactory.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/BasicGetResult.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/BasicGetResult.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/BinaryTableValue.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/BinaryTableValue.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactoryBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactoryBase.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/DefaultBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/DefaultBasicConsumer.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/DefaultEndpointResolver.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/DefaultEndpointResolver.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/ExchangeType.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ExchangeType.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/ExternalMechanism.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ExternalMechanism.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/ExternalMechanismFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ExternalMechanismFactory.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/Headers.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/Headers.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IBasicConsumer.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IBasicProperties.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IBasicProperties.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IConnection.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IConnectionFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IConnectionFactory.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IContentHeader.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IContentHeader.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IEndpointResolver.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IEndpointResolver.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IEndpointResolverExtensions.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IEndpointResolverExtensions.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IMethod.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IMethod.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IModel.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IModelExtensions.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IModelExtensions.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IProtocol.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IProtocol.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IQueueingBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IQueueingBasicConsumer.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IRecoverable.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IRecoverable.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IStreamProperties.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IStreamProperties.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/NetworkConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/NetworkConnection.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/PlainMechanism.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/PlainMechanism.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/PlainMechanismFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/PlainMechanismFactory.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/Protocols.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/Protocols.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/PublicationAddress.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/PublicationAddress.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/QueueDeclareOk.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/QueueDeclareOk.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/QueueingBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/QueueingBasicConsumer.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/ShutdownEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ShutdownEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/ShutdownInitiator.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ShutdownInitiator.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/ShutdownReportEntry.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ShutdownReportEntry.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/SslHelper.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/SslHelper.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/SslOption.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/SslOption.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/TopologyRecoveryException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/TopologyRecoveryException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/BasicMessageBuilder.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/BasicMessageBuilder.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/BasicMessageReader.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/BasicMessageReader.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/BytesMessageBuilder.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/BytesMessageBuilder.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/BytesMessageReader.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/BytesMessageReader.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/BytesWireFormatting.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/BytesWireFormatting.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/IBytesMessageBuilder.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/IBytesMessageBuilder.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/IBytesMessageReader.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/IBytesMessageReader.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/IMapMessageBuilder.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/IMapMessageBuilder.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/IMapMessageReader.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/IMapMessageReader.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/IMessageBuilder.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/IMessageBuilder.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/IMessageReader.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/IMessageReader.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/IStreamMessageBuilder.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/IStreamMessageBuilder.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/IStreamMessageReader.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/IStreamMessageReader.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/MapMessageBuilder.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/MapMessageBuilder.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/MapMessageReader.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/MapMessageReader.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/MapWireFormatting.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/MapWireFormatting.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/PrimitiveParser.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/PrimitiveParser.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/StreamMessageBuilder.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/StreamMessageBuilder.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/StreamMessageReader.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/StreamMessageReader.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/StreamWireFormatting.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/StreamWireFormatting.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/BasicAckEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/BasicAckEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/BasicDeliverEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/BasicDeliverEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/BasicNackEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/BasicNackEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/BasicReturnEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/BasicReturnEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/CallbackExceptionEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/CallbackExceptionEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/ConnectionBlockedEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/ConnectionBlockedEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/ConnectionRecoveryErrorEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/ConnectionRecoveryErrorEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/ConsumerEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/ConsumerEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/ConsumerTagChangedAfterRecoveryEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/ConsumerTagChangedAfterRecoveryEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/EventingBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/EventingBasicConsumer.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/FlowControlEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/FlowControlEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/QueueNameChangedAfterRecoveryEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/QueueNameChangedAfterRecoveryEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/RecoveryExceptionEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/RecoveryExceptionEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/AlreadyClosedException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/AlreadyClosedException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/AuthenticationFailureException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/AuthenticationFailureException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/BrokerUnreachableException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/BrokerUnreachableException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/ChannelAllocationException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/ChannelAllocationException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/ConnectFailureException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/ConnectFailureException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/OperationInterruptedException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/OperationInterruptedException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/PacketNotRecognizedException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/PacketNotRecognizedException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/PossibleAuthenticationFailureException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/PossibleAuthenticationFailureException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/ProtocolVersionMismatchException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/ProtocolVersionMismatchException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/ProtocolViolationException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/ProtocolViolationException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/UnexpectedMethodException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/UnexpectedMethodException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/UnsupportedMethodException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/UnsupportedMethodException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/UnsupportedMethodFieldException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/UnsupportedMethodFieldException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/WireFormattingException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/WireFormattingException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/BasicProperties.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/BasicProperties.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ChannelErrorException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ChannelErrorException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/Command.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Command.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/CommandAssembler.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/CommandAssembler.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ConnectionStartDetails.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ConnectionStartDetails.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ContentHeaderBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ContentHeaderBase.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ContentHeaderPropertyReader.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ContentHeaderPropertyReader.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ContentHeaderPropertyWriter.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ContentHeaderPropertyWriter.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ExtensionMethods.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ExtensionMethods.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/Frame.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Frame.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/HardProtocolException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/HardProtocolException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/IConsumerDispatcher.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/IConsumerDispatcher.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/IFrameHandler.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/IFrameHandler.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/IFullModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/IFullModel.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/IProtocolExtensions.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/IProtocolExtensions.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/IRpcContinuation.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/IRpcContinuation.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ISession.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ISession.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/MainSession.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/MainSession.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/MalformedFrameException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/MalformedFrameException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/MethodArgumentReader.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/MethodArgumentReader.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/MethodArgumentWriter.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/MethodArgumentWriter.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/MethodBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/MethodBase.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ProtocolBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ProtocolBase.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ProtocolException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ProtocolException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/QuiescingSession.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/QuiescingSession.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/RecordedBinding.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RecordedBinding.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/RecordedConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RecordedConsumer.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/RecordedEntity.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RecordedEntity.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/RecordedExchange.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RecordedExchange.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/RecordedNamedEntity.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RecordedNamedEntity.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/RecordedQueue.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RecordedQueue.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/RecoveryAwareModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RecoveryAwareModel.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/RpcContinuationQueue.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RpcContinuationQueue.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/Session.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Session.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/SessionBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SessionBase.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/SessionManager.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SessionManager.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ShutdownContinuation.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ShutdownContinuation.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/SimpleBlockingRpcContinuation.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SimpleBlockingRpcContinuation.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/SoftProtocolException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SoftProtocolException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/StreamProperties.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/StreamProperties.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/SyntaxError.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SyntaxError.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/UnexpectedFrameException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/UnexpectedFrameException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/UnknownClassOrMethodException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/UnknownClassOrMethodException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/WireFormatting.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/WireFormatting.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/messagepatterns/ISubscription.cs
+++ b/projects/client/RabbitMQ.Client/src/client/messagepatterns/ISubscription.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/messagepatterns/SimpleRpcClient.cs
+++ b/projects/client/RabbitMQ.Client/src/client/messagepatterns/SimpleRpcClient.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/messagepatterns/SimpleRpcServer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/messagepatterns/SimpleRpcServer.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/messagepatterns/Subscription.cs
+++ b/projects/client/RabbitMQ.Client/src/client/messagepatterns/Subscription.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/properties/AssemblyInfo.cs
+++ b/projects/client/RabbitMQ.Client/src/client/properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/logging/ESLog.cs
+++ b/projects/client/RabbitMQ.Client/src/logging/ESLog.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/logging/RabbitMqClientEventSource.cs
+++ b/projects/client/RabbitMQ.Client/src/logging/RabbitMqClientEventSource.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/logging/RabbitMqConsoleEventListener.cs
+++ b/projects/client/RabbitMQ.Client/src/logging/RabbitMqConsoleEventListener.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/logging/RabbitMqExceptionDetail.cs
+++ b/projects/client/RabbitMQ.Client/src/logging/RabbitMqExceptionDetail.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/tokenized/AssemblyInfo.cs.in
+++ b/projects/client/RabbitMQ.Client/src/tokenized/AssemblyInfo.cs.in
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/util/BlockingCell.cs
+++ b/projects/client/RabbitMQ.Client/src/util/BlockingCell.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/util/DebugUtil.cs
+++ b/projects/client/RabbitMQ.Client/src/util/DebugUtil.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/util/Either.cs
+++ b/projects/client/RabbitMQ.Client/src/util/Either.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/util/IntAllocator.cs
+++ b/projects/client/RabbitMQ.Client/src/util/IntAllocator.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/util/NetworkBinaryReader.cs
+++ b/projects/client/RabbitMQ.Client/src/util/NetworkBinaryReader.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/util/NetworkBinaryWriter.cs
+++ b/projects/client/RabbitMQ.Client/src/util/NetworkBinaryWriter.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/util/SetQueue.cs
+++ b/projects/client/RabbitMQ.Client/src/util/SetQueue.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/util/SharedQueue.cs
+++ b/projects/client/RabbitMQ.Client/src/util/SharedQueue.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/util/SynchronizedList.cs
+++ b/projects/client/RabbitMQ.Client/src/util/SynchronizedList.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit.WinRT/properties/AssemblyInfo.cs
+++ b/projects/client/Unit.WinRT/properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/properties/AssemblyInfo.cs
+++ b/projects/client/Unit/properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/Fixtures.cs
+++ b/projects/client/Unit/src/unit/Fixtures.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestAmqpTcpEndpointParsing.cs
+++ b/projects/client/Unit/src/unit/TestAmqpTcpEndpointParsing.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestAmqpUri.cs
+++ b/projects/client/Unit/src/unit/TestAmqpUri.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestAsyncConsumer.cs
+++ b/projects/client/Unit/src/unit/TestAsyncConsumer.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestAuth.cs
+++ b/projects/client/Unit/src/unit/TestAuth.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestBasicGet.cs
+++ b/projects/client/Unit/src/unit/TestBasicGet.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestBasicProperties.cs
+++ b/projects/client/Unit/src/unit/TestBasicProperties.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestBlockingCell.cs
+++ b/projects/client/Unit/src/unit/TestBlockingCell.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestBytesWireFormatting.cs
+++ b/projects/client/Unit/src/unit/TestBytesWireFormatting.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestChannelAllocation.cs
+++ b/projects/client/Unit/src/unit/TestChannelAllocation.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestConcurrentAccessWithSharedConnection.cs
+++ b/projects/client/Unit/src/unit/TestConcurrentAccessWithSharedConnection.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestConfirmSelect.cs
+++ b/projects/client/Unit/src/unit/TestConfirmSelect.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestConnectionBlocked.cs
+++ b/projects/client/Unit/src/unit/TestConnectionBlocked.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestConnectionFactory.cs
+++ b/projects/client/Unit/src/unit/TestConnectionFactory.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestConnectionRecovery.cs
+++ b/projects/client/Unit/src/unit/TestConnectionRecovery.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestConnectionShutdown.cs
+++ b/projects/client/Unit/src/unit/TestConnectionShutdown.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestConnectionWithBackgroundThreads.cs
+++ b/projects/client/Unit/src/unit/TestConnectionWithBackgroundThreads.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestConsumerCancelNotify.cs
+++ b/projects/client/Unit/src/unit/TestConsumerCancelNotify.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestConsumerCount.cs
+++ b/projects/client/Unit/src/unit/TestConsumerCount.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestConsumerExceptions.cs
+++ b/projects/client/Unit/src/unit/TestConsumerExceptions.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestConsumerOperationDispatch.cs
+++ b/projects/client/Unit/src/unit/TestConsumerOperationDispatch.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestContentHeaderCodec.cs
+++ b/projects/client/Unit/src/unit/TestContentHeaderCodec.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestEventingConsumer.cs
+++ b/projects/client/Unit/src/unit/TestEventingConsumer.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestExceptionMessages.cs
+++ b/projects/client/Unit/src/unit/TestExceptionMessages.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestExchangeDeclare.cs
+++ b/projects/client/Unit/src/unit/TestExchangeDeclare.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestExtensions.cs
+++ b/projects/client/Unit/src/unit/TestExtensions.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestFieldTableFormatting.cs
+++ b/projects/client/Unit/src/unit/TestFieldTableFormatting.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestFieldTableFormattingGeneric.cs
+++ b/projects/client/Unit/src/unit/TestFieldTableFormattingGeneric.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestFloodPublishing.cs
+++ b/projects/client/Unit/src/unit/TestFloodPublishing.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestHeartbeats.cs
+++ b/projects/client/Unit/src/unit/TestHeartbeats.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestIEndpointResolverExtensions.cs
+++ b/projects/client/Unit/src/unit/TestIEndpointResolverExtensions.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestInitialConnection.cs
+++ b/projects/client/Unit/src/unit/TestInitialConnection.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestIntAllocator.cs
+++ b/projects/client/Unit/src/unit/TestIntAllocator.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestInvalidAck.cs
+++ b/projects/client/Unit/src/unit/TestInvalidAck.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestMainLoop.cs
+++ b/projects/client/Unit/src/unit/TestMainLoop.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestMapMessage.cs
+++ b/projects/client/Unit/src/unit/TestMapMessage.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestMessageCount.cs
+++ b/projects/client/Unit/src/unit/TestMessageCount.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestMessagePatternsSubscription.cs
+++ b/projects/client/Unit/src/unit/TestMessagePatternsSubscription.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestMethodArgumentCodec.cs
+++ b/projects/client/Unit/src/unit/TestMethodArgumentCodec.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestModelShutdown.cs
+++ b/projects/client/Unit/src/unit/TestModelShutdown.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestNetworkBinaryCodec.cs
+++ b/projects/client/Unit/src/unit/TestNetworkBinaryCodec.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestNowait.cs
+++ b/projects/client/Unit/src/unit/TestNowait.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestPassiveDeclare.cs
+++ b/projects/client/Unit/src/unit/TestPassiveDeclare.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestPropertiesClone.cs
+++ b/projects/client/Unit/src/unit/TestPropertiesClone.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestPublicationAddress.cs
+++ b/projects/client/Unit/src/unit/TestPublicationAddress.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestPublisherConfirms.cs
+++ b/projects/client/Unit/src/unit/TestPublisherConfirms.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestQueueDeclare.cs
+++ b/projects/client/Unit/src/unit/TestQueueDeclare.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestRecoverAfterCancel.cs
+++ b/projects/client/Unit/src/unit/TestRecoverAfterCancel.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestSharedQueue.cs
+++ b/projects/client/Unit/src/unit/TestSharedQueue.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestSsl.cs
+++ b/projects/client/Unit/src/unit/TestSsl.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestStreamWireFormatting.cs
+++ b/projects/client/Unit/src/unit/TestStreamWireFormatting.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestSubscription.cs
+++ b/projects/client/Unit/src/unit/TestSubscription.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestTcpClientAdapter.cs
+++ b/projects/client/Unit/src/unit/TestTcpClientAdapter.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/WireFormattingFixture.cs
+++ b/projects/client/Unit/src/unit/WireFormattingFixture.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 228 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).