### PR TITLE
DO NOT MERGE Reintroduce locking around socket writes

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/Command.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Command.cs
@@ -134,7 +134,10 @@ namespace RabbitMQ.Client.Impl
                 }
             }
 
-            connection.WriteFrameSet(frames);
+            // synchronise multi-frame writes as particularly risky
+            lock(connection.SocketWriteLock) {
+                connection.WriteFrameSet(frames);
+            }
         }
 
 

--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -66,6 +66,7 @@ namespace RabbitMQ.Client.Framing.Impl
     public class Connection : IConnection
     {
         private readonly object m_eventLock = new object();
+        private object m_socketWriteLock = new object();
 
         ///<summary>Heartbeat frame for transmission. Reusable across connections.</summary>
         private readonly EmptyOutboundFrame m_heartbeatFrame = new EmptyOutboundFrame();
@@ -271,6 +272,11 @@ namespace RabbitMQ.Client.Framing.Impl
                 }
             }
         }
+
+        public object SocketWriteLock {
+            get { return m_socketWriteLock; }
+        }
+
         public string ClientProvidedName { get; private set; }
 
         public ushort ChannelMax

--- a/projects/client/Unit/src/unit/APIApproval.Approve.approved.txt
+++ b/projects/client/Unit/src/unit/APIApproval.Approve.approved.txt
@@ -1503,6 +1503,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public int RemotePort { get; }
         public System.Collections.Generic.IDictionary<string, object> ServerProperties { get; set; }
         public System.Collections.Generic.IList<RabbitMQ.Client.ShutdownReportEntry> ShutdownReport { get; }
+        public object SocketWriteLock { get; }
         public event System.EventHandler<RabbitMQ.Client.Events.CallbackExceptionEventArgs> CallbackException;
         public event System.EventHandler<RabbitMQ.Client.Events.ConnectionBlockedEventArgs> ConnectionBlocked;
         public event System.EventHandler<RabbitMQ.Client.Events.ConnectionRecoveryErrorEventArgs> ConnectionRecoveryError;


### PR DESCRIPTION
This reintroduces locking around socket writes when transmitting multiple frames at once.

While changes in #350, #354 are supposed to be safe, there's some
evidence (#681) that sometimes they are not which leads to incorrect
byte stream interleaving on the wire.
