### PR TITLE
Fix for #648: ConnectOrFail TimeoutAfter fix

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
@@ -298,12 +298,12 @@ namespace RabbitMQ.Client.Impl
         {
             try
             {
-                Task.Run(() => socket.ConnectAsync(endpoint.HostName, endpoint.Port))
-                      .TimeoutAfter(timeout)
-                      .ConfigureAwait(false)
-                      // this ensures exceptions aren't wrapped in an AggregateException
-                      .GetAwaiter()
-                      .GetResult();
+               socket.ConnectAsync(endpoint.HostName, endpoint.Port)
+                    .TimeoutAfter(timeout)
+                    .ConfigureAwait(false)
+                    // this ensures exceptions aren't wrapped in an AggregateException
+                    .GetAwaiter()
+                    .GetResult();
             }
             catch (ArgumentException e)
             {

--- a/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
@@ -298,7 +298,7 @@ namespace RabbitMQ.Client.Impl
         {
             try
             {
-                socket.ConnectAsync(endpoint.HostName, endpoint.Port)
+                Task.Run(() => socket.ConnectAsync(endpoint.HostName, endpoint.Port))
                       .TimeoutAfter(timeout)
                       .ConfigureAwait(false)
                       // this ensures exceptions aren't wrapped in an AggregateException

--- a/projects/client/RabbitMQ.Client/src/client/impl/TcpClientAdapter.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/TcpClientAdapter.cs
@@ -35,7 +35,7 @@ namespace RabbitMQ.Client
 #if CORECLR
             await sock.ConnectAsync(ep, port).ConfigureAwait(false);
 #else
-            sock.Connect(ep, port);
+            await Task.Run(() => sock.Connect(ep, port));
 #endif
         }
 


### PR DESCRIPTION
## Proposed Changes

Actual connection timeout may vary significantly due to the use of `TimeoutAfter` in `ConnectOrFail`, I added `Task.Run` when calling `ConnectAsync` in order to permit `TimeoutAfter` to correctly raise the exception when needed.

Fixes #648 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
