### PR TITLE
Deprecate messaging patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ TestResults.xml
 TestResult.xml
 /packages
 /.fake
+/.ionide
 .paket/*
 .paket/paket.exe
 /paket-files/*

--- a/projects/client/RabbitMQ.Client/src/client/messagepatterns/ISubscription.cs
+++ b/projects/client/RabbitMQ.Client/src/client/messagepatterns/ISubscription.cs
@@ -51,6 +51,7 @@ namespace RabbitMQ.Client.MessagePatterns
     /// for <see cref="Subscription" /> easier.
     ///</para>
     ///</remarks>
+    [Obsolete("Messaging patters are no longer recommended for use and will be removed.")]
     public interface ISubscription : IEnumerable, IEnumerator, IDisposable
     {
         void Ack();

--- a/projects/client/RabbitMQ.Client/src/client/messagepatterns/ISubscription.cs
+++ b/projects/client/RabbitMQ.Client/src/client/messagepatterns/ISubscription.cs
@@ -51,7 +51,7 @@ namespace RabbitMQ.Client.MessagePatterns
     /// for <see cref="Subscription" /> easier.
     ///</para>
     ///</remarks>
-    [Obsolete("Messaging patters are no longer recommended for use and will be removed.")]
+    [Obsolete("Messaging patterns are no longer recommended for use and will be removed.")]
     public interface ISubscription : IEnumerable, IEnumerator, IDisposable
     {
         void Ack();

--- a/projects/client/RabbitMQ.Client/src/client/messagepatterns/SimpleRpcClient.cs
+++ b/projects/client/RabbitMQ.Client/src/client/messagepatterns/SimpleRpcClient.cs
@@ -87,6 +87,7 @@ namespace RabbitMQ.Client.MessagePatterns
     ///</para>
     ///</remarks>
     ///<see cref="SimpleRpcServer"/>
+    [Obsolete("Messaging patters are no longer recommended for use and will be removed.")]
     public class SimpleRpcClient : IDisposable
     {
         ///<summary>Construct an instance with no configured

--- a/projects/client/RabbitMQ.Client/src/client/messagepatterns/SimpleRpcClient.cs
+++ b/projects/client/RabbitMQ.Client/src/client/messagepatterns/SimpleRpcClient.cs
@@ -87,7 +87,7 @@ namespace RabbitMQ.Client.MessagePatterns
     ///</para>
     ///</remarks>
     ///<see cref="SimpleRpcServer"/>
-    [Obsolete("Messaging patters are no longer recommended for use and will be removed.")]
+    [Obsolete("Messaging patterns are no longer recommended for use and will be removed.")]
     public class SimpleRpcClient : IDisposable
     {
         ///<summary>Construct an instance with no configured

--- a/projects/client/RabbitMQ.Client/src/client/messagepatterns/SimpleRpcServer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/messagepatterns/SimpleRpcServer.cs
@@ -113,6 +113,7 @@ namespace RabbitMQ.Client.MessagePatterns
     ///</para>
     ///</remarks>
     ///<see cref="SimpleRpcClient"/>
+    [Obsolete("Messaging patters are no longer recommended for use and will be removed.")]
     public class SimpleRpcServer : IDisposable
     {
         protected Subscription m_subscription;

--- a/projects/client/RabbitMQ.Client/src/client/messagepatterns/SimpleRpcServer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/messagepatterns/SimpleRpcServer.cs
@@ -113,7 +113,7 @@ namespace RabbitMQ.Client.MessagePatterns
     ///</para>
     ///</remarks>
     ///<see cref="SimpleRpcClient"/>
-    [Obsolete("Messaging patters are no longer recommended for use and will be removed.")]
+    [Obsolete("Messaging patterns are no longer recommended for use and will be removed.")]
     public class SimpleRpcServer : IDisposable
     {
         protected Subscription m_subscription;

--- a/projects/client/RabbitMQ.Client/src/client/messagepatterns/Subscription.cs
+++ b/projects/client/RabbitMQ.Client/src/client/messagepatterns/Subscription.cs
@@ -73,6 +73,7 @@ namespace RabbitMQ.Client.MessagePatterns
     /// called with the correct parameters.
     ///</para>
     ///</remarks>
+    [Obsolete("Messaging patters are no longer recommended for use and will be removed.")]
     public class Subscription : ISubscription
     {
         protected readonly object m_eventLock = new object();

--- a/projects/client/RabbitMQ.Client/src/client/messagepatterns/Subscription.cs
+++ b/projects/client/RabbitMQ.Client/src/client/messagepatterns/Subscription.cs
@@ -73,7 +73,7 @@ namespace RabbitMQ.Client.MessagePatterns
     /// called with the correct parameters.
     ///</para>
     ///</remarks>
-    [Obsolete("Messaging patters are no longer recommended for use and will be removed.")]
+    [Obsolete("Messaging patterns are no longer recommended for use and will be removed.")]
     public class Subscription : ISubscription
     {
         protected readonly object m_eventLock = new object();

--- a/projects/client/Unit/Unit.csproj
+++ b/projects/client/Unit/Unit.csproj
@@ -18,9 +18,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">


### PR DESCRIPTION
So they can be removed in 6.0

fixes: #514 
