### PR TITLE
Re-introduce lock for all socket writes on a connection

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/Command.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Command.cs
@@ -134,10 +134,7 @@ namespace RabbitMQ.Client.Impl
                 }
             }
 
-            // synchronise multi-frame writes as particularly risky
-            lock(connection.SocketWriteLock) {
-                connection.WriteFrameSet(frames);
-            }
+            connection.WriteFrameSet(frames);
         }
 
 

--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -66,7 +66,6 @@ namespace RabbitMQ.Client.Framing.Impl
     public class Connection : IConnection
     {
         private readonly object m_eventLock = new object();
-        private object m_socketWriteLock = new object();
 
         ///<summary>Heartbeat frame for transmission. Reusable across connections.</summary>
         private readonly EmptyOutboundFrame m_heartbeatFrame = new EmptyOutboundFrame();
@@ -271,10 +270,6 @@ namespace RabbitMQ.Client.Framing.Impl
                     connectionRecoveryFailure -= value;
                 }
             }
-        }
-
-        public object SocketWriteLock {
-            get { return m_socketWriteLock; }
         }
 
         public string ClientProvidedName { get; private set; }

--- a/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
@@ -79,9 +79,8 @@ namespace RabbitMQ.Client.Impl
         private readonly ITcpClient m_socket;
         private readonly NetworkBinaryWriter m_writer;
         private readonly object _semaphore = new object();
-        private readonly object _sslStreamLock = new object();
+        private readonly object _streamLock = new object();
         private bool _closed;
-        private bool _ssl = false;
         public SocketFrameHandler(AmqpTcpEndpoint endpoint,
             Func<AddressFamily, ITcpClient> socketFactory,
             int connectionTimeout, int readTimeout, int writeTimeout)
@@ -112,7 +111,6 @@ namespace RabbitMQ.Client.Impl
                 try
                 {
                     netstream = SslHelper.TcpUpgrade(netstream, endpoint.Ssl);
-                    _ssl = true;
                 }
                 catch (Exception)
                 {
@@ -248,14 +246,7 @@ namespace RabbitMQ.Client.Impl
 
         private void Write(ArraySegment<byte> bufferSegment)
         {
-            if(_ssl)
-            {
-                lock (_sslStreamLock)
-                {
-                    m_writer.Write(bufferSegment.Array, bufferSegment.Offset, bufferSegment.Count);
-                }
-            }
-            else
+            lock (_streamLock)
             {
                 m_writer.Write(bufferSegment.Array, bufferSegment.Offset, bufferSegment.Count);
             }

--- a/projects/client/Unit/src/unit/APIApproval.Approve.approved.txt
+++ b/projects/client/Unit/src/unit/APIApproval.Approve.approved.txt
@@ -1503,7 +1503,6 @@ namespace RabbitMQ.Client.Framing.Impl
         public int RemotePort { get; }
         public System.Collections.Generic.IDictionary<string, object> ServerProperties { get; set; }
         public System.Collections.Generic.IList<RabbitMQ.Client.ShutdownReportEntry> ShutdownReport { get; }
-        public object SocketWriteLock { get; }
         public event System.EventHandler<RabbitMQ.Client.Events.CallbackExceptionEventArgs> CallbackException;
         public event System.EventHandler<RabbitMQ.Client.Events.ConnectionBlockedEventArgs> ConnectionBlocked;
         public event System.EventHandler<RabbitMQ.Client.Events.ConnectionRecoveryErrorEventArgs> ConnectionRecoveryError;


### PR DESCRIPTION
The official `NetworkStream` docs are confusing:

https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.networkstream?view=netframework-4.5.1

> Read and write operations can be performed simultaneously on an
instance of the NetworkStream class without the need for
synchronization. As long as there is one unique thread for the write
operations and one unique thread for the read operations, there will be
no cross-interference between read and write threads and no
synchronization is required.

This is a poorly-written way to say "multiple threads must be synchronized".

Fixes #681, references #350 and #354. Supersedes #682.