### PR TITLE
SslOption null protection

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/AmqpTcpEndpoint.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/AmqpTcpEndpoint.cs
@@ -68,6 +68,8 @@ namespace RabbitMQ.Client
         public const int UseDefaultPort = -1;
 
         private int _port;
+        
+        private SslOption _ssl;
 
         /// <summary>
         /// Creates a new instance of the <see cref="AmqpTcpEndpoint"/>.
@@ -79,7 +81,7 @@ namespace RabbitMQ.Client
         {
             HostName = hostName;
             _port = portOrMinusOne;
-            Ssl = ssl;
+            Ssl = ssl ?? new SslOption();
         }
 
         /// <summary>
@@ -182,7 +184,16 @@ namespace RabbitMQ.Client
         /// <summary>
         /// Retrieve the SSL options for this AmqpTcpEndpoint. If not set, null is returned.
         /// </summary>
-        public SslOption Ssl { get; set; }
+        public SslOption Ssl
+        {
+            get { return _ssl; }
+            set
+            {
+                if (_ssl == null)
+                    throw new ArgumentNullException("Ssl", "Ssl property must be and instance of SslOption (cannot be null)");
+                _ssl = value;
+            }
+        }
 
         /// <summary>
         /// Construct an instance from a protocol and an address in "hostname:port" format.

--- a/projects/client/RabbitMQ.Client/src/client/api/AmqpTcpEndpoint.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/AmqpTcpEndpoint.cs
@@ -182,7 +182,7 @@ namespace RabbitMQ.Client
         public System.Net.Sockets.AddressFamily AddressFamily { get; set; } = ConnectionFactory.DefaultAddressFamily;
 
         /// <summary>
-        /// Retrieve the SSL options for this AmqpTcpEndpoint. If not set, null is returned.
+        /// Retrieve the SSL options for this AmqpTcpEndpoint. If not set, a default SslOption instance is returned.
         /// </summary>
         public SslOption Ssl
         {
@@ -190,7 +190,7 @@ namespace RabbitMQ.Client
             set
             {
                 if (_ssl == null)
-                    throw new ArgumentNullException("Ssl", "Ssl property must be and instance of SslOption (cannot be null)");
+                    throw new ArgumentNullException("Ssl", "Ssl property must be an instance of SslOption (cannot be null)");
                 _ssl = value;
             }
         }


### PR DESCRIPTION
There are assumptions that the Ssl property will not be null. For example, ConnectionFactory.CreateConnection will fail to make an amqp connection if the Ssl property on the ConnectionFactory (which gets packged in an AmqpTcpEndpoint) is null due to an unprotected access of the Ssl.Enabled property when Ssl is null.