### PR TITLE
Fix shutdown event args format

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/ShutdownEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ShutdownEventArgs.cs
@@ -108,12 +108,12 @@ namespace RabbitMQ.Client
         /// </summary>
         public override string ToString()
         { 
-            return $"AMQP close-reason, initiated by {Initiator}, " 
-                + $"code={ReplyCode}, "
-                + (ReplyText != null ? $"text='{ReplyText}', " : string.Empty)
-                + $"classId={ClassId}, "
-                + $"methodId={MethodId}, "
-                + (Cause != null ? $"cause={Cause}" : string.Empty);
+            return $"AMQP close-reason, initiated by {Initiator}" 
+                + $", code={ReplyCode}, "
+                + (ReplyText != null ? $", text='{ReplyText}'" : string.Empty)
+                + $", classId={ClassId}"
+                + $", methodId={MethodId}"
+                + (Cause != null ? $", cause={Cause}" : string.Empty);
         }
     }
 }

--- a/projects/client/RabbitMQ.Client/src/client/api/ShutdownEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ShutdownEventArgs.cs
@@ -109,7 +109,7 @@ namespace RabbitMQ.Client
         public override string ToString()
         { 
             return $"AMQP close-reason, initiated by {Initiator}" 
-                + $", code={ReplyCode}, "
+                + $", code={ReplyCode}"
                 + (ReplyText != null ? $", text='{ReplyText}'" : string.Empty)
                 + $", classId={ClassId}"
                 + $", methodId={MethodId}"

--- a/projects/client/RabbitMQ.Client/src/client/api/ShutdownEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ShutdownEventArgs.cs
@@ -107,13 +107,13 @@ namespace RabbitMQ.Client
         /// Override ToString to be useful for debugging.
         /// </summary>
         public override string ToString()
-        {
-            return "AMQP close-reason, initiated by " + Initiator +
-                   ", code=" + ReplyCode +
-                   ", text=\"" + ReplyText + "\"" +
-                   ", classId=" + ClassId +
-                   ", methodId=" + MethodId +
-                   ", cause=" + Cause;
+        { 
+            return $"AMQP close-reason, initiated by {Initiator}, " 
+                + $"code={ReplyCode}, "
+                + (ReplyText != null ? $"text='{ReplyText}', " : string.Empty)
+                + $"classId={ClassId}, "
+                + $"methodId={MethodId}, "
+                + (Cause != null ? $"cause={Cause}" : string.Empty);
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes
Do not show `... cause=` if  `Cause` is null, same for `ReplyText`(it can be null?? or can't), because it does not helps.

## Types of Changes
- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [x] Cosmetics (whitespace, appearance)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Example before:
`The AMQP operation was interrupted: AMQP close-reason, initiated by Peer, code=404, text="NOT_FOUND - no queue 'some-queue' in vhost '/'", classId=60, methodId=20, cause=`

Example after:
`The AMQP operation was interrupted: AMQP close-reason, initiated by Peer, code=404, text="NOT_FOUND - no queue 'some-queue' in vhost '/'", classId=60, methodId=20`
