### PR TITLE
Backport change from #683 (Re-introduce lock for all socket writes on a connection) to 5.x branch

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
@@ -79,9 +79,8 @@ namespace RabbitMQ.Client.Impl
         private readonly ITcpClient m_socket;
         private readonly NetworkBinaryWriter m_writer;
         private readonly object _semaphore = new object();
-        private readonly object _sslStreamLock = new object();
+        private readonly object _streamLock = new object();
         private bool _closed;
-        private bool _ssl = false;
         public SocketFrameHandler(AmqpTcpEndpoint endpoint,
             Func<AddressFamily, ITcpClient> socketFactory,
             int connectionTimeout, int readTimeout, int writeTimeout)
@@ -112,7 +111,6 @@ namespace RabbitMQ.Client.Impl
                 try
                 {
                     netstream = SslHelper.TcpUpgrade(netstream, endpoint.Ssl);
-                    _ssl = true;
                 }
                 catch (Exception)
                 {
@@ -245,14 +243,7 @@ namespace RabbitMQ.Client.Impl
 
         private void Write(byte [] buffer)
         {
-            if(_ssl)
-            {
-                lock (_sslStreamLock)
-                {
-                    m_writer.Write(buffer);
-                }
-            }
-            else
+            lock (_streamLock)
             {
                 m_writer.Write(buffer);
             }


### PR DESCRIPTION
## Proposed Changes

This PR backports the change introduced in #683 to the 5.x branch.

We're running several services that may be affected by the problem in #681. These services are running on .NET Core 2.2, and we experienced the issue running on RHEL 7 (similar to other reports in that thread). We're currently using EasyNetQ atop the RabbitMQ client library, so upgrading to the 6.0 RC isn't currently feasible for us.

Because the troublesome locking behavior was introduced in 5.1, I'm requesting that this fix be backported to 5.x (and it would be _really really awesome_ if there was a way we could get a 5.1.3 patch release with this fix cherry-picked in, but we'll take what we can get).

## Types of Changes

What types of changes does your code introduce to this project?

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

(As a side note: I'm not sure the changes in #683 actually made it into master. That PR targeted the branch in #682, which appeared to have been deleted rather than merged.)