### PR TITLE
Added support for update-secret method to the Connection class

### DIFF
--- a/docs/specs/amqp0-9-1.stripped.xml
+++ b/docs/specs/amqp0-9-1.stripped.xml
@@ -176,6 +176,17 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <chassis name="server" implement="MUST"/>
       <chassis name="client" implement="MUST"/>
     </method>
+    <method name="update-secret" synchronous="1" index="70">
+      <chassis name="server" implement="MUST"/>
+      <chassis name="client" implement="MUST"/>
+      <response name="update-secret-ok"/>
+      <field name="new-secret" domain="longstr" />
+      <field name="reason" domain="shortstr" />
+    </method>
+    <method name="update-secret-ok" synchronous="1" index="71">
+      <chassis name="client" implement="MUST"/>
+      <chassis name="server" implement="MUST"/>
+    </method>
   </class>
   <class name="channel" handler="channel" index="20">
     <chassis name="server" implement="MUST"/>

--- a/docs/specs/amqp0-9-1.xml
+++ b/docs/specs/amqp0-9-1.xml
@@ -919,6 +919,29 @@
       <chassis name = "client" implement = "MUST" />
       <chassis name = "server" implement = "MUST" />
     </method>
+
+
+    <method name="update-secret" synchronous="1" index="70">
+      <doc>
+        Updates the secret used to authenticate this connection. 
+      </doc>
+
+      <chassis name="server" implement="MUST"/>
+      <chassis name="client" implement="MUST"/>
+      <response name="update-secret-ok"/>
+      <field name="new-secret" domain="longstr" />
+      <field name="reason" domain="shortstr" />
+    </method>
+
+    <method name="update-secret-ok" synchronous="1" index="71">
+      <doc>
+        This method confirms the updated secret is valid.
+      </doc>
+
+      <chassis name="client" implement="MUST"/>
+      <chassis name="server" implement="MUST"/>
+    </method>
+
   </class>
 
   <!-- ==  CHANNEL  ========================================================== -->

--- a/docs/specs/amqp0-9-1.xml
+++ b/docs/specs/amqp0-9-1.xml
@@ -920,7 +920,6 @@
       <chassis name = "server" implement = "MUST" />
     </method>
 
-
     <method name="update-secret" synchronous="1" index="70">
       <doc>
         Updates the secret used to authenticate this connection. 

--- a/projects/client/RabbitMQ.Client/src/client/api/IConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IConnection.cs
@@ -179,6 +179,15 @@ namespace RabbitMQ.Client
         event EventHandler<EventArgs> ConnectionUnblocked;
 
         /// <summary>
+        /// This method updates the secret used to authenticate this connection.
+        /// It is used when secrets have an expiration date and need to be renewed,
+        /// like OAuth 2 tokens.
+        /// </summary>
+        /// <param name="newSecret">The new secret.</param>
+        /// <param name="reason">The reason for the secret update.</param>
+        void UpdateSecret(string newSecret, string reason);
+
+        /// <summary>
         /// Abort this connection and all its channels.
         /// </summary>
         /// <remarks>

--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
@@ -575,6 +575,14 @@ namespace RabbitMQ.Client.Framing.Impl
             }
         }
 
+        ///<summary>API-side invocation of updating the secret.</summary>
+        public void UpdateSecret(string newSecret, string reason)
+        {
+            EnsureIsOpen();
+            m_delegate.UpdateSecret(newSecret, reason);
+            m_factory.Password = newSecret;
+        }
+
         ///<summary>API-side invocation of connection abort.</summary>
         public void Abort()
         {

--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
@@ -651,6 +651,11 @@ namespace RabbitMQ.Client.Impl
                 response, locale);
         }
 
+        public void _Private_UpdateSecret(byte[] newSecret, string reason)
+        {
+            m_delegate._Private_UpdateSecret(newSecret, reason);
+        }
+
         public void _Private_ExchangeBind(string destination,
             string source,
             string routingKey,
@@ -820,6 +825,12 @@ namespace RabbitMQ.Client.Impl
                 mandatory,
                 basicProperties,
                 body);
+        }
+
+        public void UpdateSecret(string newSecret, string reason)
+        {
+            m_delegate.BasicPublish(newSecret,
+                reason);
         }
 
         public void BasicQos(uint prefetchSize,

--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
@@ -827,12 +827,6 @@ namespace RabbitMQ.Client.Impl
                 body);
         }
 
-        public void UpdateSecret(string newSecret, string reason)
-        {
-            m_delegate.BasicPublish(newSecret,
-                reason);
-        }
-
         public void BasicQos(uint prefetchSize,
             ushort prefetchCount,
             bool global)

--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -1221,6 +1221,11 @@ entry.ToString());
             m_frameHandler.WriteFrameSet(f);
         }
 
+        public void UpdateSecret(string newSecret, string reason)
+        {
+            m_model0.UpdateSecret(newSecret, reason);
+        }
+
         ///<summary>API-side invocation of connection abort.</summary>
         public void Abort()
         {

--- a/projects/client/RabbitMQ.Client/src/client/impl/IFullModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/IFullModel.cs
@@ -299,6 +299,12 @@ namespace RabbitMQ.Client.Impl
             byte[] response,
             string locale);
 
+        ///<summary>Used to send a Conection.UpdateSecret method. Called by the
+        ///public UpdateSecret method.
+        ///</summary>
+        [AmqpMethodMapping(null, "connection", "update-secret")]
+        void _Private_UpdateSecret(byte[] newSecret, string reason);
+
         ///<summary>Used to send a Exchange.Bind method. Called by the
         ///public bind method.
         ///</summary>

--- a/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
@@ -47,6 +47,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 using System.Threading;
 
 #if (NETFX_CORE)
@@ -1123,6 +1124,10 @@ namespace RabbitMQ.Client.Impl
             byte[] response,
             string locale);
 
+        public abstract void _Private_UpdateSecret(
+            byte[] @newSecret,
+            string @reason);
+
         public abstract void _Private_ExchangeBind(string destination,
             string source,
             string routingKey,
@@ -1305,6 +1310,21 @@ namespace RabbitMQ.Client.Impl
                 mandatory,
                 basicProperties,
                 body);
+        }
+
+        public void UpdateSecret(string newSecret, string reason)
+        {
+            if (newSecret == null)
+            {
+                throw new ArgumentNullException(nameof(newSecret));
+            }
+
+            if (reason == null)
+            {
+                throw new ArgumentNullException(nameof(reason));
+            }
+
+            _Private_UpdateSecret(Encoding.UTF8.GetBytes(newSecret), reason);
         }
 
         public abstract void BasicQos(uint prefetchSize,

--- a/projects/client/Unit/src/unit/APIApproval.Approve.approved.txt
+++ b/projects/client/Unit/src/unit/APIApproval.Approve.approved.txt
@@ -321,6 +321,7 @@ namespace RabbitMQ.Client
         RabbitMQ.Client.IModel CreateModel();
         void HandleConnectionBlocked(string reason);
         void HandleConnectionUnblocked();
+        void UpdateSecret(string newSecret, string reason);
     }
     public interface IConnectionFactory
     {
@@ -1354,6 +1355,12 @@ namespace RabbitMQ.Client.Framing
         ushort Heartbeat { get; }
     }
     public interface IConnectionUnblocked : RabbitMQ.Client.IMethod { }
+    public interface IConnectionUpdateSecret : RabbitMQ.Client.IMethod
+    {
+        byte[] NewSecret { get; }
+        string Reason { get; }
+    }
+    public interface IConnectionUpdateSecretOk : RabbitMQ.Client.IMethod { }
     public interface IExchangeBind : RabbitMQ.Client.IMethod
     {
         System.Collections.Generic.IDictionary<string, object> Arguments { get; }
@@ -1544,6 +1551,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public void StartMainLoop(bool useBackgroundThread) { }
         public void TerminateMainloop() { }
         public override string ToString() { }
+        public void UpdateSecret(string newSecret, string reason) { }
         public void WriteFrame(RabbitMQ.Client.Impl.OutboundFrame f) { }
         public void WriteFrameSet(System.Collections.Generic.IList<RabbitMQ.Client.Impl.OutboundFrame> f) { }
     }
@@ -1896,6 +1904,8 @@ namespace RabbitMQ.Client.Impl
         [RabbitMQ.Client.Apigen.Attributes.AmqpMethodMappingAttribute(null, "queue", "purge")]
         [return: RabbitMQ.Client.Apigen.Attributes.AmqpFieldMappingAttribute(null, "messageCount")]
         uint _Private_QueuePurge(string queue, [RabbitMQ.Client.Apigen.Attributes.AmqpNowaitArgumentAttribute(null, "0xFFFFFFFF")] bool nowait);
+        [RabbitMQ.Client.Apigen.Attributes.AmqpMethodMappingAttribute(null, "connection", "update-secret")]
+        void _Private_UpdateSecret(byte[] newSecret, string reason);
     }
     public interface IRpcContinuation
     {
@@ -2094,6 +2104,7 @@ namespace RabbitMQ.Client.Impl
         public abstract void TxCommit();
         public abstract void TxRollback();
         public abstract void TxSelect();
+        public void UpdateSecret(string newSecret, string reason) { }
         public bool WaitForConfirms(System.TimeSpan timeout, out bool timedOut) { }
         public bool WaitForConfirms() { }
         public bool WaitForConfirms(System.TimeSpan timeout) { }
@@ -2122,6 +2133,7 @@ namespace RabbitMQ.Client.Impl
         public abstract void _Private_QueueDeclare(string queue, bool passive, bool durable, bool exclusive, bool autoDelete, bool nowait, System.Collections.Generic.IDictionary<string, object> arguments);
         public abstract uint _Private_QueueDelete(string queue, bool ifUnused, bool ifEmpty, bool nowait);
         public abstract uint _Private_QueuePurge(string queue, bool nowait);
+        public abstract void _Private_UpdateSecret(byte[] newSecret, string reason);
         protected virtual void handleAckNack(ulong deliveryTag, bool multiple, bool isNack) { }
         public class BasicConsumerRpcContinuation : RabbitMQ.Client.Impl.SimpleBlockingRpcContinuation
         {

--- a/projects/client/Unit/src/unit/Fixtures.cs
+++ b/projects/client/Unit/src/unit/Fixtures.cs
@@ -59,6 +59,7 @@ namespace RabbitMQ.Client.Unit
 
     public class IntegrationFixture
     {
+        internal IConnectionFactory ConnFactory;
         internal IConnection Conn;
         internal IModel Model;
 
@@ -68,8 +69,8 @@ namespace RabbitMQ.Client.Unit
         [SetUp]
         public virtual void Init()
         {
-            var connFactory = new ConnectionFactory();
-            Conn = connFactory.CreateConnection();
+            ConnFactory = new ConnectionFactory();
+            Conn = ConnFactory.CreateConnection();
             Model = Conn.CreateModel();
         }
 

--- a/projects/client/Unit/src/unit/TestUpdateSecret.cs
+++ b/projects/client/Unit/src/unit/TestUpdateSecret.cs
@@ -1,0 +1,57 @@
+// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 1.1.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2016 Pivotal Software, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       https://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v1.1:
+//
+//---------------------------------------------------------------------------
+//  The contents of this file are subject to the Mozilla Public License
+//  Version 1.1 (the "License"); you may not use this file except in
+//  compliance with the License. You may obtain a copy of the License
+//  at https://www.mozilla.org/MPL/
+//
+//  Software distributed under the License is distributed on an "AS IS"
+//  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+//  the License for the specific language governing rights and
+//  limitations under the License.
+//
+//  The Original Code is RabbitMQ.
+//
+//  The Initial Developer of the Original Code is Pivotal Software, Inc.
+//  Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+//---------------------------------------------------------------------------
+
+using NUnit.Framework;
+
+namespace RabbitMQ.Client.Unit
+{
+    [TestFixture]
+    public class TestUpdateSecret : IntegrationFixture
+    {
+
+        [Test]
+        public void TestUpdatingConnectionSecret()
+        {
+            this.Conn.UpdateSecret("new-secret", "Test Case");
+
+            Assert.AreEqual("new-secret", this.ConnFactory.Password);
+        }
+    }
+}

--- a/projects/client/Unit/src/unit/TestUpdateSecret.cs
+++ b/projects/client/Unit/src/unit/TestUpdateSecret.cs
@@ -39,19 +39,42 @@
 //---------------------------------------------------------------------------
 
 using NUnit.Framework;
+using System;
+using System.Text;
 
 namespace RabbitMQ.Client.Unit
 {
     [TestFixture]
-    public class TestUpdateSecret : IntegrationFixture
-    {
+    public class TestUpdateSecret : IntegrationFixture {
 
         [Test]
         public void TestUpdatingConnectionSecret()
         {
+            if (!this.RabbitMQ380OrHigher())
+            {
+                Console.WriteLine("Not connected to RabbitMQ 3.8 or higher, skipping test");
+                return;
+            }
+
             this.Conn.UpdateSecret("new-secret", "Test Case");
 
             Assert.AreEqual("new-secret", this.ConnFactory.Password);
+        }
+
+        private bool RabbitMQ380OrHigher()
+        {
+            var properties = this.Conn.ServerProperties;
+
+            if (properties.TryGetValue("version", out var versionVal))
+            {
+                var versionStr = Encoding.UTF8.GetString((byte[])versionVal);
+                if (Version.TryParse(versionStr, out var version))
+                {
+                    return version >= new Version(3, 8);
+                }
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

Support connection.update-secret in RabbitMQ.Client.

Background:
The AMQP 0-9-1 reference guide at https://www.rabbitmq.com/amqp-0-9-1-reference.html defines a method connection.update-secret. This method is intended to be used with authorization plugins like rabbitmq_auth_backend_oauth2. This plugin allows establishing a connection with a token rather than a password. Such tokens usually have an expiry timestamp and connections become unusable after this point. Using the method connection.update-secret, it is possible to supply a new token that has not yet expired without having to re-establish the connection. It would also allow updating permissions at this point. The plugin ships with RabbitMQ 3.8 and therefore it makes sense to support it within RabbitMQ.Client. 

Issue #672 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix
- [x] New feature
- [x] Breaking public interface change
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

