### PR TITLE
Let operating system choose which TLS version to use

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
@@ -137,7 +137,7 @@ namespace RabbitMQ.Client
         /// TLS versions enabled by default: TLSv1.2, v1.1, v1.0.
         /// </summary>
         public static SslProtocols DefaultAmqpUriSslProtocols { get; set; } =
-            SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
+            SslProtocols.None;
 
         /// <summary>
         /// The AMQP URI SSL protocols.

--- a/projects/client/RabbitMQ.Client/src/client/api/SslOption.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/SslOption.cs
@@ -57,7 +57,7 @@ namespace RabbitMQ.Client
         /// </summary>
         public SslOption(string serverName, string certificatePath = "", bool enabled = false)
         {
-            Version = SslProtocols.Tls;
+            Version = SslProtocols.None;
             AcceptablePolicyErrors = SslPolicyErrors.None;
             ServerName = serverName;
             CertPath = certificatePath;

--- a/projects/client/Unit/src/unit/TestSsl.cs
+++ b/projects/client/Unit/src/unit/TestSsl.cs
@@ -145,7 +145,7 @@ namespace RabbitMQ.Client.Unit
                 Enabled = true,
             };
 
-            cf.Ssl.Version = SslProtocols.Tls;
+            cf.Ssl.Version = SslProtocols.None;
             cf.Ssl.AcceptablePolicyErrors = SslPolicyErrors.RemoteCertificateNotAvailable |
                                         SslPolicyErrors.RemoteCertificateNameMismatch;
 


### PR DESCRIPTION
This is the recommendation according to the official docs:

https://docs.microsoft.com/en-us/dotnet/api/system.security.authentication.sslprotocols?view=netcore-2.2