### PR TITLE
Accept null as basic property value

### DIFF
--- a/projects/client/Apigen/src/apigen/Apigen.cs
+++ b/projects/client/Apigen/src/apigen/Apigen.cs
@@ -578,7 +578,15 @@ namespace RabbitMQ.Client.Apigen
                 EmitLine("      set {");
                 if (!IsBoolean(f))
                 {
-                    EmitLine("        m_" + MangleMethod(f.Name) + "_present = true;");
+                    if (IsReferenceType(f))
+                    {
+                        EmitLine("        m_" + MangleMethod(f.Name) + "_present = value != null;");
+
+                    }
+                    else
+                    {
+                        EmitLine("        m_" + MangleMethod(f.Name) + "_present = true;");
+                    }
                 }
                 EmitLine("        m_" + MangleMethod(f.Name) + " = value;");
                 EmitLine("      }");


### PR DESCRIPTION
## Proposed Changes

I ran into a problem when working with basic properties and setting properties of reference types to null.
The current implementation will set the "is present" value to `true` even though the value is null. This ends up throwing during the write to network, with a hard to understand `ArgumentNullException`. The motivation for this change is to spare time from folks that run into this problem. I also feel the API is friendlier if it would accept setting a property to null. If null should never be set it should then throw at the setter.

Example:
```C#
var basicProperties = model.CreateBasicProperties();
basicProperties.CorrelationId = null;

// sending a message with this basic properties will throw!

```

Stack trace:
```
Message: 
    System.ArgumentNullException : String reference not set to an instance of a String.
    Parameter name: s
  Stack Trace: 
    at Encoding.GetBytes(String s)
    at WireFormatting.WriteShortstr(NetworkBinaryWriter writer, String val) in WireFormatting.cs line: 389
    at ContentHeaderPropertyWriter.WriteShortstr(String val) in ContentHeaderPropertyWriter.cs line: 113
    at BasicProperties.WritePropertiesTo(ContentHeaderPropertyWriter writer) in autogenerated-api-0-9-1.cs line: 1055
```

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Since the implementation of the BasicProperties is code generated, the fix included in this PR changes slightly the generated code for properties. Properties of reference type will set the `is set` member variable only if the value being passed is not null.

I have executed the local tests with success, but I might be missing something. Please let me know.
