### PR TITLE
5.x

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ contribution.
 If something isn't clear, feel free to ask on our [mailing list][rmq-users].
 
 [rmq-collect-env]: https://github.com/rabbitmq/support-tools/blob/master/scripts/rabbitmq-collect-env
-[git-commit-msgs]: https://goo.gl/xwWq
+[git-commit-msgs]: https://chris.beams.io/posts/git-commit/
 [rmq-users]: https://groups.google.com/forum/#!forum/rabbitmq-users
 [ca-agreement]: https://cla.pivotal.io/sign/rabbitmq
 [github-fork]: https://help.github.com/articles/fork-a-repo/

--- a/LICENSE-APACHE2
+++ b/LICENSE-APACHE2
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/docs/specs/amqp0-9-1.xml
+++ b/docs/specs/amqp0-9-1.xml
@@ -130,7 +130,7 @@
 
     Links to full AMQP specification:
     =================================
-    http://www.amqp.org
+    https://www.amqp.org
 -->
 
 <!--

--- a/projects/client/Apigen/properties/AssemblyInfo.cs
+++ b/projects/client/Apigen/properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Apigen/src/apigen/AmqpClass.cs
+++ b/projects/client/Apigen/src/apigen/AmqpClass.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Apigen/src/apigen/AmqpEntity.cs
+++ b/projects/client/Apigen/src/apigen/AmqpEntity.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Apigen/src/apigen/AmqpField.cs
+++ b/projects/client/Apigen/src/apigen/AmqpField.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Apigen/src/apigen/AmqpMethod.cs
+++ b/projects/client/Apigen/src/apigen/AmqpMethod.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Apigen/src/apigen/Apigen.cs
+++ b/projects/client/Apigen/src/apigen/Apigen.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -407,7 +407,7 @@ namespace RabbitMQ.Client.Apigen
             EmitLine("//   you may not use this file except in compliance with the License.");
             EmitLine("//   You may obtain a copy of the License at");
             EmitLine("//");
-            EmitLine("//       http://www.apache.org/licenses/LICENSE-2.0");
+            EmitLine("//       https://www.apache.org/licenses/LICENSE-2.0");
             EmitLine("//");
             EmitLine("//   Unless required by applicable law or agreed to in writing, software");
             EmitLine("//   distributed under the License is distributed on an \"AS IS\" BASIS,");

--- a/projects/client/ApigenBootstrap/properties/AssemblyInfo.cs
+++ b/projects/client/ApigenBootstrap/properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client.WinRT/src/client/impl/SocketFrameHandlerWinRT.cs
+++ b/projects/client/RabbitMQ.Client.WinRT/src/client/impl/SocketFrameHandlerWinRT.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client.WinRT/src/tokenized/AssemblyInfo.cs.in
+++ b/projects/client/RabbitMQ.Client.WinRT/src/tokenized/AssemblyInfo.cs.in
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client.WinRT/src/util/ICloneable.cs
+++ b/projects/client/RabbitMQ.Client.WinRT/src/util/ICloneable.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client.WinRT/src/util/MetroEventSource.cs
+++ b/projects/client/RabbitMQ.Client.WinRT/src/util/MetroEventSource.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client.WinRT/src/util/SerializableAttribute.cs
+++ b/projects/client/RabbitMQ.Client.WinRT/src/util/SerializableAttribute.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client.WinRT/src/util/Timer.cs
+++ b/projects/client/RabbitMQ.Client.WinRT/src/util/Timer.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/AmqpTcpEndpoint.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/AmqpTcpEndpoint.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/AmqpTimestamp.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/AmqpTimestamp.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/AmqpVersion.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/AmqpVersion.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/AuthMechanism.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/AuthMechanism.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/AuthMechanismFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/AuthMechanismFactory.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/BasicGetResult.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/BasicGetResult.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/BinaryTableValue.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/BinaryTableValue.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
@@ -328,7 +328,7 @@ namespace RabbitMQ.Client
         public string VirtualHost { get; set; } = DefaultVHost;
 
         /// <summary>
-        /// Username to use when authenticating to the server.
+        /// The uri to use for the connection.
         /// </summary>
         public Uri Uri
         {

--- a/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactoryBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactoryBase.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/DefaultBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/DefaultBasicConsumer.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/DefaultEndpointResolver.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/DefaultEndpointResolver.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/ExchangeType.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ExchangeType.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/ExternalMechanism.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ExternalMechanism.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/ExternalMechanismFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ExternalMechanismFactory.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/Headers.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/Headers.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IBasicConsumer.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IBasicProperties.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IBasicProperties.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IBasicPublishBatch.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IBasicPublishBatch.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IConnection.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IConnection.cs
@@ -221,11 +221,12 @@ namespace RabbitMQ.Client
         /// </summary>
         /// <remarks>
         /// This method, behaves in a similar way as method <see cref="Abort()"/> with the
-        /// only difference that it explictly specifies the timeout given
+        /// only difference that it explictly specifies a timeout given
         /// for all the in-progress close operations to complete.
         /// If timeout is reached and the close operations haven't finished, then socket is forced to close.
         /// <para>
-        ///To wait infinitely for the close operations to complete use <see cref="Timeout.Infinite"/>.
+        /// The timeout value is in milliseconds.
+        /// To wait infinitely for the close operations to complete use <see cref="Timeout.Infinite"/>.
         /// </para>
         /// </remarks>
         void Abort(int timeout);
@@ -238,10 +239,13 @@ namespace RabbitMQ.Client
         /// The method behaves in the same way as <see cref="Abort(int)"/>, with the only
         /// difference that the connection is closed with the given connection close code and message.
         /// <para>
-        /// The close code (See under "Reply Codes" in the AMQP specification).
+        /// The close code (See under "Reply Codes" in the AMQP 0-9-1 specification).
         /// </para>
         /// <para>
         /// A message indicating the reason for closing the connection.
+        /// </para>
+        /// <para>
+        /// Operation timeout in milliseconds.
         /// </para>
         /// </remarks>
         void Abort(ushort reasonCode, string reasonText, int timeout);
@@ -286,6 +290,7 @@ namespace RabbitMQ.Client
         /// It can also throw <see cref="IOException"/> when socket was closed unexpectedly.
         /// If timeout is reached and the close operations haven't finished, then socket is forced to close.
         /// <para>
+        /// The timeout value is in milliseconds.
         /// To wait infinitely for the close operations to complete use <see cref="Timeout.Infinite"/>.
         /// </para>
         /// </remarks>
@@ -303,6 +308,9 @@ namespace RabbitMQ.Client
         /// </para>
         /// <para>
         /// A message indicating the reason for closing the connection.
+        /// </para>
+        /// <para>
+        /// Operation timeout in milliseconds.
         /// </para>
         /// </remarks>
         void Close(ushort reasonCode, string reasonText, int timeout);

--- a/projects/client/RabbitMQ.Client/src/client/api/IConnectionFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IConnectionFactory.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IContentHeader.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IContentHeader.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IEndpointResolver.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IEndpointResolver.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IEndpointResolverExtensions.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IEndpointResolverExtensions.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IMethod.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IMethod.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IModel.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IModelExtensions.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IModelExtensions.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IProtocol.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IProtocol.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IQueueingBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IQueueingBasicConsumer.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IRecoverable.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IRecoverable.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/IStreamProperties.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IStreamProperties.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/ITcpClient.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ITcpClient.cs
@@ -19,7 +19,7 @@ namespace RabbitMQ.Client
 
         Socket Client { get; }
 
-        Task ConnectAsync(string host, int port, CancellationToken cancellationToken);
+        Task ConnectAsync(string host, int port);
 
         NetworkStream GetStream();
 

--- a/projects/client/RabbitMQ.Client/src/client/api/ITcpClient.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ITcpClient.cs
@@ -3,6 +3,7 @@ using System;
 using System.Threading.Tasks;
 
 using System.Net.Sockets;
+using System.Threading;
 
 namespace RabbitMQ.Client
 {
@@ -18,7 +19,7 @@ namespace RabbitMQ.Client
 
         Socket Client { get; }
 
-        Task ConnectAsync(string host, int port);
+        Task ConnectAsync(string host, int port, CancellationToken cancellationToken);
 
         NetworkStream GetStream();
 

--- a/projects/client/RabbitMQ.Client/src/client/api/NetworkConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/NetworkConnection.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/PlainMechanism.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/PlainMechanism.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/PlainMechanismFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/PlainMechanismFactory.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/Protocols.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/Protocols.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/PublicationAddress.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/PublicationAddress.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/QueueDeclareOk.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/QueueDeclareOk.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/QueueingBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/QueueingBasicConsumer.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/ShutdownEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ShutdownEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/ShutdownEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ShutdownEventArgs.cs
@@ -107,13 +107,13 @@ namespace RabbitMQ.Client
         /// Override ToString to be useful for debugging.
         /// </summary>
         public override string ToString()
-        {
-            return "AMQP close-reason, initiated by " + Initiator +
-                   ", code=" + ReplyCode +
-                   ", text=\"" + ReplyText + "\"" +
-                   ", classId=" + ClassId +
-                   ", methodId=" + MethodId +
-                   ", cause=" + Cause;
+        { 
+            return $"AMQP close-reason, initiated by {Initiator}" 
+                + $", code={ReplyCode}"
+                + (ReplyText != null ? $", text='{ReplyText}'" : string.Empty)
+                + $", classId={ClassId}"
+                + $", methodId={MethodId}"
+                + (Cause != null ? $", cause={Cause}" : string.Empty);
         }
     }
 }

--- a/projects/client/RabbitMQ.Client/src/client/api/ShutdownInitiator.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ShutdownInitiator.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/ShutdownReportEntry.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ShutdownReportEntry.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/SslHelper.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/SslHelper.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/SslOption.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/SslOption.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/api/TopologyRecoveryException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/TopologyRecoveryException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/BasicMessageBuilder.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/BasicMessageBuilder.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/BasicMessageReader.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/BasicMessageReader.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/BytesMessageBuilder.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/BytesMessageBuilder.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/BytesMessageReader.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/BytesMessageReader.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/BytesWireFormatting.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/BytesWireFormatting.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/IBytesMessageBuilder.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/IBytesMessageBuilder.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/IBytesMessageReader.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/IBytesMessageReader.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/IMapMessageBuilder.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/IMapMessageBuilder.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/IMapMessageReader.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/IMapMessageReader.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/IMessageBuilder.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/IMessageBuilder.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/IMessageReader.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/IMessageReader.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/IStreamMessageBuilder.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/IStreamMessageBuilder.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/IStreamMessageReader.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/IStreamMessageReader.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/MapMessageBuilder.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/MapMessageBuilder.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/MapMessageReader.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/MapMessageReader.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/MapWireFormatting.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/MapWireFormatting.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/PrimitiveParser.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/PrimitiveParser.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/StreamMessageBuilder.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/StreamMessageBuilder.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/StreamMessageReader.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/StreamMessageReader.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/content/StreamWireFormatting.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/StreamWireFormatting.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/BasicAckEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/BasicAckEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/BasicDeliverEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/BasicDeliverEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/BasicNackEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/BasicNackEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/BasicReturnEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/BasicReturnEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/CallbackExceptionEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/CallbackExceptionEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/ConnectionBlockedEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/ConnectionBlockedEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/ConnectionRecoveryErrorEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/ConnectionRecoveryErrorEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/ConsumerEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/ConsumerEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/ConsumerTagChangedAfterRecoveryEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/ConsumerTagChangedAfterRecoveryEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/EventingBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/EventingBasicConsumer.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/FlowControlEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/FlowControlEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/QueueNameChangedAfterRecoveryEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/QueueNameChangedAfterRecoveryEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/events/RecoveryExceptionEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/RecoveryExceptionEventArgs.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/AlreadyClosedException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/AlreadyClosedException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/AuthenticationFailureException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/AuthenticationFailureException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/BrokerUnreachableException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/BrokerUnreachableException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/ChannelAllocationException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/ChannelAllocationException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/ConnectFailureException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/ConnectFailureException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/OperationInterruptedException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/OperationInterruptedException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/PacketNotRecognizedException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/PacketNotRecognizedException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/PossibleAuthenticationFailureException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/PossibleAuthenticationFailureException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/ProtocolVersionMismatchException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/ProtocolVersionMismatchException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/ProtocolViolationException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/ProtocolViolationException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/RabbitMQClientException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/RabbitMQClientException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/UnexpectedMethodException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/UnexpectedMethodException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/UnsupportedMethodException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/UnsupportedMethodException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/UnsupportedMethodFieldException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/UnsupportedMethodFieldException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/WireFormattingException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/WireFormattingException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
@@ -644,7 +644,7 @@ namespace RabbitMQ.Client.Impl
             bool nowait,
             IDictionary<string, object> arguments)
         {
-            _Private_ExchangeBind(destination, source, routingKey,
+            m_delegate._Private_ExchangeBind(destination, source, routingKey,
                 nowait, arguments);
         }
 
@@ -657,7 +657,7 @@ namespace RabbitMQ.Client.Impl
             bool nowait,
             IDictionary<string, object> arguments)
         {
-            _Private_ExchangeDeclare(exchange, type, passive,
+            m_delegate._Private_ExchangeDeclare(exchange, type, passive,
                 durable, autoDelete, @internal,
                 nowait, arguments);
         }
@@ -666,7 +666,7 @@ namespace RabbitMQ.Client.Impl
             bool ifUnused,
             bool nowait)
         {
-            _Private_ExchangeDelete(exchange, ifUnused, nowait);
+            m_delegate._Private_ExchangeDelete(exchange, ifUnused, nowait);
         }
 
         public void _Private_ExchangeUnbind(string destination,
@@ -685,7 +685,7 @@ namespace RabbitMQ.Client.Impl
             bool nowait,
             IDictionary<string, object> arguments)
         {
-            _Private_QueueBind(queue, exchange, routingKey,
+            m_delegate._Private_QueueBind(queue, exchange, routingKey,
                 nowait, arguments);
         }
 

--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/BasicProperties.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/BasicProperties.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/BasicPublishBatch.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/BasicPublishBatch.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ChannelErrorException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ChannelErrorException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/Command.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Command.cs
@@ -66,12 +66,10 @@ namespace RabbitMQ.Client.Impl
 
         public Command() : this(null, null, null)
         {
-            m_body = new MemoryStream();
         }
 
         public Command(MethodBase method) : this(method, null, null)
         {
-            m_body = new MemoryStream();
         }
 
         public Command(MethodBase method, ContentHeaderBase header, byte[] body)

--- a/projects/client/RabbitMQ.Client/src/client/impl/Command.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Command.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/CommandAssembler.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/CommandAssembler.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ConnectionStartDetails.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ConnectionStartDetails.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ContentHeaderBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ContentHeaderBase.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ContentHeaderPropertyReader.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ContentHeaderPropertyReader.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ContentHeaderPropertyWriter.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ContentHeaderPropertyWriter.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ExtensionMethods.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ExtensionMethods.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/Frame.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Frame.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/HardProtocolException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/HardProtocolException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/IConsumerDispatcher.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/IConsumerDispatcher.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/IFrameHandler.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/IFrameHandler.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/IFullModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/IFullModel.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/IProtocolExtensions.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/IProtocolExtensions.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/IRpcContinuation.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/IRpcContinuation.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ISession.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ISession.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/MainSession.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/MainSession.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/MalformedFrameException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/MalformedFrameException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/MethodArgumentReader.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/MethodArgumentReader.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/MethodArgumentWriter.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/MethodArgumentWriter.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/MethodBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/MethodBase.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ProtocolBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ProtocolBase.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ProtocolException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ProtocolException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/QuiescingSession.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/QuiescingSession.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/RecordedBinding.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RecordedBinding.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/RecordedConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RecordedConsumer.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/RecordedEntity.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RecordedEntity.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/RecordedExchange.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RecordedExchange.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/RecordedNamedEntity.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RecordedNamedEntity.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/RecordedQueue.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RecordedQueue.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/RecoveryAwareModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RecoveryAwareModel.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/RpcContinuationQueue.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RpcContinuationQueue.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/Session.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Session.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/SessionBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SessionBase.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/SessionManager.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SessionManager.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/ShutdownContinuation.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ShutdownContinuation.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/SimpleBlockingRpcContinuation.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SimpleBlockingRpcContinuation.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
@@ -61,7 +61,7 @@ namespace RabbitMQ.Client.Impl
                 await task;
             else
             {
-                task.ContinueWith(t => t.Exception.Handle(e => true), TaskContinuationOptions.OnlyOnFaulted).Start();
+                var supressErrorTask = task.ContinueWith(t => t.Exception.Handle(e => true), TaskContinuationOptions.OnlyOnFaulted);
                 throw new TimeoutException();
             }
         }

--- a/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/SoftProtocolException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SoftProtocolException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/StreamProperties.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/StreamProperties.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/SyntaxError.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SyntaxError.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/UnexpectedFrameException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/UnexpectedFrameException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/UnknownClassOrMethodException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/UnknownClassOrMethodException.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/WireFormatting.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/WireFormatting.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/impl/WireFormatting.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/WireFormatting.cs
@@ -126,6 +126,9 @@ namespace RabbitMQ.Client.Impl
                 case 'I':
                     value = reader.ReadInt32();
                     break;
+                case 'i':
+                    value = reader.ReadUInt32();
+                    break;
                 case 'D':
                     value = ReadDecimal(reader);
                     break;
@@ -294,6 +297,10 @@ namespace RabbitMQ.Client.Impl
                     break;
                 case int val:
                     WriteOctet(writer, (byte)'I');
+                    writer.Write(val);
+                    break;
+                case uint val:
+                    WriteOctet(writer, (byte)'i');
                     writer.Write(val);
                     break;
                 case decimal val:

--- a/projects/client/RabbitMQ.Client/src/client/impl/WireFormatting.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/WireFormatting.cs
@@ -57,11 +57,17 @@ namespace RabbitMQ.Client.Impl
                 throw new SyntaxError("Unrepresentable AMQP decimal table field: " +
                                       "scale=" + scale);
             }
-            return new decimal((int)(unsignedMantissa & 0x7FFFFFFF),
-                0,
-                0,
-                ((unsignedMantissa & 0x80000000) == 0) ? false : true,
-                scale);
+
+            return new decimal(
+                // The low 32 bits of a 96-bit integer
+                lo: (int)(unsignedMantissa & 0x7FFFFFFF),
+                // The middle 32 bits of a 96-bit integer.
+                mid: 0,
+                // The high 32 bits of a 96-bit integer.
+                hi: 0,
+                isNegative: (unsignedMantissa & 0x80000000) != 0,
+                // A power of 10 ranging from 0 to 28.
+                scale: scale);
         }
 
         public static void DecimalToAmqp(decimal value, out byte scale, out int mantissa)
@@ -91,7 +97,7 @@ namespace RabbitMQ.Client.Impl
         {
             IList array = new List<object>();
             long arrayLength = reader.ReadUInt32();
-            Stream backingStream = reader.BaseStream;
+            var backingStream = reader.BaseStream;
             long startPosition = backingStream.Position;
             while ((backingStream.Position - startPosition) < arrayLength)
             {
@@ -129,9 +135,11 @@ namespace RabbitMQ.Client.Impl
                 case 'F':
                     value = ReadTable(reader);
                     break;
-
                 case 'A':
                     value = ReadArray(reader);
+                    break;
+                case 'B':
+                    value = reader.ReadByte();
                     break;
                 case 'b':
                     value = reader.ReadSByte();
@@ -215,7 +223,7 @@ namespace RabbitMQ.Client.Impl
             IDictionary<string, object> table = new Dictionary<string, object>();
             long tableLength = reader.ReadUInt32();
 
-            Stream backingStream = reader.BaseStream;
+            var backingStream = reader.BaseStream;
             long startPosition = backingStream.Position;
             while ((backingStream.Position - startPosition) < tableLength)
             {
@@ -247,7 +255,7 @@ namespace RabbitMQ.Client.Impl
             }
             else
             {
-                Stream backingStream = writer.BaseStream;
+                var backingStream = writer.BaseStream;
                 long patchPosition = backingStream.Position;
                 writer.Write((uint)0); // length of table - will be backpatched
                 foreach (object entry in val)
@@ -264,93 +272,82 @@ namespace RabbitMQ.Client.Impl
 
         public static void WriteDecimal(NetworkBinaryWriter writer, decimal value)
         {
-            byte scale;
-            int mantissa;
-            DecimalToAmqp(value, out scale, out mantissa);
+            DecimalToAmqp(value, out var scale, out var mantissa);
             WriteOctet(writer, scale);
             WriteLong(writer, (uint)mantissa);
         }
 
         public static void WriteFieldValue(NetworkBinaryWriter writer, object value)
         {
-            if (value == null)
+            switch (value)
             {
-                WriteOctet(writer, (byte)'V');
-            }
-            else if (value is string)
-            {
-                WriteOctet(writer, (byte)'S');
-                WriteLongstr(writer, Encoding.UTF8.GetBytes((string)value));
-            }
-            else if (value is byte[])
-            {
-                WriteOctet(writer, (byte)'S');
-                WriteLongstr(writer, (byte[])value);
-            }
-            else if (value is int)
-            {
-                WriteOctet(writer, (byte)'I');
-                writer.Write((int)value);
-            }
-            else if (value is decimal)
-            {
-                WriteOctet(writer, (byte)'D');
-                WriteDecimal(writer, (decimal)value);
-            }
-            else if (value is AmqpTimestamp)
-            {
-                WriteOctet(writer, (byte)'T');
-                WriteTimestamp(writer, (AmqpTimestamp)value);
-            }
-            else if (value is IDictionary)
-            {
-                WriteOctet(writer, (byte)'F');
-                WriteTable(writer, (IDictionary)value);
-            }
-            else if (value is IList)
-            {
-                WriteOctet(writer, (byte)'A');
-                WriteArray(writer, (IList)value);
-            }
-            else if (value is sbyte)
-            {
-                WriteOctet(writer, (byte)'b');
-                writer.Write((sbyte)value);
-            }
-            else if (value is double)
-            {
-                WriteOctet(writer, (byte)'d');
-                writer.Write((double)value);
-            }
-            else if (value is float)
-            {
-                WriteOctet(writer, (byte)'f');
-                writer.Write((float)value);
-            }
-            else if (value is long)
-            {
-                WriteOctet(writer, (byte)'l');
-                writer.Write((long)value);
-            }
-            else if (value is short)
-            {
-                WriteOctet(writer, (byte)'s');
-                writer.Write((short)value);
-            }
-            else if (value is bool)
-            {
-                WriteOctet(writer, (byte)'t');
-                WriteOctet(writer, (byte)(((bool)value) ? 1 : 0));
-            }
-            else if (value is BinaryTableValue)
-            {
-                WriteOctet(writer, (byte)'x');
-                WriteLongstr(writer, ((BinaryTableValue)value).Bytes);
-            }
-            else
-            {
-                throw new WireFormattingException("Value cannot appear as table value",
-                    value);
+                case null:
+                    WriteOctet(writer, (byte)'V');
+                    break;
+                case string val:
+                    WriteOctet(writer, (byte)'S');
+                    WriteLongstr(writer, Encoding.UTF8.GetBytes(val));
+                    break;
+                case byte[] val:
+                    WriteOctet(writer, (byte)'S');
+                    WriteLongstr(writer, val);
+                    break;
+                case int val:
+                    WriteOctet(writer, (byte)'I');
+                    writer.Write(val);
+                    break;
+                case decimal val:
+                    WriteOctet(writer, (byte)'D');
+                    WriteDecimal(writer, val);
+                    break;
+                case AmqpTimestamp val:
+                    WriteOctet(writer, (byte)'T');
+                    WriteTimestamp(writer, val);
+                    break;
+                case IDictionary val:
+                    WriteOctet(writer, (byte)'F');
+                    WriteTable(writer, val);
+                    break;
+                case IList val:
+                    WriteOctet(writer, (byte)'A');
+                    WriteArray(writer, val);
+                    break;
+                case byte val:
+                    WriteOctet(writer, (byte)'B');
+                    writer.Write(val);
+                    break;
+                case sbyte val:
+                    WriteOctet(writer, (byte)'b');
+                    writer.Write(val);
+                    break;
+                case double val:
+                    WriteOctet(writer, (byte)'d');
+                    writer.Write(val);
+                    break;
+                case float val:
+                    WriteOctet(writer, (byte)'f');
+                    writer.Write(val);
+                    break;
+                case long val:
+                    WriteOctet(writer, (byte)'l');
+                    writer.Write(val);
+                    break;
+                case short val:
+                    WriteOctet(writer, (byte)'s');
+                    writer.Write(val);
+                    break;
+                case bool val:
+                    WriteOctet(writer, (byte)'t');
+                    WriteOctet(writer, (byte)(val ? 1 : 0));
+                    break;
+                case BinaryTableValue val:
+                    WriteOctet(writer, (byte)'x');
+                    WriteLongstr(writer, val.Bytes);
+                    break;
+                default:
+                    throw new WireFormattingException(
+                        $"Value of type '{value.GetType().Name}' cannot appear as table value",
+                        value);
             }
         }
 
@@ -382,14 +379,16 @@ namespace RabbitMQ.Client.Impl
 
         public static void WriteShortstr(NetworkBinaryWriter writer, string val)
         {
-            byte[] bytes = Encoding.UTF8.GetBytes(val);
-            int len = bytes.Length;
-            if (len > 255)
+            var bytes = Encoding.UTF8.GetBytes(val);
+            var length = bytes.Length;
+            
+            if (length > 255)
             {
                 throw new WireFormattingException("Short string too long; " +
-                                                  "UTF-8 encoded length=" + len + ", max=255");
+                                                  "UTF-8 encoded length=" + length + ", max=255");
             }
-            writer.Write((byte)len);
+
+            writer.Write((byte)length);
             writer.Write(bytes);
         }
 
@@ -415,15 +414,14 @@ namespace RabbitMQ.Client.Impl
             }
             else
             {
-                Stream backingStream = writer.BaseStream;
+                var backingStream = writer.BaseStream;
                 long patchPosition = backingStream.Position;
                 writer.Write((uint)0); // length of table - will be backpatched
 
                 foreach (DictionaryEntry entry in val)
                 {
                     WriteShortstr(writer, entry.Key.ToString());
-                    object value = entry.Value;
-                    WriteFieldValue(writer, value);
+                    WriteFieldValue(writer, entry.Value);
                 }
 
                 // Now, backpatch the table length.
@@ -457,15 +455,14 @@ namespace RabbitMQ.Client.Impl
             }
             else
             {
-                Stream backingStream = writer.BaseStream;
+                var backingStream = writer.BaseStream;
                 long patchPosition = backingStream.Position;
                 writer.Write((uint)0); // length of table - will be backpatched
 
-                foreach (KeyValuePair<string, object> entry in val)
+                foreach (var entry in val)
                 {
                     WriteShortstr(writer, entry.Key);
-                    object value = entry.Value;
-                    WriteFieldValue(writer, value);
+                    WriteFieldValue(writer, entry.Value);
                 }
 
                 // Now, backpatch the table length.

--- a/projects/client/RabbitMQ.Client/src/client/messagepatterns/ISubscription.cs
+++ b/projects/client/RabbitMQ.Client/src/client/messagepatterns/ISubscription.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/messagepatterns/SimpleRpcClient.cs
+++ b/projects/client/RabbitMQ.Client/src/client/messagepatterns/SimpleRpcClient.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/messagepatterns/SimpleRpcServer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/messagepatterns/SimpleRpcServer.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/messagepatterns/Subscription.cs
+++ b/projects/client/RabbitMQ.Client/src/client/messagepatterns/Subscription.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/client/properties/AssemblyInfo.cs
+++ b/projects/client/RabbitMQ.Client/src/client/properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/logging/ESLog.cs
+++ b/projects/client/RabbitMQ.Client/src/logging/ESLog.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/logging/RabbitMqClientEventSource.cs
+++ b/projects/client/RabbitMQ.Client/src/logging/RabbitMqClientEventSource.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/logging/RabbitMqConsoleEventListener.cs
+++ b/projects/client/RabbitMQ.Client/src/logging/RabbitMqConsoleEventListener.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/logging/RabbitMqExceptionDetail.cs
+++ b/projects/client/RabbitMQ.Client/src/logging/RabbitMqExceptionDetail.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/tokenized/AssemblyInfo.cs.in
+++ b/projects/client/RabbitMQ.Client/src/tokenized/AssemblyInfo.cs.in
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/util/BlockingCell.cs
+++ b/projects/client/RabbitMQ.Client/src/util/BlockingCell.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/util/DebugUtil.cs
+++ b/projects/client/RabbitMQ.Client/src/util/DebugUtil.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/util/Either.cs
+++ b/projects/client/RabbitMQ.Client/src/util/Either.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/util/IntAllocator.cs
+++ b/projects/client/RabbitMQ.Client/src/util/IntAllocator.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/util/NetworkBinaryReader.cs
+++ b/projects/client/RabbitMQ.Client/src/util/NetworkBinaryReader.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/util/NetworkBinaryWriter.cs
+++ b/projects/client/RabbitMQ.Client/src/util/NetworkBinaryWriter.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/util/SetQueue.cs
+++ b/projects/client/RabbitMQ.Client/src/util/SetQueue.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/util/SharedQueue.cs
+++ b/projects/client/RabbitMQ.Client/src/util/SharedQueue.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/RabbitMQ.Client/src/util/SynchronizedList.cs
+++ b/projects/client/RabbitMQ.Client/src/util/SynchronizedList.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit.WinRT/properties/AssemblyInfo.cs
+++ b/projects/client/Unit.WinRT/properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/properties/AssemblyInfo.cs
+++ b/projects/client/Unit/properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/Fixtures.cs
+++ b/projects/client/Unit/src/unit/Fixtures.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/Fixtures.cs
+++ b/projects/client/Unit/src/unit/Fixtures.cs
@@ -549,7 +549,7 @@ namespace RabbitMQ.Client.Unit
 
         protected List<ConnectionInfo> ListConnections()
         {
-            Process proc  = ExecRabbitMQCtl("list_connections -q pid peer_port");
+            Process proc  = ExecRabbitMQCtl("list_connections --silent pid peer_port");
             String stdout = proc.StandardOutput.ReadToEnd();
 
             try
@@ -568,7 +568,7 @@ namespace RabbitMQ.Client.Unit
             }
             catch (Exception)
             {
-                Console.WriteLine("Bad response from rabbitmqctl list_connections -q pid peer_port:" + Environment.NewLine + stdout);
+                Console.WriteLine("Bad response from rabbitmqctl list_connections --silent pid peer_port:" + Environment.NewLine + stdout);
                 throw;
             }
         }

--- a/projects/client/Unit/src/unit/TestAmqpTcpEndpointParsing.cs
+++ b/projects/client/Unit/src/unit/TestAmqpTcpEndpointParsing.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestAmqpUri.cs
+++ b/projects/client/Unit/src/unit/TestAmqpUri.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestAsyncConsumer.cs
+++ b/projects/client/Unit/src/unit/TestAsyncConsumer.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestAuth.cs
+++ b/projects/client/Unit/src/unit/TestAuth.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestBasicGet.cs
+++ b/projects/client/Unit/src/unit/TestBasicGet.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestBasicProperties.cs
+++ b/projects/client/Unit/src/unit/TestBasicProperties.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestBasicPublishBatch.cs
+++ b/projects/client/Unit/src/unit/TestBasicPublishBatch.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestBlockingCell.cs
+++ b/projects/client/Unit/src/unit/TestBlockingCell.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestBytesWireFormatting.cs
+++ b/projects/client/Unit/src/unit/TestBytesWireFormatting.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestChannelAllocation.cs
+++ b/projects/client/Unit/src/unit/TestChannelAllocation.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestConcurrentAccessWithSharedConnection.cs
+++ b/projects/client/Unit/src/unit/TestConcurrentAccessWithSharedConnection.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestConfirmSelect.cs
+++ b/projects/client/Unit/src/unit/TestConfirmSelect.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestConnectionBlocked.cs
+++ b/projects/client/Unit/src/unit/TestConnectionBlocked.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestConnectionFactory.cs
+++ b/projects/client/Unit/src/unit/TestConnectionFactory.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestConnectionRecovery.cs
+++ b/projects/client/Unit/src/unit/TestConnectionRecovery.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestConnectionShutdown.cs
+++ b/projects/client/Unit/src/unit/TestConnectionShutdown.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestConnectionWithBackgroundThreads.cs
+++ b/projects/client/Unit/src/unit/TestConnectionWithBackgroundThreads.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestConsumerCancelNotify.cs
+++ b/projects/client/Unit/src/unit/TestConsumerCancelNotify.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestConsumerCount.cs
+++ b/projects/client/Unit/src/unit/TestConsumerCount.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestConsumerExceptions.cs
+++ b/projects/client/Unit/src/unit/TestConsumerExceptions.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestConsumerOperationDispatch.cs
+++ b/projects/client/Unit/src/unit/TestConsumerOperationDispatch.cs
@@ -133,7 +133,7 @@ namespace RabbitMQ.Client.Unit
                     basicProperties: new BasicProperties(),
                     body: encoding.GetBytes("msg"));
             }
-            counter.Wait(TimeSpan.FromSeconds(30));
+            counter.Wait(TimeSpan.FromSeconds(120));
 
             foreach (var cons in consumers)
             {

--- a/projects/client/Unit/src/unit/TestConsumerOperationDispatch.cs
+++ b/projects/client/Unit/src/unit/TestConsumerOperationDispatch.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestContentHeaderCodec.cs
+++ b/projects/client/Unit/src/unit/TestContentHeaderCodec.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestEventingConsumer.cs
+++ b/projects/client/Unit/src/unit/TestEventingConsumer.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestExceptionMessages.cs
+++ b/projects/client/Unit/src/unit/TestExceptionMessages.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestExchangeDeclare.cs
+++ b/projects/client/Unit/src/unit/TestExchangeDeclare.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestExtensions.cs
+++ b/projects/client/Unit/src/unit/TestExtensions.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestFieldTableFormatting.cs
+++ b/projects/client/Unit/src/unit/TestFieldTableFormatting.cs
@@ -117,17 +117,19 @@ namespace RabbitMQ.Client.Unit
         {
             NetworkBinaryWriter w = Writer();
             Hashtable t = new Hashtable();
+            t["B"] = (byte)255;
             t["b"] = (sbyte)-128;
             t["d"] = (double)123;
             t["f"] = (float)123;
             t["l"] = (long)123;
             t["s"] = (short)123;
             t["t"] = true;
-            byte[] xbytes = new byte[] { 0xaa, 0x55 };
+            byte[] xbytes = { 0xaa, 0x55 };
             t["x"] = new BinaryTableValue(xbytes);
             t["V"] = null;
             WireFormatting.WriteTable(w, t);
             IDictionary nt = (IDictionary)WireFormatting.ReadTable(Reader(Contents(w)));
+            Assert.AreEqual(typeof(byte), nt["B"].GetType()); Assert.AreEqual((byte)255, nt["B"]);
             Assert.AreEqual(typeof(sbyte), nt["b"].GetType()); Assert.AreEqual((sbyte)-128, nt["b"]);
             Assert.AreEqual(typeof(double), nt["d"].GetType()); Assert.AreEqual((double)123, nt["d"]);
             Assert.AreEqual(typeof(float), nt["f"].GetType()); Assert.AreEqual((float)123, nt["f"]);

--- a/projects/client/Unit/src/unit/TestFieldTableFormatting.cs
+++ b/projects/client/Unit/src/unit/TestFieldTableFormatting.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestFieldTableFormatting.cs
+++ b/projects/client/Unit/src/unit/TestFieldTableFormatting.cs
@@ -60,6 +60,7 @@ namespace RabbitMQ.Client.Unit
             Hashtable t = new Hashtable();
             t["string"] = "Hello";
             t["int"] = 1234;
+            t["uint"] = 1234u;
             t["decimal"] = 12.34m;
             t["timestamp"] = new AmqpTimestamp(0);
             Hashtable t2 = new Hashtable();
@@ -73,6 +74,7 @@ namespace RabbitMQ.Client.Unit
             IDictionary nt = (IDictionary)WireFormatting.ReadTable(Reader(Contents(w)));
             Assert.AreEqual(Encoding.UTF8.GetBytes("Hello"), nt["string"]);
             Assert.AreEqual(1234, nt["int"]);
+            Assert.AreEqual(1234u, nt["uint"]);
             Assert.AreEqual(12.34m, nt["decimal"]);
             Assert.AreEqual(0, ((AmqpTimestamp)nt["timestamp"]).UnixTime);
             IDictionary nt2 = (IDictionary)nt["fieldtable"];

--- a/projects/client/Unit/src/unit/TestFieldTableFormattingGeneric.cs
+++ b/projects/client/Unit/src/unit/TestFieldTableFormattingGeneric.cs
@@ -119,6 +119,7 @@ namespace RabbitMQ.Client.Unit
         {
             NetworkBinaryWriter w = Writer();
             IDictionary<string, object> t = new Dictionary<string, object>();
+            t["B"] = (byte)255;
             t["b"] = (sbyte)-128;
             t["d"] = (double)123;
             t["f"] = (float)123;
@@ -130,6 +131,7 @@ namespace RabbitMQ.Client.Unit
             t["V"] = null;
             WireFormatting.WriteTable(w, t);
             IDictionary nt = (IDictionary)WireFormatting.ReadTable(Reader(Contents(w)));
+            Assert.AreEqual(typeof(byte), nt["B"].GetType()); Assert.AreEqual((byte)255, nt["B"]);
             Assert.AreEqual(typeof(sbyte), nt["b"].GetType()); Assert.AreEqual((sbyte)-128, nt["b"]);
             Assert.AreEqual(typeof(double), nt["d"].GetType()); Assert.AreEqual((double)123, nt["d"]);
             Assert.AreEqual(typeof(float), nt["f"].GetType()); Assert.AreEqual((float)123, nt["f"]);

--- a/projects/client/Unit/src/unit/TestFieldTableFormattingGeneric.cs
+++ b/projects/client/Unit/src/unit/TestFieldTableFormattingGeneric.cs
@@ -62,6 +62,7 @@ namespace RabbitMQ.Client.Unit
             IDictionary<string, object> t = new Dictionary<string, object>();
             t["string"] = "Hello";
             t["int"] = 1234;
+            t["uint"] = 1234u;
             t["decimal"] = 12.34m;
             t["timestamp"] = new AmqpTimestamp(0);
             IDictionary<string, object> t2 = new Dictionary<string, object>();
@@ -75,6 +76,7 @@ namespace RabbitMQ.Client.Unit
             IDictionary<string, object> nt = WireFormatting.ReadTable(Reader(Contents(w)));
             Assert.AreEqual(Encoding.UTF8.GetBytes("Hello"), nt["string"]);
             Assert.AreEqual(1234, nt["int"]);
+            Assert.AreEqual(1234u, nt["uint"]);
             Assert.AreEqual(12.34m, nt["decimal"]);
             Assert.AreEqual(0, ((AmqpTimestamp)nt["timestamp"]).UnixTime);
             IDictionary<string, object> nt2 = (IDictionary<string, object>)nt["fieldtable"];

--- a/projects/client/Unit/src/unit/TestFieldTableFormattingGeneric.cs
+++ b/projects/client/Unit/src/unit/TestFieldTableFormattingGeneric.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestFloodPublishing.cs
+++ b/projects/client/Unit/src/unit/TestFloodPublishing.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestHeartbeats.cs
+++ b/projects/client/Unit/src/unit/TestHeartbeats.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestIEndpointResolverExtensions.cs
+++ b/projects/client/Unit/src/unit/TestIEndpointResolverExtensions.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestInitialConnection.cs
+++ b/projects/client/Unit/src/unit/TestInitialConnection.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestIntAllocator.cs
+++ b/projects/client/Unit/src/unit/TestIntAllocator.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestInvalidAck.cs
+++ b/projects/client/Unit/src/unit/TestInvalidAck.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestMainLoop.cs
+++ b/projects/client/Unit/src/unit/TestMainLoop.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestMapMessage.cs
+++ b/projects/client/Unit/src/unit/TestMapMessage.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestMessageCount.cs
+++ b/projects/client/Unit/src/unit/TestMessageCount.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestMessagePatternsSubscription.cs
+++ b/projects/client/Unit/src/unit/TestMessagePatternsSubscription.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestMethodArgumentCodec.cs
+++ b/projects/client/Unit/src/unit/TestMethodArgumentCodec.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestModelShutdown.cs
+++ b/projects/client/Unit/src/unit/TestModelShutdown.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestNetworkBinaryCodec.cs
+++ b/projects/client/Unit/src/unit/TestNetworkBinaryCodec.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestNowait.cs
+++ b/projects/client/Unit/src/unit/TestNowait.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestPassiveDeclare.cs
+++ b/projects/client/Unit/src/unit/TestPassiveDeclare.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestPropertiesClone.cs
+++ b/projects/client/Unit/src/unit/TestPropertiesClone.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestPublicationAddress.cs
+++ b/projects/client/Unit/src/unit/TestPublicationAddress.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestPublisherConfirms.cs
+++ b/projects/client/Unit/src/unit/TestPublisherConfirms.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestQueueDeclare.cs
+++ b/projects/client/Unit/src/unit/TestQueueDeclare.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestRecoverAfterCancel.cs
+++ b/projects/client/Unit/src/unit/TestRecoverAfterCancel.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestSharedQueue.cs
+++ b/projects/client/Unit/src/unit/TestSharedQueue.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestSsl.cs
+++ b/projects/client/Unit/src/unit/TestSsl.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestStreamWireFormatting.cs
+++ b/projects/client/Unit/src/unit/TestStreamWireFormatting.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestSubscription.cs
+++ b/projects/client/Unit/src/unit/TestSubscription.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/TestTcpClientAdapter.cs
+++ b/projects/client/Unit/src/unit/TestTcpClientAdapter.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,

--- a/projects/client/Unit/src/unit/WireFormattingFixture.cs
+++ b/projects/client/Unit/src/unit/WireFormattingFixture.cs
@@ -10,7 +10,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//       https://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
## Proposed Changes

Dear Team,

my problem with the 5.1.1-rc1 rabbitmq.client Nuget package is that the assembly version is not correct. We install the the dll into the GAC and if the assembly version is the same the dll would not be changed. I need a Nuget package from the 5.1.1-rc1 version with the corrected version. 

Can you please provide me a new signed package with the changes. Please see the attached SC what has to be changed. 

It would be nice for the future that the Assembly- Package and File version has the same number.

Thanks in advice.

Br 
Milan
![RMQSetting](https://user-images.githubusercontent.com/32311493/63507788-d52d3300-c4d8-11e9-9a6b-80adf79add33.PNG)
