### PR TITLE
646 - Adding connection abort time span

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/IConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IConnection.cs
@@ -225,6 +225,21 @@ namespace RabbitMQ.Client
         /// timeout for all the in-progress close operations to complete.
         /// </summary>
         /// <remarks>
+        /// This method, behaves in a similar way as method <see cref="Abort()"/> with the
+        /// only difference that it explictly specifies a timeout given
+        /// for all the in-progress close operations to complete.
+        /// If timeout is reached and the close operations haven't finished, then socket is forced to close.
+        /// <para>
+        /// To wait infinitely for the close operations to complete use <see cref="Timeout.Infinite"/>.
+        /// </para>
+        /// </remarks>
+        void Abort(TimeSpan timeout);
+
+        /// <summary>
+        /// Abort this connection and all its channels and wait with a
+        /// timeout for all the in-progress close operations to complete.
+        /// </summary>
+        /// <remarks>
         /// The method behaves in the same way as <see cref="Abort(int)"/>, with the only
         /// difference that the connection is closed with the given connection close code and message.
         /// <para>
@@ -238,6 +253,22 @@ namespace RabbitMQ.Client
         /// </para>
         /// </remarks>
         void Abort(ushort reasonCode, string reasonText, int timeout);
+
+        /// <summary>
+        /// Abort this connection and all its channels and wait with a
+        /// timeout for all the in-progress close operations to complete.
+        /// </summary>
+        /// <remarks>
+        /// The method behaves in the same way as <see cref="Abort(TimeSpan)"/>, with the only
+        /// difference that the connection is closed with the given connection close code and message.
+        /// <para>
+        /// The close code (See under "Reply Codes" in the AMQP 0-9-1 specification).
+        /// </para>
+        /// <para>
+        /// A message indicating the reason for closing the connection.
+        /// </para>
+        /// </remarks>
+        void Abort(ushort reasonCode, string reasonText, TimeSpan timeout);
 
         /// <summary>
         /// Close this connection and all its channels.

--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
@@ -598,9 +598,25 @@ namespace RabbitMQ.Client.Framing.Impl
             if (m_delegate.IsOpen)
                 m_delegate.Abort(timeout);
         }
+        
+        ///<summary>API-side invocation of connection abort with timeout.</summary>
+        public void Abort(TimeSpan timeout)
+        {
+            StopRecoveryLoop();
+            if (m_delegate.IsOpen)
+                m_delegate.Abort(timeout);
+        }
 
         ///<summary>API-side invocation of connection abort with timeout.</summary>
         public void Abort(ushort reasonCode, string reasonText, int timeout)
+        {
+            StopRecoveryLoop();
+            if (m_delegate.IsOpen)
+                m_delegate.Abort(reasonCode, reasonText, timeout);
+        }
+        
+        ///<summary>API-side invocation of connection abort with timeout.</summary>
+        public void Abort(ushort reasonCode, string reasonText, TimeSpan timeout)
         {
             StopRecoveryLoop();
             if (m_delegate.IsOpen)

--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -1240,9 +1240,21 @@ entry.ToString());
         }
 
         ///<summary>API-side invocation of connection abort with timeout.</summary>
+        public void Abort(TimeSpan timeout)
+        {
+            Abort(Constants.ReplySuccess, "Connection close forced", timeout.Milliseconds);
+        }
+
+        ///<summary>API-side invocation of connection abort with timeout.</summary>
         public void Abort(ushort reasonCode, string reasonText, int timeout)
         {
             Abort(reasonCode, reasonText, ShutdownInitiator.Application, timeout);
+        }
+
+        ///<summary>API-side invocation of connection abort with timeout.</summary>
+        public void Abort(ushort reasonCode, string reasonText, TimeSpan timeout)
+        {
+            Abort(reasonCode, reasonText, ShutdownInitiator.Application, timeout.Milliseconds);
         }
 
         ///<summary>API-side invocation of connection.close.</summary>

--- a/projects/client/Unit/src/unit/APIApproval.Approve.approved.txt
+++ b/projects/client/Unit/src/unit/APIApproval.Approve.approved.txt
@@ -313,7 +313,9 @@ namespace RabbitMQ.Client
         void Abort();
         void Abort(ushort reasonCode, string reasonText);
         void Abort(int timeout);
+        void Abort(System.TimeSpan timeout);
         void Abort(ushort reasonCode, string reasonText, int timeout);
+        void Abort(ushort reasonCode, string reasonText, System.TimeSpan timeout);
         void Close();
         void Close(ushort reasonCode, string reasonText);
         void Close(int timeout);
@@ -1504,7 +1506,9 @@ namespace RabbitMQ.Client.Framing.Impl
         public void Abort() { }
         public void Abort(ushort reasonCode, string reasonText) { }
         public void Abort(int timeout) { }
+        public void Abort(System.TimeSpan timeout) { }
         public void Abort(ushort reasonCode, string reasonText, int timeout) { }
+        public void Abort(ushort reasonCode, string reasonText, System.TimeSpan timeout) { }
         public void Close(RabbitMQ.Client.ShutdownEventArgs reason) { }
         public void Close(RabbitMQ.Client.ShutdownEventArgs reason, bool abort, int timeout) { }
         public void Close() { }


### PR DESCRIPTION
## Proposed Changes

Adding Abort(TimeSpan) to the IConnection interface (with implementation in Connection and AutorecoveringConnection so users don't have to calculate minutes into milliseconds which makes for a bit of a nicer interface (as mentioned in issue #646)

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories
