### PR TITLE
Multiple consumer tags per Consumer instance

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/events/AsyncEventingBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/AsyncEventingBasicConsumer.cs
@@ -28,14 +28,14 @@ namespace RabbitMQ.Client.Events
         public override async Task HandleBasicCancelOk(string consumerTag)
         {
             await base.HandleBasicCancelOk(consumerTag).ConfigureAwait(false);
-            await Raise(Unregistered, new ConsumerEventArgs(consumerTag)).ConfigureAwait(false);
+            await Raise(Unregistered, new ConsumerEventArgs(new []{consumerTag})).ConfigureAwait(false);
         }
 
         ///<summary>Fires the Registered event.</summary>
         public override async Task HandleBasicConsumeOk(string consumerTag)
         {
             await base.HandleBasicConsumeOk(consumerTag).ConfigureAwait(false);
-            await Raise(Registered, new ConsumerEventArgs(consumerTag)).ConfigureAwait(false);
+            await Raise(Registered, new ConsumerEventArgs(new[] { consumerTag })).ConfigureAwait(false);
         }
 
         ///<summary>Fires the Received event.</summary>

--- a/projects/client/RabbitMQ.Client/src/client/events/ConsumerEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/ConsumerEventArgs.cs
@@ -46,15 +46,15 @@ namespace RabbitMQ.Client.Events
     ///or cancellation.</summary>
     public class ConsumerEventArgs : EventArgs
     {
-        ///<summary>Construct an event containing the consumer-tag of
+        ///<summary>Construct an event containing the consumer-tags of
         ///the consumer the event relates to.</summary>
-        public ConsumerEventArgs(string consumerTag)
+        public ConsumerEventArgs(string[] consumerTags)
         {
-            ConsumerTag = consumerTag;
+            ConsumerTags = consumerTags;
         }
 
-        ///<summary>Access the consumer-tag of the consumer the event
+        ///<summary>Access the consumer-tags of the consumer the event
         ///relates to.</summary>
-        public string ConsumerTag { get; private set; }
+        public string[] ConsumerTags { get; private set; }
     }
 }

--- a/projects/client/RabbitMQ.Client/src/client/events/EventingBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/EventingBasicConsumer.cs
@@ -68,14 +68,14 @@ namespace RabbitMQ.Client.Events
         public override void HandleBasicCancelOk(string consumerTag)
         {
             base.HandleBasicCancelOk(consumerTag);
-            Raise(Unregistered, new ConsumerEventArgs(consumerTag));
+            Raise(Unregistered, new ConsumerEventArgs(new[] { consumerTag }));
         }
 
         ///<summary>Fires the Registered event.</summary>
         public override void HandleBasicConsumeOk(string consumerTag)
         {
             base.HandleBasicConsumeOk(consumerTag);
-            Raise(Registered, new ConsumerEventArgs(consumerTag));
+            Raise(Registered, new ConsumerEventArgs(new[] { consumerTag }));
         }
 
         ///<summary>Fires the Received event.</summary>


### PR DESCRIPTION
## Proposed Changes

We found that when using a single consumer to consume from multiple queues the `ConsumerTag` property would only contain the consumer tag from the last successful `BasicConsume`.

This caused two issues:
- It was not possible to get a list of all the consumer tags for a consumer
- When the `ConsumerCancelled` event is raised it can contain the wrong consumer tag

This change exposes a collection of consumer tags on the consumer object and also changes the `ConsumerCancelled` event args to include a collection of consumer tags

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

