### PR TITLE
Fix for #395: Added settable DefaultAddressFamily to force IPv4 or IPv6

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/AmqpTcpEndpoint.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/AmqpTcpEndpoint.cs
@@ -172,9 +172,17 @@ namespace RabbitMQ.Client
         }
 
         /// <summary>
+        /// Address family used by default.
+        /// Use <see cref="System.Net.Sockets.AddressFamily.InterNetwork" /> to force to IPv4.
+        /// Use <see cref="System.Net.Sockets.AddressFamily.InterNetworkV6" /> to force to IPv6.
+        /// Or use <see cref="System.Net.Sockets.AddressFamily.Unknown" /> to attempt both IPv6 and IPv4.
+        /// </summary>
+        public static System.Net.Sockets.AddressFamily DefaultAddressFamily { get; set; }
+
+        /// <summary>
         /// Used to force the address family of the endpoint
         /// </summary>
-        public System.Net.Sockets.AddressFamily AddressFamily {get; set;}
+        public System.Net.Sockets.AddressFamily AddressFamily { get; set; } = DefaultAddressFamily;
 
         /// <summary>
         /// Retrieve the SSL options for this AmqpTcpEndpoint. If not set, null is returned.

--- a/projects/client/RabbitMQ.Client/src/client/api/AmqpTcpEndpoint.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/AmqpTcpEndpoint.cs
@@ -172,17 +172,12 @@ namespace RabbitMQ.Client
         }
 
         /// <summary>
-        /// Address family used by default.
+        /// Used to force the address family of the endpoint.
         /// Use <see cref="System.Net.Sockets.AddressFamily.InterNetwork" /> to force to IPv4.
         /// Use <see cref="System.Net.Sockets.AddressFamily.InterNetworkV6" /> to force to IPv6.
         /// Or use <see cref="System.Net.Sockets.AddressFamily.Unknown" /> to attempt both IPv6 and IPv4.
         /// </summary>
-        public static System.Net.Sockets.AddressFamily DefaultAddressFamily { get; set; }
-
-        /// <summary>
-        /// Used to force the address family of the endpoint
-        /// </summary>
-        public System.Net.Sockets.AddressFamily AddressFamily { get; set; } = DefaultAddressFamily;
+        public System.Net.Sockets.AddressFamily AddressFamily { get; set; } = ConnectionFactory.DefaultAddressFamily;
 
         /// <summary>
         /// Retrieve the SSL options for this AmqpTcpEndpoint. If not set, null is returned.

--- a/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
@@ -161,6 +161,14 @@ namespace RabbitMQ.Client
         public IList<AuthMechanismFactory> AuthMechanisms { get; set; } = DefaultAuthMechanisms;
 
         /// <summary>
+        /// Address family used by default.
+        /// Use <see cref="System.Net.Sockets.AddressFamily.InterNetwork" /> to force to IPv4.
+        /// Use <see cref="System.Net.Sockets.AddressFamily.InterNetworkV6" /> to force to IPv6.
+        /// Or use <see cref="System.Net.Sockets.AddressFamily.Unknown" /> to attempt both IPv6 and IPv4.
+        /// </summary>
+        public static System.Net.Sockets.AddressFamily DefaultAddressFamily { get; set; }
+
+        /// <summary>
         /// Set to false to disable automatic connection recovery.
         /// Defaults to true.
         /// </summary>

--- a/projects/client/Unit/src/unit/APIApproval.Approve.approved.txt
+++ b/projects/client/Unit/src/unit/APIApproval.Approve.approved.txt
@@ -98,6 +98,7 @@ namespace RabbitMQ.Client
         public System.Collections.Generic.IDictionary<string, object> ClientProperties { get; set; }
         public string ClientProvidedName { get; set; }
         public System.TimeSpan ContinuationTimeout { get; set; }
+        public static System.Net.Sockets.AddressFamily DefaultAddressFamily { get; set; }
         public static System.Security.Authentication.SslProtocols DefaultAmqpUriSslProtocols { get; set; }
         public bool DispatchConsumersAsync { get; set; }
         public RabbitMQ.Client.AmqpTcpEndpoint Endpoint { get; set; }


### PR DESCRIPTION
## Proposed Changes

Currently, the RabbitMQ client first attempts to resolve the IPv6 address of the host, then if that fails, IPv4 is attempted.  In certain applications and environments, the consumer of the library knows that IPv6 will always fail.  So to reduce the DNS failure first chance exceptions, we needed a way to configure the default AddressFamily for all connections.

This fixes issue #395

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #395)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
