### PR TITLE
Add unsigned 32 bit integer support

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/WireFormatting.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/WireFormatting.cs
@@ -126,6 +126,9 @@ namespace RabbitMQ.Client.Impl
                 case 'I':
                     value = reader.ReadInt32();
                     break;
+                case 'i':
+                    value = reader.ReadUInt32();
+                    break;
                 case 'D':
                     value = ReadDecimal(reader);
                     break;
@@ -294,6 +297,10 @@ namespace RabbitMQ.Client.Impl
                     break;
                 case int val:
                     WriteOctet(writer, (byte)'I');
+                    writer.Write(val);
+                    break;
+                case uint val:
+                    WriteOctet(writer, (byte)'i');
                     writer.Write(val);
                     break;
                 case decimal val:

--- a/projects/client/Unit/src/unit/TestFieldTableFormatting.cs
+++ b/projects/client/Unit/src/unit/TestFieldTableFormatting.cs
@@ -60,6 +60,7 @@ namespace RabbitMQ.Client.Unit
             Hashtable t = new Hashtable();
             t["string"] = "Hello";
             t["int"] = 1234;
+            t["uint"] = 1234u;
             t["decimal"] = 12.34m;
             t["timestamp"] = new AmqpTimestamp(0);
             Hashtable t2 = new Hashtable();
@@ -73,6 +74,7 @@ namespace RabbitMQ.Client.Unit
             IDictionary nt = (IDictionary)WireFormatting.ReadTable(Reader(Contents(w)));
             Assert.AreEqual(Encoding.UTF8.GetBytes("Hello"), nt["string"]);
             Assert.AreEqual(1234, nt["int"]);
+            Assert.AreEqual(1234u, nt["uint"]);
             Assert.AreEqual(12.34m, nt["decimal"]);
             Assert.AreEqual(0, ((AmqpTimestamp)nt["timestamp"]).UnixTime);
             IDictionary nt2 = (IDictionary)nt["fieldtable"];

--- a/projects/client/Unit/src/unit/TestFieldTableFormattingGeneric.cs
+++ b/projects/client/Unit/src/unit/TestFieldTableFormattingGeneric.cs
@@ -62,6 +62,7 @@ namespace RabbitMQ.Client.Unit
             IDictionary<string, object> t = new Dictionary<string, object>();
             t["string"] = "Hello";
             t["int"] = 1234;
+            t["uint"] = 1234u;
             t["decimal"] = 12.34m;
             t["timestamp"] = new AmqpTimestamp(0);
             IDictionary<string, object> t2 = new Dictionary<string, object>();
@@ -75,6 +76,7 @@ namespace RabbitMQ.Client.Unit
             IDictionary<string, object> nt = WireFormatting.ReadTable(Reader(Contents(w)));
             Assert.AreEqual(Encoding.UTF8.GetBytes("Hello"), nt["string"]);
             Assert.AreEqual(1234, nt["int"]);
+            Assert.AreEqual(1234u, nt["uint"]);
             Assert.AreEqual(12.34m, nt["decimal"]);
             Assert.AreEqual(0, ((AmqpTimestamp)nt["timestamp"]).UnixTime);
             IDictionary<string, object> nt2 = (IDictionary<string, object>)nt["fieldtable"];


### PR DESCRIPTION
## Proposed Changes
I tried to use for queues `x-max-length` and `x-max-length-bytes` arguments unsigned integers, as mentioned here https://www.rabbitmq.com/maxlength.html
1. Maximum number of messages can be set by supplying the x-max-length queue declaration argument with a *non-negative integer* value.
2. Maximum length in bytes can be set by supplying the x-max-length-bytes queue declaration argument with a *non-negative integer* value.

And got the same `WireFormattingException(Value cannot appear as table value)`.

From https://www.rabbitmq.com/amqp-0-9-1-errata.html 'Unsigned 32-bit' is 'i', i wanted to add ulong support, but if i'm not mistaken rabbitmq does not support it?

## Types of Changes
- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [x] (Possible) Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

There is still possible breaking change, when new-version producer send u32, but old-version consumer don't know about it, but guess all client code now uses signed integers for args
