### PR TITLE
Don't consider a heartbeat frame write failure to be fatal

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -1146,7 +1146,7 @@ entry.ToString());
             }
             catch (Exception)
             {
-                // ignore, let the read callback detected
+                // ignore, let the read callback detect
                 // peer unavailability. See rabbitmq/rabbitmq-dotnet-client#638 for details.
             }
 

--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -1132,31 +1132,11 @@ entry.ToString());
                 }
             }
 
-            bool shouldTerminate = false;
-
             try
             {
-                try
+                if (!m_closed)
                 {
-                    if (!m_closed)
-                    {
-                        WriteFrame(m_heartbeatFrame);
-                    }
-                }
-                catch (Exception e)
-                {
-                    HandleMainLoopException(new ShutdownEventArgs(
-                        ShutdownInitiator.Library,
-                        0,
-                        "End of stream",
-                        e));
-                    shouldTerminate = true;
-                }
-
-                if (m_closed || shouldTerminate)
-                {
-                    TerminateMainloop();
-                    FinishClose();
+                    WriteFrame(m_heartbeatFrame);
                 }
             }
             catch (ObjectDisposedException)
@@ -1164,10 +1144,15 @@ entry.ToString());
                 // timer is already disposed,
                 // e.g. due to shutdown
             }
+            catch (Exception)
+            {
+                // ignore, let the read callback detected
+                // peer unavailability. See rabbitmq/rabbitmq-dotnet-client#638 for details.
+            }
 
             lock(_heartBeatWriteLock)
             {
-                if(m_closed == false && shouldTerminate == false && _heartbeatWriteTimer != null)
+                if(m_closed == false && _heartbeatWriteTimer != null)
                 {
                     _heartbeatWriteTimer.Change((int)m_heartbeatTimeSpan.TotalMilliseconds, Timeout.Infinite);
                 }


### PR DESCRIPTION
## Proposed Changes

This changes failed heartbeat frame write behavior to not close the connection.
Other clients do not do it [1], the spec doesn't instruct us to do so.
Let the heartbeat reader side detect peer unavailability (as it
currently does, using two missed heartbeats/intervals).

Heartbeat frame write can fail on on a highly congested connection
or a connection that's blocked by a resource alarm. The alarm might
clear soon enough for connection to be considered functional
by the peer.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #638)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #638.

1. https://github.com/rabbitmq/rabbitmq-java-client/blob/5.6.x-stable/src/main/java/com/rabbitmq/client/impl/HeartbeatSender.java
