### PR TITLE
Unit test to check consumer tag in ConsumerCancelled event

### DIFF
--- a/projects/client/Unit/src/unit/TestConsumerCancelNotify.cs
+++ b/projects/client/Unit/src/unit/TestConsumerCancelNotify.cs
@@ -64,6 +64,36 @@ namespace RabbitMQ.Client.Unit
             TestConsumerCancel("queue_consumer_cancel_event", true, ref notifiedEvent);
         }
 
+        [Test]
+        public void TestCorrectConsumerTag()
+        {
+            string q1 = GenerateQueueName();
+            string q2 = GenerateQueueName();
+
+            Model.QueueDeclare(q1, false, false, false, null);
+            Model.QueueDeclare(q2, false, false, false, null);
+
+            EventingBasicConsumer consumer = new EventingBasicConsumer(Model);
+            string consumerTag1 = Model.BasicConsume(q1, true, consumer);
+            string consumerTag2 = Model.BasicConsume(q2, true, consumer);
+
+            string notifiedConsumerTag = null;
+            consumer.ConsumerCancelled += (sender, args) =>
+            {
+                lock (lockObject)
+                {
+                    notifiedConsumerTag = args.ConsumerTag;
+                    Monitor.PulseAll(lockObject);
+                }
+            };
+
+            Model.QueueDelete(q1);
+            WaitOn(lockObject);
+            Assert.AreEqual(consumerTag1, notifiedConsumerTag);
+
+            Model.QueueDelete(q2);
+        }
+
         public void TestConsumerCancel(string queue, bool EventMode, ref bool notified)
         {
             Model.QueueDeclare(queue, false, true, false, null);


### PR DESCRIPTION
## Proposed Changes

As requested in #664 this test demonstrates the issue where the consumer tag in the `ConsumerCancelled` event is not as expected

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories