### PR TITLE
Allow sending a data segment from a data buffer.

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/IBasicPublishBatch.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IBasicPublishBatch.cs
@@ -41,7 +41,7 @@ namespace RabbitMQ.Client
 {
     public interface IBasicPublishBatch
     {
-        void Add(string exchange, string routingKey, bool mandatory, IBasicProperties properties, byte[] body);
+        void Add(string exchange, string routingKey, bool mandatory, IBasicProperties properties, byte[] body, int start = 0, int len = -1);
         void Publish();
     }
 }

--- a/projects/client/RabbitMQ.Client/src/client/api/IModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IModel.cs
@@ -225,7 +225,7 @@ namespace RabbitMQ.Client
         /// </remarks>
         [AmqpMethodDoNotImplement(null)]
         void BasicPublish(string exchange, string routingKey, bool mandatory,
-            IBasicProperties basicProperties, byte[] body);
+            IBasicProperties basicProperties, byte[] body, int start, int len);
 
         /// <summary>
         /// Configures QoS parameters of the Basic content-class.

--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
@@ -573,7 +573,9 @@ namespace RabbitMQ.Client.Impl
             string routingKey,
             bool mandatory,
             IBasicProperties basicProperties,
-            byte[] body)
+            byte[] body, 
+            int start, 
+            int len)
         {
             if (routingKey == null)
             {
@@ -581,7 +583,7 @@ namespace RabbitMQ.Client.Impl
             }
 
             m_delegate._Private_BasicPublish(exchange, routingKey, mandatory,
-                basicProperties, body);
+                basicProperties, body, start, len);
         }
 
         public void _Private_BasicRecover(bool requeue)
@@ -808,7 +810,9 @@ namespace RabbitMQ.Client.Impl
             string routingKey,
             bool mandatory,
             IBasicProperties basicProperties,
-            byte[] body)
+            byte[] body, 
+            int start,
+            int len)
         {
             if (routingKey == null)
             {
@@ -819,7 +823,9 @@ namespace RabbitMQ.Client.Impl
                 routingKey,
                 mandatory,
                 basicProperties,
-                body);
+                body, 
+                start, 
+                len);
         }
 
         public void BasicQos(uint prefetchSize,

--- a/projects/client/RabbitMQ.Client/src/client/impl/BasicPublishBatch.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/BasicPublishBatch.cs
@@ -54,7 +54,7 @@ namespace RabbitMQ.Client.Impl
             this.model = model;
         }
 
-        public void Add(string exchange, string routingKey, bool mandatory, IBasicProperties basicProperties, byte[] body)
+        public void Add(string exchange, string routingKey, bool mandatory, IBasicProperties basicProperties, byte[] body, int start = 0, int len = -1)
         {
             var bp = basicProperties == null ? model.CreateBasicProperties() : basicProperties;
             var method = new BasicPublish
@@ -64,7 +64,7 @@ namespace RabbitMQ.Client.Impl
                 m_mandatory = mandatory
             };
 
-            commands.Add(new Command(method, (ContentHeaderBase)bp, body));
+            commands.Add(new Command(method, (ContentHeaderBase)bp, body, start, len));
         }
 
         public void Publish()

--- a/projects/client/RabbitMQ.Client/src/client/impl/CommandAssembler.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/CommandAssembler.cs
@@ -141,7 +141,8 @@ namespace RabbitMQ.Client.Impl
         {
             if (m_state == AssemblyState.Complete)
             {
-                Command result = new Command(m_method, m_header, m_body);
+                var len = m_body == null ? -1 : m_body.Length;
+                Command result = new Command(m_method, m_header, m_body, 0, len);
                 Reset();
                 return result;
             }

--- a/projects/client/RabbitMQ.Client/src/client/impl/IFullModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/IFullModel.cs
@@ -226,7 +226,9 @@ namespace RabbitMQ.Client.Impl
             string routingKey,
             bool mandatory,
             [AmqpContentHeaderMapping] IBasicProperties basicProperties,
-            [AmqpContentBodyMapping] byte[] body);
+            [AmqpContentBodyMapping] byte[] body,
+            [AmqpContentBodyStartMapping] int start,
+            [AmqpContentBodyLengthMapping] int len);
 
         [AmqpForceOneWay]
         [AmqpMethodMapping(null, "basic", "recover")]
@@ -556,7 +558,20 @@ namespace RabbitMQ.Client.Apigen.Attributes
     {
     }
 
+    ///<summary>This attribute, if placed on a parameter in a
+    ///content-carrying IModel method, causes it to be sent as part of
+    ///the content body frame start position.</summary>
+    public class AmqpContentBodyStartMappingAttribute : Attribute
+    {
+    }
 
+    ///<summary>This attribute, if placed on a parameter in a
+    ///content-carrying IModel method, causes it to be sent as part of
+    ///the content body frame length.</summary>
+    public class AmqpContentBodyLengthMappingAttribute : Attribute
+    {
+    }
+    
     ///<summary>This attribute, placed on an IModel method, causes
     ///what would normally be an RPC, sent with ModelRpc, to be sent
     ///as if it were oneway, with ModelSend. The assumption that this

--- a/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
@@ -464,26 +464,26 @@ namespace RabbitMQ.Client.Impl
                 m_continuationQueue.Next().HandleCommand(cmd);
         }
 
-        public MethodBase ModelRpc(MethodBase method, ContentHeaderBase header, byte[] body)
+        public MethodBase ModelRpc(MethodBase method, ContentHeaderBase header, byte[] body, int start, int len)
         {
             var k = new SimpleBlockingRpcContinuation();
             lock(_rpcLock)
             {
-                TransmitAndEnqueue(new Command(method, header, body), k);
+                TransmitAndEnqueue(new Command(method, header, body, start, len), k);
                 return k.GetReply(this.ContinuationTimeout).Method;
             }
         }
 
-        public void ModelSend(MethodBase method, ContentHeaderBase header, byte[] body)
+        public void ModelSend(MethodBase method, ContentHeaderBase header, byte[] body, int start, int len)
         {
             if (method.HasContent)
             {
                 m_flowControlBlock.WaitOne();
-                Session.Transmit(new Command(method, header, body));
+                Session.Transmit(new Command(method, header, body, start, len));
             }
             else
             {
-                Session.Transmit(new Command(method, header, body));
+                Session.Transmit(new Command(method, header, body, start, len));
             }
         }
 
@@ -1088,7 +1088,9 @@ namespace RabbitMQ.Client.Impl
             string routingKey,
             bool mandatory,
             IBasicProperties basicProperties,
-            byte[] body);
+            byte[] body, 
+            int start,
+            int len);
 
         public abstract void _Private_BasicRecover(bool requeue);
 
@@ -1278,7 +1280,9 @@ namespace RabbitMQ.Client.Impl
             string routingKey,
             bool mandatory,
             IBasicProperties basicProperties,
-            byte[] body)
+            byte[] body, 
+            int start,
+            int len)
         {
             if (routingKey == null)
             {
@@ -1304,7 +1308,9 @@ namespace RabbitMQ.Client.Impl
                 routingKey,
                 mandatory,
                 basicProperties,
-                body);
+                body, 
+                start,
+                len);
         }
 
         public abstract void BasicQos(uint prefetchSize,

--- a/projects/client/Unit/src/unit/APIApproval.Approve.approved.txt
+++ b/projects/client/Unit/src/unit/APIApproval.Approve.approved.txt
@@ -281,7 +281,7 @@ namespace RabbitMQ.Client
     }
     public interface IBasicPublishBatch
     {
-        void Add(string exchange, string routingKey, bool mandatory, RabbitMQ.Client.IBasicProperties properties, byte[] body);
+        void Add(string exchange, string routingKey, bool mandatory, RabbitMQ.Client.IBasicProperties properties, byte[] body, int start = 0, int len = -1);
         void Publish();
     }
     public interface IConnection : RabbitMQ.Client.NetworkConnection, System.IDisposable
@@ -383,7 +383,7 @@ namespace RabbitMQ.Client
         RabbitMQ.Client.BasicGetResult BasicGet(string queue, bool autoAck);
         void BasicNack(ulong deliveryTag, bool multiple, bool requeue);
         [RabbitMQ.Client.Apigen.Attributes.AmqpMethodDoNotImplementAttribute(null)]
-        void BasicPublish(string exchange, string routingKey, bool mandatory, RabbitMQ.Client.IBasicProperties basicProperties, byte[] body);
+        void BasicPublish(string exchange, string routingKey, bool mandatory, RabbitMQ.Client.IBasicProperties basicProperties, byte[] body, int start, int len);
         void BasicQos(uint prefetchSize, ushort prefetchCount, bool global);
         [RabbitMQ.Client.Apigen.Attributes.AmqpMethodDoNotImplementAttribute(null)]
         void BasicRecover(bool requeue);
@@ -635,9 +635,17 @@ namespace RabbitMQ.Client.Apigen.Attributes
     {
         public AmqpAsynchronousHandlerAttribute(string namespaceName) { }
     }
+    public class AmqpContentBodyLengthMappingAttribute : System.Attribute
+    {
+        public AmqpContentBodyLengthMappingAttribute() { }
+    }
     public class AmqpContentBodyMappingAttribute : System.Attribute
     {
         public AmqpContentBodyMappingAttribute() { }
+    }
+    public class AmqpContentBodyStartMappingAttribute : System.Attribute
+    {
+        public AmqpContentBodyStartMappingAttribute() { }
     }
     public class AmqpContentHeaderFactoryAttribute : System.Attribute
     {
@@ -1632,7 +1640,7 @@ namespace RabbitMQ.Client.Impl
     }
     public class BasicPublishBatch : RabbitMQ.Client.IBasicPublishBatch
     {
-        public void Add(string exchange, string routingKey, bool mandatory, RabbitMQ.Client.IBasicProperties basicProperties, byte[] body) { }
+        public void Add(string exchange, string routingKey, bool mandatory, RabbitMQ.Client.IBasicProperties basicProperties, byte[] body, int start = 0, int len = -1) { }
         public void Publish() { }
     }
     public class BodySegmentOutboundFrame : RabbitMQ.Client.Impl.OutboundFrame
@@ -1649,10 +1657,12 @@ namespace RabbitMQ.Client.Impl
     public class Command
     {
         public Command(RabbitMQ.Client.Impl.MethodBase method) { }
-        public Command(RabbitMQ.Client.Impl.MethodBase method, RabbitMQ.Client.Impl.ContentHeaderBase header, byte[] body) { }
+        public Command(RabbitMQ.Client.Impl.MethodBase method, RabbitMQ.Client.Impl.ContentHeaderBase header, byte[] body, int start, int len = -1) { }
         public byte[] Body { get; }
         public RabbitMQ.Client.Impl.ContentHeaderBase Header { get; }
+        public int Length { get; }
         public RabbitMQ.Client.Impl.MethodBase Method { get; }
+        public int Start { get; }
         public static System.Collections.Generic.List<RabbitMQ.Client.Impl.OutboundFrame> CalculateFrames(int channelNumber, RabbitMQ.Client.Framing.Impl.Connection connection, System.Collections.Generic.IList<RabbitMQ.Client.Impl.Command> commands) { }
         public static void CheckEmptyFrameSize() { }
         public void Transmit(int channelNumber, RabbitMQ.Client.Framing.Impl.Connection connection) { }
@@ -1844,7 +1854,7 @@ namespace RabbitMQ.Client.Impl
         [RabbitMQ.Client.Apigen.Attributes.AmqpMethodMappingAttribute(null, "basic", "get")]
         void _Private_BasicGet(string queue, [RabbitMQ.Client.Apigen.Attributes.AmqpFieldMappingAttribute(null, "noAck")] bool autoAck);
         [RabbitMQ.Client.Apigen.Attributes.AmqpMethodMappingAttribute(null, "basic", "publish")]
-        void _Private_BasicPublish(string exchange, string routingKey, bool mandatory, [RabbitMQ.Client.Apigen.Attributes.AmqpContentHeaderMappingAttribute()] RabbitMQ.Client.IBasicProperties basicProperties, [RabbitMQ.Client.Apigen.Attributes.AmqpContentBodyMappingAttribute()] byte[] body);
+        void _Private_BasicPublish(string exchange, string routingKey, bool mandatory, [RabbitMQ.Client.Apigen.Attributes.AmqpContentHeaderMappingAttribute()] RabbitMQ.Client.IBasicProperties basicProperties, [RabbitMQ.Client.Apigen.Attributes.AmqpContentBodyMappingAttribute()] byte[] body, [RabbitMQ.Client.Apigen.Attributes.AmqpContentBodyStartMappingAttribute()] int start, [RabbitMQ.Client.Apigen.Attributes.AmqpContentBodyLengthMappingAttribute()] int len);
         [RabbitMQ.Client.Apigen.Attributes.AmqpForceOneWayAttribute()]
         [RabbitMQ.Client.Apigen.Attributes.AmqpMethodMappingAttribute(null, "basic", "recover")]
         void _Private_BasicRecover(bool requeue);
@@ -2009,7 +2019,7 @@ namespace RabbitMQ.Client.Impl
         public string BasicConsume(string queue, bool autoAck, string consumerTag, bool noLocal, bool exclusive, System.Collections.Generic.IDictionary<string, object> arguments, RabbitMQ.Client.IBasicConsumer consumer) { }
         public RabbitMQ.Client.BasicGetResult BasicGet(string queue, bool autoAck) { }
         public abstract void BasicNack(ulong deliveryTag, bool multiple, bool requeue);
-        public void BasicPublish(string exchange, string routingKey, bool mandatory, RabbitMQ.Client.IBasicProperties basicProperties, byte[] body) { }
+        public void BasicPublish(string exchange, string routingKey, bool mandatory, RabbitMQ.Client.IBasicProperties basicProperties, byte[] body, int start, int len) { }
         public abstract void BasicQos(uint prefetchSize, ushort prefetchCount, bool global);
         public void BasicRecover(bool requeue) { }
         public abstract void BasicRecoverAsync(bool requeue);
@@ -2064,8 +2074,8 @@ namespace RabbitMQ.Client.Impl
         public void HandleQueueDeclareOk(string queue, uint messageCount, uint consumerCount) { }
         protected void Initialise(RabbitMQ.Client.Impl.ISession session) { }
         public uint MessageCount(string queue) { }
-        public RabbitMQ.Client.Impl.MethodBase ModelRpc(RabbitMQ.Client.Impl.MethodBase method, RabbitMQ.Client.Impl.ContentHeaderBase header, byte[] body) { }
-        public void ModelSend(RabbitMQ.Client.Impl.MethodBase method, RabbitMQ.Client.Impl.ContentHeaderBase header, byte[] body) { }
+        public RabbitMQ.Client.Impl.MethodBase ModelRpc(RabbitMQ.Client.Impl.MethodBase method, RabbitMQ.Client.Impl.ContentHeaderBase header, byte[] body, int start, int len) { }
+        public void ModelSend(RabbitMQ.Client.Impl.MethodBase method, RabbitMQ.Client.Impl.ContentHeaderBase header, byte[] body, int start, int len) { }
         public virtual void OnBasicAck(RabbitMQ.Client.Events.BasicAckEventArgs args) { }
         public virtual void OnBasicNack(RabbitMQ.Client.Events.BasicNackEventArgs args) { }
         public virtual void OnBasicRecoverOk(System.EventArgs args) { }
@@ -2097,7 +2107,7 @@ namespace RabbitMQ.Client.Impl
         public abstract void _Private_BasicCancel(string consumerTag, bool nowait);
         public abstract void _Private_BasicConsume(string queue, string consumerTag, bool noLocal, bool autoAck, bool exclusive, bool nowait, System.Collections.Generic.IDictionary<string, object> arguments);
         public abstract void _Private_BasicGet(string queue, bool autoAck);
-        public abstract void _Private_BasicPublish(string exchange, string routingKey, bool mandatory, RabbitMQ.Client.IBasicProperties basicProperties, byte[] body);
+        public abstract void _Private_BasicPublish(string exchange, string routingKey, bool mandatory, RabbitMQ.Client.IBasicProperties basicProperties, byte[] body, int start, int len);
         public abstract void _Private_BasicRecover(bool requeue);
         public abstract void _Private_ChannelClose(ushort replyCode, string replyText, ushort classId, ushort methodId);
         public abstract void _Private_ChannelCloseOk();


### PR DESCRIPTION
## Proposed Changes

Sending a part of a data buffer may improve the client performances. The users of the API can now use a larger buffer for data serialization and then they don't have to copy out the segment of that data in a new byte array, and they can pass the buffer to the API indicating the position and the Length of tha data in buffer.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [ ] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments


