### PR TITLE
Code cleanups and fixing build warning.

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/IProtocol.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IProtocol.cs
@@ -94,13 +94,13 @@ namespace RabbitMQ.Client
         /// a frame handler, a client-provided name, and no automatic recovery.
         /// The "insist" parameter is passed on to the AMQP connection.open method.
         /// </summary>
-        IConnection CreateConnection(IConnectionFactory factory, bool insist, IFrameHandler frameHandler, String clientProvidedName);
+        IConnection CreateConnection(IConnectionFactory factory, bool insist, IFrameHandler frameHandler, string clientProvidedName);
 
         /// <summary>
         /// Construct a connection from a given set of parameters,
         /// a frame handler, a client-provided name, and automatic recovery settings.
         /// </summary>
-        IConnection CreateConnection(ConnectionFactory factory, IFrameHandler frameHandler, bool automaticRecoveryEnabled, String clientProvidedName);
+        IConnection CreateConnection(ConnectionFactory factory, IFrameHandler frameHandler, bool automaticRecoveryEnabled, string clientProvidedName);
 
         /// <summary>
         /// Construct a protocol model atop a given session.

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/AuthenticationFailureException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/AuthenticationFailureException.cs
@@ -49,7 +49,7 @@ namespace RabbitMQ.Client.Exceptions
 #endif
     public class AuthenticationFailureException : PossibleAuthenticationFailureException
     {
-        public AuthenticationFailureException(String msg) : base(msg)
+        public AuthenticationFailureException(string msg) : base(msg)
         {
         }
     }

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/ConnectFailureException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/ConnectFailureException.cs
@@ -48,7 +48,7 @@ namespace RabbitMQ.Client.Exceptions
 #endif
     public class ConnectFailureException : ProtocolViolationException
     {
-        public ConnectFailureException(String msg, Exception inner)
+        public ConnectFailureException(string msg, Exception inner)
             : base(msg, inner)
         {
         }

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/OperationInterruptedException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/OperationInterruptedException.cs
@@ -67,7 +67,7 @@ namespace RabbitMQ.Client.Exceptions
 
         ///<summary>Construct an OperationInterruptedException with
         ///the passed-in explanation and prefix, if any.</summary>
-        public OperationInterruptedException(ShutdownEventArgs reason, String prefix)
+        public OperationInterruptedException(ShutdownEventArgs reason, string prefix)
             : base(reason == null ? ($"{prefix}: The AMQP operation was interrupted") :
                 $"{prefix}: The AMQP operation was interrupted: {reason}")
         {

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/PossibleAuthenticationFailureException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/PossibleAuthenticationFailureException.cs
@@ -49,10 +49,10 @@ namespace RabbitMQ.Client.Exceptions
 #endif
     public class PossibleAuthenticationFailureException : RabbitMQClientException
     {
-        public PossibleAuthenticationFailureException(String msg, Exception inner) : base(msg, inner)
+        public PossibleAuthenticationFailureException(string msg, Exception inner) : base(msg, inner)
         {
         }
-        public PossibleAuthenticationFailureException(String msg) : base(msg)
+        public PossibleAuthenticationFailureException(string msg) : base(msg)
         {
         }
     }

--- a/projects/client/RabbitMQ.Client/src/client/exceptions/ProtocolVersionMismatchException.cs
+++ b/projects/client/RabbitMQ.Client/src/client/exceptions/ProtocolVersionMismatchException.cs
@@ -75,7 +75,7 @@ namespace RabbitMQ.Client.Exceptions
         ///<summary>The peer's AMQP specification minor version.</summary>
         public int ServerMinor { get; private set; }
 
-        private static String positiveOrUnknown(int version)
+        private static string positiveOrUnknown(int version)
         {
             return version >= 0 ? version.ToString() : "unknown";
         }

--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
@@ -747,7 +747,7 @@ namespace RabbitMQ.Client.Framing.Impl
                 }
                 catch (Exception cause)
                 {
-                    string s = String.Format("Caught an exception while recovering binding between {0} and {1}: {2}",
+                    string s = string.Format("Caught an exception while recovering binding between {0} and {1}: {2}",
                         b.Source, b.Destination, cause.Message);
                     HandleTopologyRecoveryException(new TopologyRecoveryException(s, cause));
                 }
@@ -844,7 +844,7 @@ namespace RabbitMQ.Client.Framing.Impl
                 }
                 catch (Exception cause)
                 {
-                    string s = String.Format("Caught an exception while recovering consumer {0} on queue {1}: {2}",
+                    string s = string.Format("Caught an exception while recovering consumer {0} on queue {1}: {2}",
                         tag, cons.Queue, cause.Message);
                     HandleTopologyRecoveryException(new TopologyRecoveryException(s, cause));
                 }
@@ -874,7 +874,7 @@ namespace RabbitMQ.Client.Framing.Impl
                 }
                 catch (Exception cause)
                 {
-                    string s = String.Format("Caught an exception while recovering exchange {0}: {1}",
+                    string s = string.Format("Caught an exception while recovering exchange {0}: {1}",
                         rx.Name, cause.Message);
                     HandleTopologyRecoveryException(new TopologyRecoveryException(s, cause));
                 }
@@ -940,7 +940,7 @@ namespace RabbitMQ.Client.Framing.Impl
                     }
                     catch (Exception cause)
                     {
-                        string s = String.Format("Caught an exception while recovering queue {0}: {1}",
+                        string s = string.Format("Caught an exception while recovering queue {0}: {1}",
                             oldName, cause.Message);
                         HandleTopologyRecoveryException(new TopologyRecoveryException(s, cause));
                     }

--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -587,7 +587,7 @@ namespace RabbitMQ.Client.Framing.Impl
             TerminateMainloop();
         }
 
-        public void LogCloseError(String error, Exception ex)
+        public void LogCloseError(string error, Exception ex)
         {
             ESLog.Error(error, ex);
             m_shutdownReport.Add(new ShutdownReportEntry(error, ex));
@@ -841,7 +841,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public void Open(bool insist)
         {
             StartAndTune();
-            m_model0.ConnectionOpen(m_factory.VirtualHost, String.Empty, false);
+            m_model0.ConnectionOpen(m_factory.VirtualHost, string.Empty, false);
         }
 
         public void PrettyPrintShutdownReport()
@@ -988,7 +988,7 @@ entry.ToString());
                     // of the heartbeat setting in setHeartbeat above.
                     if (m_missedHeartbeats > 2 * 4)
                     {
-                        String description = String.Format("Heartbeat missing with heartbeat == {0} seconds", m_heartbeat);
+                        string description = string.Format("Heartbeat missing with heartbeat == {0} seconds", m_heartbeat);
                         var eose = new EndOfStreamException(description);
                         ESLog.Error(description, eose);
                         m_shutdownReport.Add(new ShutdownReportEntry(description, eose));
@@ -1234,7 +1234,7 @@ entry.ToString());
             m_clientProperties["connection_name"] = this.ClientProvidedName;
 
             // FIXME: parse out locales properly!
-            ConnectionTuneDetails connectionTune = default(ConnectionTuneDetails);
+            ConnectionTuneDetails connectionTune = default;
             bool tuned = false;
             try
             {

--- a/projects/client/RabbitMQ.Client/src/client/impl/ExtensionMethods.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ExtensionMethods.cs
@@ -58,7 +58,7 @@ namespace RabbitMQ.Client.Impl
             var n = list.Count;
             if (n == 0)
             {
-                return default(T);
+                return default;
             }
 
             var hashCode = Math.Abs(Guid.NewGuid().GetHashCode());

--- a/projects/client/RabbitMQ.Client/src/client/impl/RecordedBinding.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RecordedBinding.cs
@@ -94,7 +94,7 @@ namespace RabbitMQ.Client.Impl
 
         public override string ToString()
         {
-            return String.Format("{0}: source = '{1}', destination = '{2}', routingKey = '{3}', arguments = '{4}'",
+            return string.Format("{0}: source = '{1}', destination = '{2}', routingKey = '{3}', arguments = '{4}'",
                 GetType().Name, Source, Destination, RoutingKey, Arguments);
         }
 

--- a/projects/client/RabbitMQ.Client/src/client/impl/RecordedExchange.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RecordedExchange.cs
@@ -67,7 +67,7 @@ namespace RabbitMQ.Client.Impl
 
         public override string ToString()
         {
-            return String.Format("{0}: name = '{1}', type = '{2}', durable = {3}, autoDelete = {4}, arguments = '{5}'",
+            return string.Format("{0}: name = '{1}', type = '{2}', durable = {3}, autoDelete = {4}, arguments = '{5}'",
                 GetType().Name, Name, type, Durable, IsAutoDelete, Arguments);
         }
 

--- a/projects/client/RabbitMQ.Client/src/client/impl/RecordedQueue.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RecordedQueue.cs
@@ -111,7 +111,7 @@ namespace RabbitMQ.Client.Impl
 
         public override string ToString()
         {
-            return String.Format("{0}: name = '{1}', durable = {2}, exlusive = {3}, autoDelete = {4}, arguments = '{5}'",
+            return string.Format("{0}: name = '{1}', durable = {2}, exlusive = {3}, autoDelete = {4}, arguments = '{5}'",
                 GetType().Name, Name, durable, exclusive, IsAutoDelete, arguments);
         }
     }

--- a/projects/client/RabbitMQ.Client/src/logging/RabbitMqExceptionDetail.cs
+++ b/projects/client/RabbitMQ.Client/src/logging/RabbitMqExceptionDetail.cs
@@ -80,7 +80,7 @@ namespace RabbitMQ.Client.Logging
 
         public override string ToString()
         {
-            return String.Format("Exception: {0}\r\n{1}\r\n\r\n{2}\r\nInnerException:\r\n{3}", Type, Message, StackTrace, InnerException);
+            return string.Format("Exception: {0}\r\n{1}\r\n\r\n{2}\r\nInnerException:\r\n{3}", Type, Message, StackTrace, InnerException);
         }
     }
 }

--- a/projects/client/RabbitMQ.Client/src/util/BlockingCell.cs
+++ b/projects/client/RabbitMQ.Client/src/util/BlockingCell.cs
@@ -56,7 +56,7 @@ namespace RabbitMQ.Util
     public class BlockingCell<T>
     {
         private readonly ManualResetEventSlim manualResetEventSlim = new ManualResetEventSlim(false);
-        private T m_value = default(T);
+        private T m_value = default;
         public EventHandler<T> ContinueUsingValue;
 
         public void ContinueWithValue(T value)

--- a/projects/client/RabbitMQ.Client/src/util/DebugUtil.cs
+++ b/projects/client/RabbitMQ.Client/src/util/DebugUtil.cs
@@ -100,7 +100,7 @@ namespace RabbitMQ.Util
         ///<remarks>Recurses into the value using DumpProperties().</remarks>
         public static void DumpKeyValue(string key, object value, TextWriter writer, int indent)
         {
-            string prefix = new String(' ', indent + 2) + key + ": ";
+            string prefix = new string(' ', indent + 2) + key + ": ";
             writer.Write(prefix);
             DumpProperties(value, writer, indent + 2);
         }

--- a/projects/client/RabbitMQ.Client/src/util/Either.cs
+++ b/projects/client/RabbitMQ.Client/src/util/Either.cs
@@ -73,13 +73,13 @@ namespace RabbitMQ.Util
         ///<summary>Constructs an Either instance representing a Left alternative.</summary>
         public static Either<L, R> Left(L value)
         {
-            return new Either<L, R>(EitherAlternative.Left, value, default(R));
+            return new Either<L, R>(EitherAlternative.Left, value, default);
         }
 
         ///<summary>Constructs an Either instance representing a Right alternative.</summary>
         public static Either<L, R> Right(R value)
         {
-            return new Either<L, R>(EitherAlternative.Right, default(L), value);
+            return new Either<L, R>(EitherAlternative.Right, default, value);
         }
     }
 }

--- a/projects/client/RabbitMQ.Client/src/util/SetQueue.cs
+++ b/projects/client/RabbitMQ.Client/src/util/SetQueue.cs
@@ -63,7 +63,7 @@ namespace RabbitMQ.Util
         {
             if (this.queue.Count == 0)
             {
-                return default(T);
+                return default;
             }
             T item = this.queue.First.Value;
             this.queue.RemoveFirst();

--- a/projects/client/RabbitMQ.Client/src/util/SharedQueue.cs
+++ b/projects/client/RabbitMQ.Client/src/util/SharedQueue.cs
@@ -153,7 +153,7 @@ namespace RabbitMQ.Util
                     TimeSpan remainingTime = timeout.Subtract(elapsedTime);
                     if (remainingTime <= TimeSpan.Zero)
                     {
-                        result = default(T);
+                        result = default;
                         return false;
                     }
 
@@ -259,7 +259,7 @@ namespace RabbitMQ.Util
         public SharedQueueEnumerator(SharedQueue<T> queue)
         {
             m_queue = queue;
-            m_current = default(T);
+            m_current = default;
         }
 
         object IEnumerator.Current
@@ -299,7 +299,7 @@ namespace RabbitMQ.Util
             }
             catch (EndOfStreamException)
             {
-                m_current = default(T);
+                m_current = default;
                 return false;
             }
         }

--- a/projects/client/RabbitMQ.Client/src/util/SynchronizedList.cs
+++ b/projects/client/RabbitMQ.Client/src/util/SynchronizedList.cs
@@ -57,7 +57,7 @@ namespace RabbitMQ.Util
         internal SynchronizedList(IList<T> list)
         {
             this.list = list;
-            root = new Object();
+            root = new object();
         }
 
         public int Count

--- a/projects/client/Unit/src/unit/APIApproval.cs
+++ b/projects/client/Unit/src/unit/APIApproval.cs
@@ -52,7 +52,7 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void Approve()
         {
-            var publicApi = ApiGenerator.GeneratePublicApi(typeof(ConnectionFactory).Assembly, excludeAttributes: new[] { "System.Runtime.Versioning.TargetFrameworkAttribute" });
+            var publicApi = typeof(ConnectionFactory).Assembly.GeneratePublicApi(new ApiGeneratorOptions { ExcludeAttributes = new[] { "System.Runtime.Versioning.TargetFrameworkAttribute" } });
             Approvals.Verify(publicApi);
         }
     }

--- a/projects/client/Unit/src/unit/Fixtures.cs
+++ b/projects/client/Unit/src/unit/Fixtures.cs
@@ -455,11 +455,11 @@ namespace RabbitMQ.Client.Unit
                 proc.StartInfo.RedirectStandardOutput = true;
 
                 proc.Start();
-                String stderr = proc.StandardError.ReadToEnd();
+                string stderr = proc.StandardError.ReadToEnd();
                 proc.WaitForExit();
                 if (stderr.Length >  0 || proc.ExitCode > 0)
                 {
-                    String stdout = proc.StandardOutput.ReadToEnd();
+                    string stdout = proc.StandardOutput.ReadToEnd();
                     ReportExecFailure("rabbitmqctl", args, stderr + "\n" + stdout);
                 }
 
@@ -512,11 +512,11 @@ namespace RabbitMQ.Client.Unit
               proc.StartInfo.RedirectStandardOutput = true;
 
               proc.Start();
-              String stderr = proc.StandardError.ReadToEnd();
+                string stderr = proc.StandardError.ReadToEnd();
               proc.WaitForExit();
               if (stderr.Length >  0 || proc.ExitCode > 0)
               {
-                  String stdout = proc.StandardOutput.ReadToEnd();
+                    string stdout = proc.StandardOutput.ReadToEnd();
                   ReportExecFailure(cmd, args, stderr + "\n" + stdout);
               }
 
@@ -529,7 +529,7 @@ namespace RabbitMQ.Client.Unit
             }
         }
 
-        internal void ReportExecFailure(String cmd, String args, String msg)
+        internal void ReportExecFailure(string cmd, string args, string msg)
         {
             Console.WriteLine("Failure while running " + cmd + " " + args + ":\n" + msg);
         }
@@ -599,7 +599,7 @@ namespace RabbitMQ.Client.Unit
         internal List<ConnectionInfo> ListConnections()
         {
             Process proc  = ExecRabbitMQCtl("list_connections --silent pid client_properties");
-            String stdout = proc.StandardOutput.ReadToEnd();
+            string stdout = proc.StandardOutput.ReadToEnd();
 
             try
             {

--- a/projects/client/Unit/src/unit/TestConnectionBlocked.cs
+++ b/projects/client/Unit/src/unit/TestConnectionBlocked.cs
@@ -48,7 +48,7 @@ namespace RabbitMQ.Client.Unit
     [TestFixture]
     public class TestConnectionBlocked : IntegrationFixture
     {
-        private readonly Object _lockObject = new Object();
+        private readonly object _lockObject = new object();
         private bool _notified;
 
         public void HandleBlocked(object sender, ConnectionBlockedEventArgs args)

--- a/projects/client/Unit/src/unit/TestConnectionRecovery.cs
+++ b/projects/client/Unit/src/unit/TestConnectionRecovery.cs
@@ -618,7 +618,7 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void TestRecoveryEventHandlersOnChannel()
         {
-            Int32 counter = 0;
+            int counter = 0;
             ((AutorecoveringModel)Model).Recovery += (source, ea) => Interlocked.Increment(ref counter);
 
             CloseAndWaitForRecovery();
@@ -631,7 +631,7 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void TestRecoveryEventHandlersOnConnection()
         {
-            Int32 counter = 0;
+            int counter = 0;
             ((AutorecoveringConnection)Conn).RecoverySucceeded += (source, ea) => Interlocked.Increment(ref counter);
 
             CloseAndWaitForRecovery();
@@ -646,7 +646,7 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void TestRecoveryEventHandlersOnModel()
         {
-            Int32 counter = 0;
+            int counter = 0;
             ((AutorecoveringModel)Model).Recovery += (source, ea) => Interlocked.Increment(ref counter);
 
             CloseAndWaitForRecovery();
@@ -715,7 +715,7 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void TestShutdownEventHandlersRecoveryOnConnection()
         {
-            Int32 counter = 0;
+            int counter = 0;
             Conn.ConnectionShutdown += (c, args) => Interlocked.Increment(ref counter);
 
             Assert.IsTrue(Conn.IsOpen);
@@ -731,7 +731,7 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void TestShutdownEventHandlersRecoveryOnConnectionAfterDelayedServerRestart()
         {
-            Int32 counter = 0;
+            int counter = 0;
             Conn.ConnectionShutdown += (c, args) => Interlocked.Increment(ref counter);
             ManualResetEvent shutdownLatch = PrepareForShutdown(Conn);
             ManualResetEvent recoveryLatch = PrepareForRecovery(((AutorecoveringConnection)Conn));
@@ -751,7 +751,7 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void TestShutdownEventHandlersRecoveryOnModel()
         {
-            Int32 counter = 0;
+            int counter = 0;
             Model.ModelShutdown += (c, args) => Interlocked.Increment(ref counter);
 
             Assert.IsTrue(Model.IsOpen);

--- a/projects/client/Unit/src/unit/TestConsumerCancelNotify.cs
+++ b/projects/client/Unit/src/unit/TestConsumerCancelNotify.cs
@@ -49,7 +49,7 @@ namespace RabbitMQ.Client.Unit
     [TestFixture]
     public class TestConsumerCancelNotify : IntegrationFixture
     {
-        protected readonly Object lockObject = new Object();
+        protected readonly object lockObject = new object();
         protected bool notifiedCallback;
         protected bool notifiedEvent;
         protected string consumerTag;

--- a/projects/client/Unit/src/unit/TestEventingConsumer.cs
+++ b/projects/client/Unit/src/unit/TestEventingConsumer.cs
@@ -92,7 +92,7 @@ namespace RabbitMQ.Client.Unit {
         public void TestEventingConsumerDeliveryEvents()
         {
             string q = Model.QueueDeclare();
-            object o = new Object ();
+            object o = new object();
 
             bool receivedInvoked = false;
             object receivedSender = null;

--- a/projects/client/Unit/src/unit/TestExtensions.cs
+++ b/projects/client/Unit/src/unit/TestExtensions.cs
@@ -52,7 +52,7 @@ namespace RabbitMQ.Client.Unit
             Model.ConfirmSelect();
             for (int i = 0; i < 10; i++)
             {
-                Model.BasicPublish("", String.Empty, null, new byte[] {});
+                Model.BasicPublish("", string.Empty, null, new byte[] {});
             }
             Assert.That(Model.WaitForConfirms(), Is.True);
         }
@@ -72,16 +72,16 @@ namespace RabbitMQ.Client.Unit
             Model.ExchangeDeclare("dest", ExchangeType.Direct, false, false, null);
             string queue = Model.QueueDeclare();
 
-            Model.ExchangeBind("dest", "src", String.Empty);
-            Model.ExchangeBind("dest", "src", String.Empty);
-            Model.QueueBind(queue, "dest", String.Empty);
+            Model.ExchangeBind("dest", "src", string.Empty);
+            Model.ExchangeBind("dest", "src", string.Empty);
+            Model.QueueBind(queue, "dest", string.Empty);
 
-            Model.BasicPublish("src", String.Empty, null, new byte[] {});
+            Model.BasicPublish("src", string.Empty, null, new byte[] {});
             Model.WaitForConfirms();
             Assert.IsNotNull(Model.BasicGet(queue, true));
 
-            Model.ExchangeUnbind("dest", "src", String.Empty);
-            Model.BasicPublish("src", String.Empty, null, new byte[] {});
+            Model.ExchangeUnbind("dest", "src", string.Empty);
+            Model.BasicPublish("src", string.Empty, null, new byte[] {});
             Model.WaitForConfirms();
             Assert.IsNull(Model.BasicGet(queue, true));
 

--- a/projects/client/Unit/src/unit/TestHeartbeats.cs
+++ b/projects/client/Unit/src/unit/TestHeartbeats.cs
@@ -156,7 +156,7 @@ namespace RabbitMQ.Client.Unit
             if (InitiatedByPeerOrLibrary(evt))
             {
                 Console.WriteLine(((Exception)evt.Cause).StackTrace);
-                var s = String.Format("Shutdown: {0}, initiated by: {1}",
+                var s = string.Format("Shutdown: {0}, initiated by: {1}",
                                       evt, evt.Initiator);
                 Console.WriteLine(s);
                 Assert.Fail(s);

--- a/projects/client/Unit/src/unit/TestInvalidAck.cs
+++ b/projects/client/Unit/src/unit/TestInvalidAck.cs
@@ -54,7 +54,7 @@ namespace RabbitMQ.Client.Unit {
         [Test]
         public void TestAckWithUnknownConsumerTagAndMultipleFalse()
         {
-            object o = new Object();
+            object o = new object();
             bool shutdownFired = false;
             ShutdownEventArgs shutdownArgs = null;
             Model.ModelShutdown += (s, args) =>

--- a/projects/client/Unit/src/unit/TestRecoverAfterCancel.cs
+++ b/projects/client/Unit/src/unit/TestRecoverAfterCancel.cs
@@ -59,7 +59,7 @@ namespace RabbitMQ.Client.Unit
     {
         IConnection Connection;
         IModel Channel;
-        String Queue;
+        string Queue;
         int callbackCount;
 
         public int ModelNumber(IModel model)
@@ -88,7 +88,7 @@ namespace RabbitMQ.Client.Unit
             SharedQueue<BasicDeliverEventArgs> EventQueue = new SharedQueue<BasicDeliverEventArgs>();
             Consumer.Received += (_, e) => EventQueue.Enqueue(e);
 
-            String CTag = Channel.BasicConsume(Queue, false, Consumer);
+            string CTag = Channel.BasicConsume(Queue, false, Consumer);
             BasicDeliverEventArgs Event = EventQueue.Dequeue();
             Channel.BasicCancel(CTag);
             Channel.BasicRecover(true);

--- a/projects/client/Unit/src/unit/TestSsl.cs
+++ b/projects/client/Unit/src/unit/TestSsl.cs
@@ -57,7 +57,7 @@ namespace RabbitMQ.Client.Unit
                 IModel ch = conn.CreateModel();
 
                 ch.ExchangeDeclare("Exchange_TestSslEndPoint", ExchangeType.Direct);
-                String qName = ch.QueueDeclare();
+                string qName = ch.QueueDeclare();
                 ch.QueueBind(qName, "Exchange_TestSslEndPoint", "Key_TestSslEndpoint", null);
 
                 string message = "Hello C# SSL Client World";


### PR DESCRIPTION
## Proposed Changes

More code cleanups to unify coding style, bringing it more in-line with standard .NET coding standards. Also fixing a build warning due to obsolete method being called.

* Fixing build warning for GeneratePublicApi.
* Simplifying "default" statements.
* Using default language types instead of CLR types.

**No public API changes are being made.**

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [X] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories