### PR TITLE
Code Cleanup: Make private fields readonly when possible

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/DefaultEndpointResolver.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/DefaultEndpointResolver.cs
@@ -46,8 +46,8 @@ namespace RabbitMQ.Client
 {
     public class DefaultEndpointResolver : IEndpointResolver
     {
-        private List<AmqpTcpEndpoint> _endpoints;
-        private Random _rnd = new Random();
+        private readonly List<AmqpTcpEndpoint> _endpoints;
+        private readonly Random _rnd = new Random();
 
         public DefaultEndpointResolver (IEnumerable<AmqpTcpEndpoint> tcpEndpoints)
         {

--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
@@ -56,7 +56,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         private readonly object _manuallyClosedLock = new object();
         private Connection _delegate;
-        private ConnectionFactory _factory;
+        private readonly ConnectionFactory _factory;
 
         // list of endpoints provided on initial connection.
         // on re-connection, the next host in the line is chosen using
@@ -65,20 +65,20 @@ namespace RabbitMQ.Client.Framing.Impl
 
         private readonly object _recordedEntitiesLock = new object();
 
-        private List<AutorecoveringModel> _models = new List<AutorecoveringModel>();
+        private readonly List<AutorecoveringModel> _models = new List<AutorecoveringModel>();
 
-        private ConcurrentDictionary<RecordedBinding, byte> _recordedBindings =
+        private readonly ConcurrentDictionary<RecordedBinding, byte> _recordedBindings =
             new ConcurrentDictionary<RecordedBinding, byte>();
 
         private EventHandler<ConnectionBlockedEventArgs> _recordedBlockedEventHandlers;
 
-        private IDictionary<string, RecordedConsumer> _recordedConsumers =
+        private readonly IDictionary<string, RecordedConsumer> _recordedConsumers =
             new ConcurrentDictionary<string, RecordedConsumer>();
 
-        private IDictionary<string, RecordedExchange> _recordedExchanges =
+        private readonly IDictionary<string, RecordedExchange> _recordedExchanges =
             new ConcurrentDictionary<string, RecordedExchange>();
 
-        private IDictionary<string, RecordedQueue> _recordedQueues =
+        private readonly IDictionary<string, RecordedQueue> _recordedQueues =
             new ConcurrentDictionary<string, RecordedQueue>();
 
         private EventHandler<ShutdownEventArgs> _recordedShutdownEventHandlers;

--- a/projects/client/RabbitMQ.Client/src/client/impl/BasicPublishBatch.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/BasicPublishBatch.cs
@@ -45,8 +45,8 @@ namespace RabbitMQ.Client.Impl
 {
     public class BasicPublishBatch : IBasicPublishBatch
     {
-        private List<Command> _commands = new List<Command>();
-        private ModelBase _model;
+        private readonly List<Command> _commands = new List<Command>();
+        private readonly ModelBase _model;
         internal BasicPublishBatch (ModelBase model)
         {
             _model = model;

--- a/projects/client/RabbitMQ.Client/src/client/impl/ConcurrentConsumerDispatcher.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ConcurrentConsumerDispatcher.cs
@@ -6,8 +6,8 @@ namespace RabbitMQ.Client.Impl
 {
     internal sealed class ConcurrentConsumerDispatcher : IConsumerDispatcher
     {
-        private ModelBase _model;
-        private ConsumerWorkService _workService;
+        private readonly ModelBase _model;
+        private readonly ConsumerWorkService _workService;
 
         public ConcurrentConsumerDispatcher(ModelBase model, ConsumerWorkService ws)
         {

--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -62,7 +62,7 @@ namespace RabbitMQ.Client.Framing.Impl
         ///<summary>Heartbeat frame for transmission. Reusable across connections.</summary>
         private readonly EmptyOutboundFrame _heartbeatFrame = new EmptyOutboundFrame();
 
-        private ManualResetEvent _appContinuation = new ManualResetEvent(false);
+        private readonly ManualResetEvent _appContinuation = new ManualResetEvent(false);
         private EventHandler<CallbackExceptionEventArgs> _callbackException;
         private EventHandler<EventArgs> _recoverySucceeded;
         private EventHandler<ConnectionRecoveryErrorEventArgs> _connectionRecoveryFailure;
@@ -76,16 +76,16 @@ namespace RabbitMQ.Client.Framing.Impl
         private EventHandler<ShutdownEventArgs> _connectionShutdown;
         private EventHandler<EventArgs> _connectionUnblocked;
 
-        private IConnectionFactory _factory;
-        private IFrameHandler _frameHandler;
+        private readonly IConnectionFactory _factory;
+        private readonly IFrameHandler _frameHandler;
 
         private Guid _id = Guid.NewGuid();
-        private ModelBase _model0;
+        private readonly ModelBase _model0;
         private volatile bool _running = true;
-        private MainSession _session0;
+        private readonly MainSession _session0;
         private SessionManager _sessionManager;
 
-        private IList<ShutdownReportEntry> _shutdownReport = new SynchronizedList<ShutdownReportEntry>(new List<ShutdownReportEntry>());
+        private readonly IList<ShutdownReportEntry> _shutdownReport = new SynchronizedList<ShutdownReportEntry>(new List<ShutdownReportEntry>());
 
         //
         // Heartbeats
@@ -97,11 +97,11 @@ namespace RabbitMQ.Client.Framing.Impl
 
         private Timer _heartbeatWriteTimer;
         private Timer _heartbeatReadTimer;
-        private AutoResetEvent _heartbeatRead = new AutoResetEvent(false);
+        private readonly AutoResetEvent _heartbeatRead = new AutoResetEvent(false);
 
         private Task _mainLoopTask;
 
-        private static string s_version = typeof(Connection).Assembly
+        private static readonly string s_version = typeof(Connection).Assembly
                                             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
                                             .InformationalVersion;
 

--- a/projects/client/RabbitMQ.Client/src/client/impl/MainSession.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/MainSession.cs
@@ -53,10 +53,10 @@ namespace RabbitMQ.Client.Impl
     {
         private readonly object _closingLock = new object();
 
-        private ushort _closeClassId;
-        private ushort _closeMethodId;
-        private ushort _closeOkClassId;
-        private ushort _closeOkMethodId;
+        private readonly ushort _closeClassId;
+        private readonly ushort _closeMethodId;
+        private readonly ushort _closeOkClassId;
+        private readonly ushort _closeOkMethodId;
 
         private bool _closeServerInitiated;
         private bool _closing;

--- a/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
@@ -64,8 +64,8 @@ namespace RabbitMQ.Client.Impl
         private TimeSpan _handshakeContinuationTimeout = TimeSpan.FromSeconds(10);
         private TimeSpan _continuationTimeout = TimeSpan.FromSeconds(20);
 
-        private RpcContinuationQueue _continuationQueue = new RpcContinuationQueue();
-        private ManualResetEvent _flowControlBlock = new ManualResetEvent(true);
+        private readonly RpcContinuationQueue _continuationQueue = new RpcContinuationQueue();
+        private readonly ManualResetEvent _flowControlBlock = new ManualResetEvent(true);
 
         private readonly object _eventLock = new object();
         private readonly object _flowSendLock = new object();

--- a/projects/client/RabbitMQ.Client/src/client/impl/Session.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Session.cs
@@ -45,7 +45,7 @@ namespace RabbitMQ.Client.Impl
     ///<summary>Normal ISession implementation used during normal channel operation.</summary>
     public class Session : SessionBase
     {
-        private CommandAssembler _assembler;
+        private readonly CommandAssembler _assembler;
 
         public Session(Connection connection, int channelNumber)
             : base(connection, channelNumber)

--- a/projects/client/RabbitMQ.Client/src/util/SetQueue.cs
+++ b/projects/client/RabbitMQ.Client/src/util/SetQueue.cs
@@ -44,8 +44,8 @@ namespace RabbitMQ.Util
 {
     public class SetQueue<T>
     {
-        private HashSet<T> _members = new HashSet<T>();
-        private LinkedList<T> _queue = new LinkedList<T>();
+        private readonly HashSet<T> _members = new HashSet<T>();
+        private readonly LinkedList<T> _queue = new LinkedList<T>();
 
         public bool Enqueue(T item)
         {

--- a/projects/client/Unit/src/unit/TestConsumerCancelNotify.cs
+++ b/projects/client/Unit/src/unit/TestConsumerCancelNotify.cs
@@ -109,8 +109,8 @@ namespace RabbitMQ.Client.Unit
 
         private class CancelNotificationConsumer : DefaultBasicConsumer
         {
-            private TestConsumerCancelNotify testClass;
-            private bool EventMode;
+            private readonly TestConsumerCancelNotify testClass;
+            private readonly bool EventMode;
 
             public CancelNotificationConsumer(IModel model, TestConsumerCancelNotify tc, bool EventMode)
                 : base(model)

--- a/projects/client/Unit/src/unit/TestConsumerOperationDispatch.cs
+++ b/projects/client/Unit/src/unit/TestConsumerOperationDispatch.cs
@@ -50,10 +50,10 @@ namespace RabbitMQ.Client.Unit
     [TestFixture]
     internal class TestConsumerOperationDispatch : IntegrationFixture
     {
-        private string x = "dotnet.tests.consumer-operation-dispatch.fanout";
-        private List<IModel> channels = new List<IModel>();
-        private List<string> queues = new List<string>();
-        private List<CollectingConsumer> consumers = new List<CollectingConsumer>();
+        private readonly string x = "dotnet.tests.consumer-operation-dispatch.fanout";
+        private readonly List<IModel> channels = new List<IModel>();
+        private readonly List<string> queues = new List<string>();
+        private readonly List<CollectingConsumer> consumers = new List<CollectingConsumer>();
 
         // number of channels (and consumers)
         private const int y = 100;

--- a/projects/client/Unit/src/unit/TestIEndpointResolverExtensions.cs
+++ b/projects/client/Unit/src/unit/TestIEndpointResolverExtensions.cs
@@ -46,7 +46,7 @@ namespace RabbitMQ.Client.Unit
 {
     public class TestEndpointResolver : IEndpointResolver
     {
-        private IEnumerable<AmqpTcpEndpoint> endpoints;
+        private readonly IEnumerable<AmqpTcpEndpoint> endpoints;
         public TestEndpointResolver (IEnumerable<AmqpTcpEndpoint> endpoints)
         {
             this.endpoints = endpoints;


### PR DESCRIPTION
## Proposed Changes

This PR makes private fields `readonly` when they are only ever set during constructors or initialization. This should **only** apply to private/internal fields (to maintain API compatibility). This also makes it a more conscious decision to mutate the state of internal fields.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [X] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories