### PR TITLE
Handle use case of single consumer consuming from multiple queues

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/DefaultBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/DefaultBasicConsumer.cs
@@ -83,8 +83,10 @@ namespace RabbitMQ.Client
         }
 
         /// <summary>
-        /// Retrieve the consumer tags this consumer is registered as; to be used when discussing this consumer
-        /// with the server, for instance with <see cref="IModel.BasicCancel"/>.
+        /// Retrieve the consumer tags this consumer is registered as; to be used to identify
+        /// this consumer, for example, when cancelling it with <see cref="IModel.BasicCancel"/>.
+        /// This value is an array because a single consumer instance can be reused to consume on
+        /// multiple channels.
         /// </summary>
         public string[] ConsumerTags {
             get

--- a/projects/client/RabbitMQ.Client/src/client/events/AsyncEventingBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/AsyncEventingBasicConsumer.cs
@@ -28,14 +28,14 @@ namespace RabbitMQ.Client.Events
         public override async Task HandleBasicCancelOk(string consumerTag)
         {
             await base.HandleBasicCancelOk(consumerTag).ConfigureAwait(false);
-            await Raise(Unregistered, new ConsumerEventArgs(consumerTag)).ConfigureAwait(false);
+            await Raise(Unregistered, new ConsumerEventArgs(new []{consumerTag})).ConfigureAwait(false);
         }
 
         ///<summary>Fires the Registered event.</summary>
         public override async Task HandleBasicConsumeOk(string consumerTag)
         {
             await base.HandleBasicConsumeOk(consumerTag).ConfigureAwait(false);
-            await Raise(Registered, new ConsumerEventArgs(consumerTag)).ConfigureAwait(false);
+            await Raise(Registered, new ConsumerEventArgs(new[] { consumerTag })).ConfigureAwait(false);
         }
 
         ///<summary>Fires the Received event.</summary>

--- a/projects/client/RabbitMQ.Client/src/client/events/ConsumerEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/ConsumerEventArgs.cs
@@ -46,15 +46,15 @@ namespace RabbitMQ.Client.Events
     ///or cancellation.</summary>
     public class ConsumerEventArgs : EventArgs
     {
-        ///<summary>Construct an event containing the consumer-tag of
+        ///<summary>Construct an event containing the consumer-tags of
         ///the consumer the event relates to.</summary>
-        public ConsumerEventArgs(string consumerTag)
+        public ConsumerEventArgs(string[] consumerTags)
         {
-            ConsumerTag = consumerTag;
+            ConsumerTags = consumerTags;
         }
 
-        ///<summary>Access the consumer-tag of the consumer the event
+        ///<summary>Access the consumer-tags of the consumer the event
         ///relates to.</summary>
-        public string ConsumerTag { get; private set; }
+        public string[] ConsumerTags { get; private set; }
     }
 }

--- a/projects/client/RabbitMQ.Client/src/client/events/EventingBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/EventingBasicConsumer.cs
@@ -68,14 +68,14 @@ namespace RabbitMQ.Client.Events
         public override void HandleBasicCancelOk(string consumerTag)
         {
             base.HandleBasicCancelOk(consumerTag);
-            Raise(Unregistered, new ConsumerEventArgs(consumerTag));
+            Raise(Unregistered, new ConsumerEventArgs(new[] { consumerTag }));
         }
 
         ///<summary>Fires the Registered event.</summary>
         public override void HandleBasicConsumeOk(string consumerTag)
         {
             base.HandleBasicConsumeOk(consumerTag);
-            Raise(Registered, new ConsumerEventArgs(consumerTag));
+            Raise(Registered, new ConsumerEventArgs(new[] { consumerTag }));
         }
 
         ///<summary>Fires the Received event.</summary>

--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -956,7 +956,7 @@ entry.ToString());
 
         public void StartMainLoop(bool useBackgroundThread)
         {
-            _mainLoopTask = Task.Run(MainLoop);
+            _mainLoopTask = Task.Run((Action)MainLoop);
         }
 
         public void HeartbeatReadTimerCallback(object state)

--- a/projects/client/RabbitMQ.Client/src/client/impl/SessionManager.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SessionManager.cs
@@ -114,7 +114,7 @@ namespace RabbitMQ.Client.Impl
                         // we would suffer a deadlock as the connection thread 
                         // would be blocking waiting for its own mainloop
                         // to reply to it.
-                        Task.Run(AutoCloseConnection).Wait();
+                        Task.Run((Action)AutoCloseConnection).Wait();
                     }
                 }
             }

--- a/projects/client/Unit/src/unit/APIApproval.Approve.approved.txt
+++ b/projects/client/Unit/src/unit/APIApproval.Approve.approved.txt
@@ -42,7 +42,7 @@ namespace RabbitMQ.Client
     {
         public AsyncDefaultBasicConsumer() { }
         public AsyncDefaultBasicConsumer(RabbitMQ.Client.IModel model) { }
-        public string ConsumerTag { get; set; }
+        public string[] ConsumerTags { get; }
         public bool IsRunning { get; set; }
         public RabbitMQ.Client.IModel Model { get; set; }
         public RabbitMQ.Client.ShutdownEventArgs ShutdownReason { get; set; }
@@ -53,7 +53,7 @@ namespace RabbitMQ.Client
         public virtual System.Threading.Tasks.Task HandleBasicConsumeOk(string consumerTag) { }
         public virtual System.Threading.Tasks.Task HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, RabbitMQ.Client.IBasicProperties properties, byte[] body) { }
         public virtual System.Threading.Tasks.Task HandleModelShutdown(object model, RabbitMQ.Client.ShutdownEventArgs reason) { }
-        public virtual System.Threading.Tasks.Task OnCancel() { }
+        public virtual System.Threading.Tasks.Task OnCancel(params string[] consumerTags) { }
     }
     public interface AuthMechanism
     {
@@ -147,7 +147,7 @@ namespace RabbitMQ.Client
         public System.EventHandler<RabbitMQ.Client.Events.ConsumerEventArgs> m_consumerCancelled;
         public DefaultBasicConsumer() { }
         public DefaultBasicConsumer(RabbitMQ.Client.IModel model) { }
-        public string ConsumerTag { get; set; }
+        public string[] ConsumerTags { get; }
         public bool IsRunning { get; set; }
         public RabbitMQ.Client.IModel Model { get; set; }
         public RabbitMQ.Client.ShutdownEventArgs ShutdownReason { get; set; }
@@ -157,7 +157,7 @@ namespace RabbitMQ.Client
         public virtual void HandleBasicConsumeOk(string consumerTag) { }
         public virtual void HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, RabbitMQ.Client.IBasicProperties properties, byte[] body) { }
         public virtual void HandleModelShutdown(object model, RabbitMQ.Client.ShutdownEventArgs reason) { }
-        public virtual void OnCancel() { }
+        public virtual void OnCancel(params string[] consumerTags) { }
     }
     public class DefaultEndpointResolver : RabbitMQ.Client.IEndpointResolver
     {
@@ -1049,8 +1049,8 @@ namespace RabbitMQ.Client.Events
     }
     public class ConsumerEventArgs : System.EventArgs
     {
-        public ConsumerEventArgs(string consumerTag) { }
-        public string ConsumerTag { get; }
+        public ConsumerEventArgs(string[] consumerTags) { }
+        public string[] ConsumerTags { get; }
     }
     public sealed class ConsumerTagChangedAfterRecoveryEventArgs : System.EventArgs
     {

--- a/projects/client/Unit/src/unit/TestConsumerCancelNotify.cs
+++ b/projects/client/Unit/src/unit/TestConsumerCancelNotify.cs
@@ -41,6 +41,7 @@
 using NUnit.Framework;
 using RabbitMQ.Client.Events;
 using System;
+using System.Linq;
 using System.Threading;
 
 namespace RabbitMQ.Client.Unit
@@ -56,13 +57,13 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void TestConsumerCancelNotification()
         {
-            TestConsumerCancel("queue_consumer_cancel_notify", false, ref notifiedCallback, ref consumerTag);
+            TestConsumerCancel("queue_consumer_cancel_notify", false, ref notifiedCallback);
         }
 
         [Test]
         public void TestConsumerCancelEvent()
         {
-            TestConsumerCancel("queue_consumer_cancel_event", true, ref notifiedEvent, ref consumerTag);
+            TestConsumerCancel("queue_consumer_cancel_event", true, ref notifiedEvent);
         }
 
         [Test]
@@ -83,7 +84,7 @@ namespace RabbitMQ.Client.Unit
             {
                 lock (lockObject)
                 {
-                    notifiedConsumerTag = args.ConsumerTag;
+                    notifiedConsumerTag = args.ConsumerTags.First();
                     Monitor.PulseAll(lockObject);
                 }
             };


### PR DESCRIPTION
Supercedes #664 since I can't push to `Polystream:multiple-consumer-tags`
