### PR TITLE
Improved Heartbeat Write Timer Handling

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -1015,15 +1015,32 @@ entry.ToString());
                 m_hasDisposedHeartBeatReadTimer = false;
                 m_hasDisposedHeartBeatWriteTimer = false;
 #if NETFX_CORE
-                _heartbeatWriteTimer = new Timer(HeartbeatWriteTimerCallback);
-                _heartbeatReadTimer = new Timer(HeartbeatReadTimerCallback);
-                _heartbeatWriteTimer.Change(200, (int)m_heartbeatTimeSpan.TotalMilliseconds);
-                _heartbeatReadTimer.Change(200, (int)m_heartbeatTimeSpan.TotalMilliseconds);
+                lock(_heartBeatWriteLock)
+                {
+                    _heartbeatWriteTimer = new Timer(HeartbeatWriteTimerCallback);
+                    _heartbeatWriteTimer.Change(200, Timeout.Infinite);
+                }
+
+                lock (_heartBeatReadLock)
+                {
+                    _heartbeatReadTimer = new Timer(HeartbeatReadTimerCallback);
+
+                    _heartbeatReadTimer.Change(300, Timeout.Infinite);
+                }
 #else
-                _heartbeatWriteTimer = new Timer(HeartbeatWriteTimerCallback, null, 200, (int)m_heartbeatTimeSpan.TotalMilliseconds);
-                _heartbeatReadTimer = new Timer(HeartbeatReadTimerCallback, null, 200, (int)m_heartbeatTimeSpan.TotalMilliseconds);
-                _heartbeatWriteTimer.Change(TimeSpan.FromMilliseconds(200), m_heartbeatTimeSpan);
-                _heartbeatReadTimer.Change(TimeSpan.FromMilliseconds(200), m_heartbeatTimeSpan);
+                lock (_heartBeatWriteLock)
+                {
+                    _heartbeatWriteTimer = new Timer(HeartbeatWriteTimerCallback, null, Timeout.Infinite, Timeout.Infinite);
+
+                    _heartbeatWriteTimer.Change(200, Timeout.Infinite);
+                }
+
+                lock (_heartBeatReadLock)
+                {
+                    _heartbeatReadTimer = new Timer(HeartbeatReadTimerCallback, null, Timeout.Infinite, Timeout.Infinite);
+
+                    _heartbeatReadTimer.Change(300, Timeout.Infinite);
+                }
 #endif
             }
         }
@@ -1050,7 +1067,9 @@ entry.ToString());
                 {
                     return;
                 }
+
                 bool shouldTerminate = false;
+                
                 try
                 {
                     if (!m_closed)
@@ -1111,37 +1130,47 @@ entry.ToString());
                 {
                     return;
                 }
-                bool shouldTerminate = false;
+            }
+
+            bool shouldTerminate = false;
+
+            try
+            {
                 try
                 {
-                    try
+                    if (!m_closed)
                     {
-                        if (!m_closed)
-                        {
-                            WriteFrame(m_heartbeatFrame);
-                        }
-                    }
-                    catch (Exception e)
-                    {
-                        HandleMainLoopException(new ShutdownEventArgs(
-                            ShutdownInitiator.Library,
-                            0,
-                            "End of stream",
-                            e));
-                        shouldTerminate = true;
-                    }
-
-                    if (m_closed || shouldTerminate)
-                    {
-                        TerminateMainloop();
-                        FinishClose();
+                        WriteFrame(m_heartbeatFrame);
                     }
                 }
-                catch (ObjectDisposedException)
+                catch (Exception e)
                 {
-                    // timer is already disposed,
-                    // e.g. due to shutdown
-                } /**/
+                    HandleMainLoopException(new ShutdownEventArgs(
+                        ShutdownInitiator.Library,
+                        0,
+                        "End of stream",
+                        e));
+                    shouldTerminate = true;
+                }
+
+                if (m_closed || shouldTerminate)
+                {
+                    TerminateMainloop();
+                    FinishClose();
+                }
+            }
+            catch (ObjectDisposedException)
+            {
+                // timer is already disposed,
+                // e.g. due to shutdown
+            } /**/
+
+            lock(_heartBeatWriteLock)
+            {
+                if(m_closed == false && shouldTerminate == false && _heartbeatWriteTimer != null)
+                {
+                    _heartbeatWriteTimer.Change((int)m_heartbeatTimeSpan.TotalMilliseconds, Timeout.Infinite);
+                }
             }
         }
 


### PR DESCRIPTION
- Resolves an issue with the Heartbeat Write Timer repeatedly firing and blocking on the sychronization lock. The timer will now fire once and be restarted (if not disposed) at the end of method processing.

## Proposed Changes

Modified synchronization and parameters of the Write Heartbeat Timer to ensure it can only fire once. It will then be started again at the end of the callback.

This resolves an issue that can occur when writing a heartbeat frame to the socket fails (e.g. broken connection) and the Write Heartbeat Timer continued to fire and block on the lockable `_heartbeatWriteLock` object. Over time this would eventually exhaust the ThreadPool if the socket write didn't return.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

