### PR TITLE
Added Serializable attribute to Exceptions classes

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/exceptions/AlreadyClosedException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/AlreadyClosedException.cs
@@ -38,11 +38,16 @@
 //  Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
+using System;
+
 namespace RabbitMQ.Client.Exceptions
 {
     /// <summary>Thrown when the application tries to make use of a
     /// session or connection that has already been shut
     /// down.</summary>
+#if !(NETSTANDARD1_5)
+    [Serializable]
+#endif
     public class AlreadyClosedException : OperationInterruptedException
     {
         ///<summary>Construct an instance containing the given

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/AuthenticationFailureException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/AuthenticationFailureException.cs
@@ -44,6 +44,9 @@ namespace RabbitMQ.Client.Exceptions
 {
     /// <summary> Thrown when the cause is  an
     /// authentication failure. </summary>
+#if !(NETSTANDARD1_5)
+    [Serializable]
+#endif
     public class AuthenticationFailureException : PossibleAuthenticationFailureException
     {
         public AuthenticationFailureException(String msg) : base(msg)

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/BrokerUnreachableException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/BrokerUnreachableException.cs
@@ -45,6 +45,9 @@ namespace RabbitMQ.Client.Exceptions
 {
     ///<summary>Thrown when no connection could be opened during a
     ///ConnectionFactory.CreateConnection attempt.</summary>
+#if !(NETSTANDARD1_5)
+    [Serializable]
+#endif
     public class BrokerUnreachableException : IOException
     {
         ///<summary>Construct a BrokerUnreachableException. The inner exception is

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/ChannelAllocationException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/ChannelAllocationException.cs
@@ -45,6 +45,9 @@ namespace RabbitMQ.Client.Exceptions
     /// <summary> Thrown when a SessionManager cannot allocate a new
     /// channel number, or the requested channel number is already in
     /// use. </summary>
+#if !(NETSTANDARD1_5)
+    [Serializable]
+#endif
     public class ChannelAllocationException : ProtocolViolationException
     {
         /// <summary>

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/ConnectFailureException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/ConnectFailureException.cs
@@ -43,6 +43,9 @@ using System;
 namespace RabbitMQ.Client.Exceptions
 {
     /// <summary>Thrown when a connection to the broker fails</summary>
+#if !(NETSTANDARD1_5)
+    [Serializable]
+#endif
     public class ConnectFailureException : ProtocolViolationException
     {
         public ConnectFailureException(String msg, Exception inner)

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/OperationInterruptedException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/OperationInterruptedException.cs
@@ -49,6 +49,9 @@ namespace RabbitMQ.Client.Exceptions
     /// operation, an OperationInterruptedException will be thrown to
     /// the caller of IModel.QueueDeclare.
     /// </summary>
+#if !(NETSTANDARD1_5)
+    [Serializable]
+#endif
     public class OperationInterruptedException
         // TODO: inherit from OperationCanceledException
         : RabbitMQClientException

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/PacketNotRecognizedException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/PacketNotRecognizedException.cs
@@ -39,7 +39,6 @@
 //---------------------------------------------------------------------------
 
 using System;
-using System.Net;
 
 namespace RabbitMQ.Client.Exceptions
 {
@@ -51,6 +50,9 @@ namespace RabbitMQ.Client.Exceptions
     ///The peer's {'A','M','Q','P',txHi,txLo,major,minor} packet is
     ///decoded into instances of this class.
     ///</remarks>
+#if !(NETSTANDARD1_5)
+    [Serializable]
+#endif
     public class PacketNotRecognizedException : RabbitMQClientException
     {
         ///<summary>Fills the new instance's properties with the values passed in.</summary>

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/PossibleAuthenticationFailureException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/PossibleAuthenticationFailureException.cs
@@ -44,6 +44,9 @@ namespace RabbitMQ.Client.Exceptions
 {
     /// <summary> Thrown when the likely cause is  an
     /// authentication failure. </summary>
+#if !(NETSTANDARD1_5)
+    [Serializable]
+#endif
     public class PossibleAuthenticationFailureException : RabbitMQClientException
     {
         public PossibleAuthenticationFailureException(String msg, Exception inner) : base(msg, inner)

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/ProtocolVersionMismatchException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/ProtocolVersionMismatchException.cs
@@ -39,13 +39,15 @@
 //---------------------------------------------------------------------------
 
 using System;
-using System.Net;
 
 namespace RabbitMQ.Client.Exceptions
 {
     ///<summary>Thrown to indicate that the peer does not support the
     ///wire protocol version we requested immediately after opening
     ///the TCP socket.</summary>
+#if !(NETSTANDARD1_5)
+    [Serializable]
+#endif
     public class ProtocolVersionMismatchException : ProtocolViolationException
     {
         ///<summary>Fills the new instance's properties with the values passed in.</summary>

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/ProtocolViolationException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/ProtocolViolationException.cs
@@ -43,6 +43,9 @@ using RabbitMQ.Client.Exceptions;
 
 namespace RabbitMQ.Client
 {
+#if !(NETSTANDARD1_5)
+    [Serializable]
+#endif
     public class ProtocolViolationException : RabbitMQClientException
     {
         public ProtocolViolationException(string message) : base(message)

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/RabbitMQClientException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/RabbitMQClientException.cs
@@ -1,4 +1,4 @@
-﻿// This source code is dual-licensed under the Apache License, version
+// This source code is dual-licensed under the Apache License, version
 // 2.0, and the Mozilla Public License, version 1.1.
 //
 // The APL v2.0:
@@ -42,6 +42,9 @@ using System;
 
 namespace RabbitMQ.Client.Exceptions
 {
+#if !(NETSTANDARD1_5)
+    [Serializable]
+#endif
     public abstract class RabbitMQClientException : Exception
     {
         /// <summary>Initializes a new instance of the <see cref="RabbitMQClientException" /> class.</summary>

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/UnexpectedMethodException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/UnexpectedMethodException.cs
@@ -45,6 +45,9 @@ namespace RabbitMQ.Client.Exceptions
     /// <summary>
     /// Thrown when the model receives an RPC reply that it wasn't expecting.
     /// </summary>
+#if !(NETSTANDARD1_5)
+    [Serializable]
+#endif
     public class UnexpectedMethodException : ProtocolViolationException
     {
         public UnexpectedMethodException(IMethod method)

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/UnsupportedMethodException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/UnsupportedMethodException.cs
@@ -45,6 +45,9 @@ namespace RabbitMQ.Client.Exceptions
     /// <summary>
     /// Thrown when the model receives an RPC request it cannot satisfy.
     /// </summary>
+#if !(NETSTANDARD1_5)
+    [Serializable]
+#endif
     public class UnsupportedMethodException : NotSupportedException
     {
         public UnsupportedMethodException(string methodName)

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/UnsupportedMethodFieldException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/UnsupportedMethodFieldException.cs
@@ -46,6 +46,9 @@ namespace RabbitMQ.Client.Exceptions
     /// because the version of the protocol the model is implementing
     /// does not contain a definition for the field in
     /// question.</summary>
+#if !(NETSTANDARD1_5)
+    [Serializable]
+#endif
     public class UnsupportedMethodFieldException : NotSupportedException
     {
         public UnsupportedMethodFieldException(string methodName, string fieldName)

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/WireFormattingException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/WireFormattingException.cs
@@ -39,12 +39,14 @@
 //---------------------------------------------------------------------------
 
 using System;
-using System.Net;
 
 namespace RabbitMQ.Client.Exceptions
 {
     /// <summary> Thrown when the wire-formatting code cannot encode a
     /// particular .NET value to AMQP protocol format.  </summary>
+#if !(NETSTANDARD1_5)
+    [Serializable]
+#endif
     public class WireFormattingException : ProtocolViolationException
     {
         ///<summary>Construct a WireFormattingException with no


### PR DESCRIPTION
## Proposed Changes
This is inline with [CA2237: Mark ISerializable types with SerializableAttribute](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2237?view=vs-2019) since the base class `Exception` inherits `ISerializable`.

Since the project targets netstandard1.5 the attribute had to be wrapped in a compiler directive to exclude it for the netstandard1.5 build.

fixes issue #684

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #684)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories