### PR TITLE
Code Cleanup: Use explicit types when type is not apparent

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/AsyncDefaultBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/AsyncDefaultBasicConsumer.cs
@@ -138,7 +138,7 @@ namespace RabbitMQ.Client
         public virtual async Task OnCancel(params string[] consumerTags)
         {
             IsRunning = false;
-            var handler = ConsumerCancelled;
+            AsyncEventHandler<ConsumerEventArgs> handler = ConsumerCancelled;
             if (handler != null)
             {
                 foreach (AsyncEventHandler<ConsumerEventArgs> h in handler.GetInvocationList())

--- a/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
@@ -336,7 +336,7 @@ namespace RabbitMQ.Client
             // Our list is in order of preference, the server one is not.
             foreach (AuthMechanismFactory factory in AuthMechanisms)
             {
-                var factoryName = factory.Name;
+                string factoryName = factory.Name;
                 if (mechanismNames.Any<string>(x => string.Equals(x, factoryName, StringComparison.OrdinalIgnoreCase)))
                 {
                     return factory;
@@ -418,7 +418,7 @@ namespace RabbitMQ.Client
         /// </exception>
         public IConnection CreateConnection(IList<string> hostnames, string clientProvidedName)
         {
-            var endpoints = hostnames.Select(h => new AmqpTcpEndpoint(h, Port, Ssl));
+            IEnumerable<AmqpTcpEndpoint> endpoints = hostnames.Select(h => new AmqpTcpEndpoint(h, Port, Ssl));
             return CreateConnection(new DefaultEndpointResolver(endpoints), clientProvidedName);
         }
 
@@ -507,14 +507,14 @@ namespace RabbitMQ.Client
 
         private IFrameHandler CreateFrameHandler()
         {
-            var fh = Protocols.DefaultProtocol.CreateFrameHandler(Endpoint, SocketFactory,
+            IFrameHandler fh = Protocols.DefaultProtocol.CreateFrameHandler(Endpoint, SocketFactory,
                 RequestedConnectionTimeout, SocketReadTimeout, SocketWriteTimeout);
             return ConfigureFrameHandler(fh);
         }
 
         internal IFrameHandler CreateFrameHandler(AmqpTcpEndpoint endpoint)
         {
-            var fh = Protocols.DefaultProtocol.CreateFrameHandler(endpoint, SocketFactory,
+            IFrameHandler fh = Protocols.DefaultProtocol.CreateFrameHandler(endpoint, SocketFactory,
                 RequestedConnectionTimeout, SocketReadTimeout, SocketWriteTimeout);
             return ConfigureFrameHandler(fh);
         }

--- a/projects/client/RabbitMQ.Client/src/client/api/IEndpointResolverExtensions.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/IEndpointResolverExtensions.cs
@@ -49,7 +49,7 @@ namespace RabbitMQ.Client
         {
             var t = default(T);
             var exceptions = new List<Exception>();
-            foreach(var ep in resolver.All())
+            foreach(AmqpTcpEndpoint ep in resolver.All())
             {
                 try
                 {

--- a/projects/client/RabbitMQ.Client/src/client/content/MapMessageBuilder.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/MapMessageBuilder.cs
@@ -84,7 +84,7 @@ namespace RabbitMQ.Client.Content
         public override byte[] GetContentBody()
         {
             MapWireFormatting.WriteMap(Writer, Body);
-            var res = base.GetContentBody();
+            byte[] res = base.GetContentBody();
             Body = null;
             return res;
         }

--- a/projects/client/RabbitMQ.Client/src/client/events/AsyncEventingBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/AsyncEventingBasicConsumer.cs
@@ -73,7 +73,7 @@ namespace RabbitMQ.Client.Events
         private Task Raise<TEvent>(AsyncEventHandler<TEvent> eventHandler, TEvent evt) 
             where TEvent : EventArgs
         {
-            var handler = eventHandler;
+            AsyncEventHandler<TEvent> handler = eventHandler;
             if (handler != null)
             {
                 return handler(this, evt);

--- a/projects/client/RabbitMQ.Client/src/client/events/CallbackExceptionEventArgs.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/CallbackExceptionEventArgs.cs
@@ -61,7 +61,7 @@ namespace RabbitMQ.Client.Events
 
         public IDictionary<string, object> UpdateDetails(IDictionary<string, object> other)
         {
-            foreach (var pair in other)
+            foreach (KeyValuePair<string, object> pair in other)
             {
                 Detail[pair.Key] = pair.Value;
             }

--- a/projects/client/RabbitMQ.Client/src/client/events/EventingBasicConsumer.cs
+++ b/projects/client/RabbitMQ.Client/src/client/events/EventingBasicConsumer.cs
@@ -112,7 +112,7 @@ namespace RabbitMQ.Client.Events
 
         private void Raise<TEvent>(EventHandler<TEvent> eventHandler, TEvent evt)
         {
-            var handler = eventHandler;
+            EventHandler<TEvent> handler = eventHandler;
             if(handler != null)
             {
                 handler(this, evt);

--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
@@ -413,8 +413,8 @@ namespace RabbitMQ.Client.Framing.Impl
 
                 // find bindings that need removal, check if some auto-delete exchanges
                 // might need the same
-                var bs = _recordedBindings.Keys.Where(b => name.Equals(b.Destination));
-                foreach (var b in bs)
+                IEnumerable<RecordedBinding> bs = _recordedBindings.Keys.Where(b => name.Equals(b.Destination));
+                foreach (RecordedBinding b in bs)
                 {
                     DeleteRecordedBinding(b);
                     MaybeDeleteRecordedAutoDeleteExchange(b.Source);
@@ -429,8 +429,8 @@ namespace RabbitMQ.Client.Framing.Impl
                 _recordedQueues.Remove(name);
                 // find bindings that need removal, check if some auto-delete exchanges
                 // might need the same
-                var bs = _recordedBindings.Keys.Where(b => name.Equals(b.Destination));
-                foreach (var b in bs)
+                IEnumerable<RecordedBinding> bs = _recordedBindings.Keys.Where(b => name.Equals(b.Destination));
+                foreach (RecordedBinding b in bs)
                 {
                     DeleteRecordedBinding(b);
                     MaybeDeleteRecordedAutoDeleteExchange(b.Source);
@@ -541,7 +541,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public void Init(IEndpointResolver endpoints)
         {
             _endpoints = endpoints;
-            var fh = endpoints.SelectOne(_factory.CreateFrameHandler);
+            IFrameHandler fh = endpoints.SelectOne(_factory.CreateFrameHandler);
             Init(fh);
         }
 
@@ -714,7 +714,7 @@ namespace RabbitMQ.Client.Framing.Impl
         {
             lock (_recordedBindings)
             {
-                var bs = _recordedBindings.Keys.Where(b => b.Destination.Equals(oldName));
+                IEnumerable<RecordedBinding> bs = _recordedBindings.Keys.Where(b => b.Destination.Equals(oldName));
                 foreach (RecordedBinding b in bs)
                 {
                     b.Destination = newName;
@@ -737,7 +737,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         private void RecoverBindings()
         {
-            foreach (var b in _recordedBindings.Keys)
+            foreach (RecordedBinding b in _recordedBindings.Keys)
             {
                 try
                 {
@@ -764,7 +764,7 @@ namespace RabbitMQ.Client.Framing.Impl
         {
             try
             {
-                var fh = _endpoints.SelectOne(_factory.CreateFrameHandler);
+                IFrameHandler fh = _endpoints.SelectOne(_factory.CreateFrameHandler);
                 _delegate = new Connection(_factory, false, fh, ClientProvidedName);
                 return true;
             }
@@ -772,7 +772,7 @@ namespace RabbitMQ.Client.Framing.Impl
             {
                 ESLog.Error("Connection recovery exception.", e);
                 // Trigger recovery error events
-                var handler = _connectionRecoveryError;
+                EventHandler<ConnectionRecoveryErrorEventArgs> handler = _connectionRecoveryError;
                 if (handler != null)
                 {
                     var args = new ConnectionRecoveryErrorEventArgs(e);
@@ -1015,7 +1015,7 @@ namespace RabbitMQ.Client.Framing.Impl
         {
             try
             {
-                while (_recoveryLoopCommandQueue.TryTake(out var command, -1, _recoveryCancellationToken.Token))
+                while (_recoveryLoopCommandQueue.TryTake(out RecoveryCommand command, -1, _recoveryCancellationToken.Token))
                 {
                     switch (_recoveryLoopState)
                     {

--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
@@ -784,7 +784,7 @@ namespace RabbitMQ.Client.Impl
             IDictionary<string, object> arguments,
             IBasicConsumer consumer)
         {
-            var result = _delegate.BasicConsume(queue, autoAck, consumerTag, noLocal,
+            string result = _delegate.BasicConsume(queue, autoAck, consumerTag, noLocal,
                 exclusive, arguments, consumer);
             RecordedConsumer rc = new RecordedConsumer(this, queue).
                 WithConsumerTag(result).
@@ -991,7 +991,7 @@ namespace RabbitMQ.Client.Impl
             string routingKey,
             IDictionary<string, object> arguments)
         {
-            var qb = new RecordedQueueBinding(this).
+            RecordedBinding qb = new RecordedQueueBinding(this).
                 WithSource(exchange).
                 WithDestination(queue).
                 WithRoutingKey(routingKey).
@@ -1012,7 +1012,7 @@ namespace RabbitMQ.Client.Impl
                                            bool exclusive, bool autoDelete,
                                            IDictionary<string, object> arguments)
         {
-            var result = _delegate.QueueDeclare(queue, durable, exclusive,
+            QueueDeclareOk result = _delegate.QueueDeclare(queue, durable, exclusive,
                 autoDelete, arguments);
             RecordedQueue rq = new RecordedQueue(this, result.QueueName).
                 Durable(durable).
@@ -1058,7 +1058,7 @@ namespace RabbitMQ.Client.Impl
             bool ifUnused,
             bool ifEmpty)
         {
-            var result = _delegate.QueueDelete(queue, ifUnused, ifEmpty);
+            uint result = _delegate.QueueDelete(queue, ifUnused, ifEmpty);
             _connection.DeleteRecordedQueue(queue);
             return result;
         }

--- a/projects/client/RabbitMQ.Client/src/client/impl/BasicPublishBatch.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/BasicPublishBatch.cs
@@ -54,7 +54,7 @@ namespace RabbitMQ.Client.Impl
 
         public void Add(string exchange, string routingKey, bool mandatory, IBasicProperties basicProperties, byte[] body)
         {
-            var bp = basicProperties == null ? _model.CreateBasicProperties() : basicProperties;
+            IBasicProperties bp = basicProperties == null ? _model.CreateBasicProperties() : basicProperties;
             var method = new BasicPublish
             {
                 _exchange = exchange,

--- a/projects/client/RabbitMQ.Client/src/client/impl/Command.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Command.cs
@@ -119,15 +119,15 @@ namespace RabbitMQ.Client.Impl
             frames.Add(new MethodOutboundFrame(channelNumber, Method));
             if (Method.HasContent)
             {
-                var body = Body;
+                byte[] body = Body;
 
                 frames.Add(new HeaderOutboundFrame(channelNumber, Header, body.Length));
-                var frameMax = (int)Math.Min(int.MaxValue, connection.FrameMax);
-                var bodyPayloadMax = (frameMax == 0) ? body.Length : frameMax - EmptyFrameSize;
+                int frameMax = (int)Math.Min(int.MaxValue, connection.FrameMax);
+                int bodyPayloadMax = (frameMax == 0) ? body.Length : frameMax - EmptyFrameSize;
                 for (int offset = 0; offset < body.Length; offset += bodyPayloadMax)
                 {
-                    var remaining = body.Length - offset;
-                    var count = (remaining < bodyPayloadMax) ? remaining : bodyPayloadMax;
+                    int remaining = body.Length - offset;
+                    int count = (remaining < bodyPayloadMax) ? remaining : bodyPayloadMax;
                     frames.Add(new BodySegmentOutboundFrame(channelNumber, body, offset, count));
                 }
             }
@@ -140,20 +140,20 @@ namespace RabbitMQ.Client.Impl
         {
             var frames = new List<OutboundFrame>();
 
-            foreach (var cmd in commands)
+            foreach (Command cmd in commands)
             {
                 frames.Add(new MethodOutboundFrame(channelNumber, cmd.Method));
                 if (cmd.Method.HasContent)
                 {
-                    var body = cmd.Body;
+                    byte[] body = cmd.Body;
 
                     frames.Add(new HeaderOutboundFrame(channelNumber, cmd.Header, body.Length));
-                    var frameMax = (int)Math.Min(int.MaxValue, connection.FrameMax);
-                    var bodyPayloadMax = (frameMax == 0) ? body.Length : frameMax - EmptyFrameSize;
+                    int frameMax = (int)Math.Min(int.MaxValue, connection.FrameMax);
+                    int bodyPayloadMax = (frameMax == 0) ? body.Length : frameMax - EmptyFrameSize;
                     for (int offset = 0; offset < body.Length; offset += bodyPayloadMax)
                     {
-                        var remaining = body.Length - offset;
-                        var count = (remaining < bodyPayloadMax) ? remaining : bodyPayloadMax;
+                        int remaining = body.Length - offset;
+                        int count = (remaining < bodyPayloadMax) ? remaining : bodyPayloadMax;
                         frames.Add(new BodySegmentOutboundFrame(channelNumber, body, offset, count));
                     }
                 }

--- a/projects/client/RabbitMQ.Client/src/client/impl/CommandAssembler.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/CommandAssembler.cs
@@ -94,7 +94,7 @@ namespace RabbitMQ.Client.Impl
                     }
                     NetworkBinaryReader reader = f.GetReader();
                     m_header = m_protocol.DecodeContentHeaderFrom(reader);
-                    var totalBodyBytes = m_header.ReadFrom(reader);
+                        ulong totalBodyBytes = m_header.ReadFrom(reader);
                     if (totalBodyBytes > MaxArrayOfBytesSize)
                     {
                         throw new UnexpectedFrameException(f);

--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -431,7 +431,7 @@ namespace RabbitMQ.Client.Framing.Impl
                 }
             }
 
-            var receivedSignal = _appContinuation.WaitOne(timeout);
+            bool receivedSignal = _appContinuation.WaitOne(timeout);
 
             if (!receivedSignal)
             {
@@ -1193,7 +1193,7 @@ entry.ToString());
             _frameHandler.ReadTimeout = _factory.HandshakeContinuationTimeout;
             _frameHandler.SendHeader();
 
-            var connectionStart = connectionStartCell.WaitForValue();
+            ConnectionStartDetails connectionStart = connectionStartCell.WaitForValue();
 
             if (connectionStart == null)
             {
@@ -1271,7 +1271,7 @@ entry.ToString());
                     "Possibly caused by authentication failure", e);
             }
 
-            var channelMax = (ushort)NegotiatedMaxValue(_factory.RequestedChannelMax,
+            ushort channelMax = (ushort)NegotiatedMaxValue(_factory.RequestedChannelMax,
                 connectionTune.m_channelMax);
             _sessionManager = new SessionManager(this, channelMax);
 
@@ -1280,7 +1280,7 @@ entry.ToString());
             FrameMax = frameMax;
 
             TimeSpan requestedHeartbeat = _factory.RequestedHeartbeat;
-            var heartbeatInSeconds = NegotiatedMaxValue((uint)requestedHeartbeat.TotalSeconds,
+            uint heartbeatInSeconds = NegotiatedMaxValue((uint)requestedHeartbeat.TotalSeconds,
                 (uint)connectionTune.m_heartbeatInSeconds);
             Heartbeat = TimeSpan.FromSeconds(heartbeatInSeconds);
 

--- a/projects/client/RabbitMQ.Client/src/client/impl/ExtensionMethods.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ExtensionMethods.cs
@@ -55,19 +55,19 @@ namespace RabbitMQ.Client.Impl
         /// <returns></returns>
         public static T RandomItem<T>(this IList<T> list)
         {
-            var n = list.Count;
+            int n = list.Count;
             if (n == 0)
             {
                 return default;
             }
 
-            var hashCode = Math.Abs(Guid.NewGuid().GetHashCode());
+            int hashCode = Math.Abs(Guid.NewGuid().GetHashCode());
             return list.ElementAt<T>(hashCode % n);
         }
 
         internal static ArraySegment<byte> GetBufferSegment(this MemoryStream ms)
         {
-            var buffer = ms.GetBuffer();
+            byte[] buffer = ms.GetBuffer();
             return new ArraySegment<byte>(buffer, 0, (int)ms.Position);
         }
     }

--- a/projects/client/RabbitMQ.Client/src/client/impl/Frame.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Frame.cs
@@ -65,7 +65,7 @@ namespace RabbitMQ.Client.Impl
             nw.Write(_header.ProtocolClassId);
             _header.WriteTo(nw, (ulong)_bodyLength);
 
-            var bufferSegment = ms.GetBufferSegment();
+            System.ArraySegment<byte> bufferSegment = ms.GetBufferSegment();
             writer.Write((uint)bufferSegment.Count);
             writer.Write(bufferSegment.Array, bufferSegment.Offset, bufferSegment.Count);
         }
@@ -112,7 +112,7 @@ namespace RabbitMQ.Client.Impl
             _method.WriteArgumentsTo(argWriter);
             argWriter.Flush();
 
-            var bufferSegment = ms.GetBufferSegment();
+            System.ArraySegment<byte> bufferSegment = ms.GetBufferSegment();
             writer.Write((uint)bufferSegment.Count);
             writer.Write(bufferSegment.Array, bufferSegment.Offset, bufferSegment.Count);
         }

--- a/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ModelBase.cs
@@ -681,7 +681,7 @@ namespace RabbitMQ.Client.Impl
 
         protected void BroadcastShutdownToConsumers(IDictionary<string, IBasicConsumer> cs, ShutdownEventArgs reason)
         {
-            foreach (var c in cs)
+            foreach (KeyValuePair<string, IBasicConsumer> c in cs)
             {
                 ConsumerDispatcher.HandleModelShutdown(c.Value, reason);
             }
@@ -1253,7 +1253,7 @@ namespace RabbitMQ.Client.Impl
 
         internal void AllocatatePublishSeqNos(int count)
         {
-            var c = 0;
+            int c = 0;
             lock (_unconfirmedSet.SyncRoot)
             {
                 while (c < count)
@@ -1467,13 +1467,13 @@ namespace RabbitMQ.Client.Impl
 
         public uint MessageCount(string queue)
         {
-            var ok = QueueDeclarePassive(queue);
+            QueueDeclareOk ok = QueueDeclarePassive(queue);
             return ok.MessageCount;
         }
 
         public uint ConsumerCount(string queue)
         {
-            var ok = QueueDeclarePassive(queue);
+            QueueDeclareOk ok = QueueDeclarePassive(queue);
             return ok.ConsumerCount;
         }
 

--- a/projects/client/RabbitMQ.Client/src/client/impl/RpcContinuationQueue.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/RpcContinuationQueue.cs
@@ -81,7 +81,7 @@ namespace RabbitMQ.Client.Impl
         ///</remarks>
         public void Enqueue(IRpcContinuation k)
         {
-            var result = Interlocked.CompareExchange(ref _outstandingRpc, k, s_tmp);
+            IRpcContinuation result = Interlocked.CompareExchange(ref _outstandingRpc, k, s_tmp);
             if (!(result is EmptyRpcContinuation))
             {
                 throw new NotSupportedException("Pipelining of requests forbidden");

--- a/projects/client/RabbitMQ.Client/src/client/impl/SimpleBlockingRpcContinuation.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SimpleBlockingRpcContinuation.cs
@@ -50,7 +50,7 @@ namespace RabbitMQ.Client.Impl
 
         public virtual Command GetReply()
         {
-            var result = m_cell.WaitForValue();
+            Either<Command, ShutdownEventArgs> result = m_cell.WaitForValue();
             switch (result.Alternative)
             {
                 case EitherAlternative.Left:
@@ -65,7 +65,7 @@ namespace RabbitMQ.Client.Impl
 
         public virtual Command GetReply(TimeSpan timeout)
         {
-            var result = m_cell.WaitForValue(timeout);
+            Either<Command, ShutdownEventArgs> result = m_cell.WaitForValue(timeout);
             switch (result.Alternative)
             {
                 case EitherAlternative.Left:

--- a/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/SocketFrameHandler.cs
@@ -61,7 +61,7 @@ namespace RabbitMQ.Client.Impl
                 await task;
             else
             {
-                var supressErrorTask = task.ContinueWith(t => t.Exception.Handle(e => true), TaskContinuationOptions.OnlyOnFaulted);
+                Task supressErrorTask = task.ContinueWith(t => t.Exception.Handle(e => true), TaskContinuationOptions.OnlyOnFaulted);
                 throw new TimeoutException();
             }
         }
@@ -240,7 +240,7 @@ namespace RabbitMQ.Client.Impl
         {
             var ms = new MemoryStream();
             var nbw = new NetworkBinaryWriter(ms);
-            for (var i = 0; i < frames.Count; ++i)
+            for (int i = 0; i < frames.Count; ++i)
             {
                 frames[i].WriteTo(nbw);
             }

--- a/projects/client/RabbitMQ.Client/src/client/impl/TcpClientAdapter.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/TcpClientAdapter.cs
@@ -23,8 +23,8 @@ namespace RabbitMQ.Client
         public virtual async Task ConnectAsync(string host, int port)
         {
             AssertSocket();
-            var adds = await Dns.GetHostAddressesAsync(host).ConfigureAwait(false);
-            var ep = TcpClientAdapterHelper.GetMatchingHost(adds, _sock.AddressFamily);
+            IPAddress[] adds = await Dns.GetHostAddressesAsync(host).ConfigureAwait(false);
+            IPAddress ep = TcpClientAdapterHelper.GetMatchingHost(adds, _sock.AddressFamily);
             if (ep == default(IPAddress))
             {
                 throw new ArgumentException("No ip address could be resolved for " + host);

--- a/projects/client/RabbitMQ.Client/src/client/impl/TcpClientAdapterHelper.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/TcpClientAdapterHelper.cs
@@ -9,7 +9,7 @@ namespace RabbitMQ.Client
     {
         public static IPAddress GetMatchingHost(IReadOnlyCollection<IPAddress> addresses, AddressFamily addressFamily)
         {
-            var ep = addresses.FirstOrDefault(a => a.AddressFamily == addressFamily);
+            IPAddress ep = addresses.FirstOrDefault(a => a.AddressFamily == addressFamily);
             if (ep == null && addresses.Count == 1 && addressFamily == AddressFamily.Unspecified)
             {
                 return addresses.Single();

--- a/projects/client/RabbitMQ.Client/src/client/impl/WireFormatting.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/WireFormatting.cs
@@ -97,7 +97,7 @@ namespace RabbitMQ.Client.Impl
         {
             IList array = new List<object>();
             long arrayLength = reader.ReadUInt32();
-            var backingStream = reader.BaseStream;
+            Stream backingStream = reader.BaseStream;
             long startPosition = backingStream.Position;
             while ((backingStream.Position - startPosition) < arrayLength)
             {
@@ -205,7 +205,7 @@ namespace RabbitMQ.Client.Impl
             IDictionary<string, object> table = new Dictionary<string, object>();
             long tableLength = reader.ReadUInt32();
 
-            var backingStream = reader.BaseStream;
+            Stream backingStream = reader.BaseStream;
             long startPosition = backingStream.Position;
             while ((backingStream.Position - startPosition) < tableLength)
             {
@@ -237,7 +237,7 @@ namespace RabbitMQ.Client.Impl
             }
             else
             {
-                var backingStream = writer.BaseStream;
+                Stream backingStream = writer.BaseStream;
                 long patchPosition = backingStream.Position;
                 writer.Write((uint)0); // length of table - will be backpatched
                 foreach (object entry in val)
@@ -254,7 +254,7 @@ namespace RabbitMQ.Client.Impl
 
         public static void WriteDecimal(NetworkBinaryWriter writer, decimal value)
         {
-            DecimalToAmqp(value, out var scale, out var mantissa);
+            DecimalToAmqp(value, out byte scale, out int mantissa);
             WriteOctet(writer, scale);
             WriteLong(writer, (uint)mantissa);
         }
@@ -365,8 +365,8 @@ namespace RabbitMQ.Client.Impl
 
         public static void WriteShortstr(NetworkBinaryWriter writer, string val)
         {
-            var bytes = Encoding.UTF8.GetBytes(val);
-            var length = bytes.Length;
+            byte[] bytes = Encoding.UTF8.GetBytes(val);
+            int length = bytes.Length;
 
             if (length > 255)
             {
@@ -400,7 +400,7 @@ namespace RabbitMQ.Client.Impl
             }
             else
             {
-                var backingStream = writer.BaseStream;
+                Stream backingStream = writer.BaseStream;
                 long patchPosition = backingStream.Position;
                 writer.Write((uint)0); // length of table - will be backpatched
 
@@ -441,11 +441,11 @@ namespace RabbitMQ.Client.Impl
             }
             else
             {
-                var backingStream = writer.BaseStream;
+                Stream backingStream = writer.BaseStream;
                 long patchPosition = backingStream.Position;
                 writer.Write((uint)0); // length of table - will be backpatched
 
-                foreach (var entry in val)
+                foreach (KeyValuePair<string, object> entry in val)
                 {
                     WriteShortstr(writer, entry.Key);
                     WriteFieldValue(writer, entry.Value);

--- a/projects/client/RabbitMQ.Client/src/logging/ESLog.cs
+++ b/projects/client/RabbitMQ.Client/src/logging/ESLog.cs
@@ -49,7 +49,7 @@ namespace RabbitMQ.Client
 
         public static void Info(string message, params object[] args)
         {
-            var msg = string.Format(message, args);
+            string msg = string.Format(message, args);
             Info(msg);
         }
 
@@ -60,7 +60,7 @@ namespace RabbitMQ.Client
 
         public static void Warn(string message, params object[] args)
         {
-            var msg = string.Format(message, args);
+            string msg = string.Format(message, args);
             Warn(msg);
         }
 
@@ -71,7 +71,7 @@ namespace RabbitMQ.Client
 
         public static void Error(string message, System.Exception ex, params object[] args)
         {
-            var msg = string.Format(message, args);
+            string msg = string.Format(message, args);
             Error(msg, ex);
         }
     }

--- a/projects/client/RabbitMQ.Client/src/logging/RabbitMqConsoleEventListener.cs
+++ b/projects/client/RabbitMQ.Client/src/logging/RabbitMqConsoleEventListener.cs
@@ -53,7 +53,7 @@ namespace RabbitMQ.Client.Logging
 
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
-            foreach(var pl in eventData.Payload)
+            foreach(object pl in eventData.Payload)
             {
                 if (pl is IDictionary<string, object> dict)
                 {

--- a/projects/client/RabbitMQ.Client/src/util/NetworkBinaryWriter.cs
+++ b/projects/client/RabbitMQ.Client/src/util/NetworkBinaryWriter.cs
@@ -134,8 +134,8 @@ namespace RabbitMQ.Util
         /// </summary>
         public override void Write(long i)
         {
-            var i1 = (uint)(i >> 32);
-            var i2 = (uint)i;
+            uint i1 = (uint)(i >> 32);
+            uint i2 = (uint)i;
             Write(i1);
             Write(i2);
         }
@@ -145,8 +145,8 @@ namespace RabbitMQ.Util
         /// </summary>
         public override void Write(ulong i)
         {
-            var i1 = (uint)(i >> 32);
-            var i2 = (uint)i;
+            uint i1 = (uint)(i >> 32);
+            uint i2 = (uint)i;
             Write(i1);
             Write(i2);
         }

--- a/projects/client/Unit/src/unit/APIApproval.cs
+++ b/projects/client/Unit/src/unit/APIApproval.cs
@@ -52,7 +52,7 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void Approve()
         {
-            var publicApi = typeof(ConnectionFactory).Assembly.GeneratePublicApi(new ApiGeneratorOptions { ExcludeAttributes = new[] { "System.Runtime.Versioning.TargetFrameworkAttribute" } });
+            string publicApi = typeof(ConnectionFactory).Assembly.GeneratePublicApi(new ApiGeneratorOptions { ExcludeAttributes = new[] { "System.Runtime.Versioning.TargetFrameworkAttribute" } });
             Approvals.Verify(publicApi);
         }
     }

--- a/projects/client/Unit/src/unit/Fixtures.cs
+++ b/projects/client/Unit/src/unit/Fixtures.cs
@@ -405,14 +405,14 @@ namespace RabbitMQ.Client.Unit
         internal Process ExecRabbitMQCtl(string args)
         {
             // Allow the path to the rabbitmqctl.bat to be set per machine
-            var envVariable = Environment.GetEnvironmentVariable("RABBITMQ_RABBITMQCTL_PATH");
+            string envVariable = Environment.GetEnvironmentVariable("RABBITMQ_RABBITMQCTL_PATH");
 
             string rabbitmqctlPath;
 
             if (envVariable != null)
             {
                 var regex = new Regex(@"^DOCKER:(?<dockerMachine>.+)$");
-                var match = regex.Match(envVariable);
+                Match match = regex.Match(envVariable);
 
                 if (match.Success)
                 {
@@ -607,10 +607,10 @@ namespace RabbitMQ.Client.Unit
                 // line: <rabbit@mercurio.1.11491.0>	{.../*client_properties*/...}
                 return lines.Select(s =>
                 {
-                    var columns = s.Split('\t');
+                    string[] columns = s.Split('\t');
                     Debug.Assert(!string.IsNullOrEmpty(columns[0]), "columns[0] is null or empty!");
                     Debug.Assert(!string.IsNullOrEmpty(columns[1]), "columns[1] is null or empty!");
-                    var match = GetConnectionName.Match(columns[1]);
+                    Match match = GetConnectionName.Match(columns[1]);
                     Debug.Assert(match.Success, "columns[1] is not in expected format.");
                     return new ConnectionInfo(columns[0], match.Groups["connection_name"].Value);
                 }).ToList();
@@ -624,14 +624,14 @@ namespace RabbitMQ.Client.Unit
 
         internal void CloseConnection(IConnection conn)
         {
-            var ci = ListConnections().First(x => conn.ClientProvidedName == x.Name);
+            ConnectionInfo ci = ListConnections().First(x => conn.ClientProvidedName == x.Name);
             CloseConnection(ci.Pid);
         }
 
         internal void CloseAllConnections()
         {
-            var cs = ListConnections();
-            foreach(var c in cs)
+            List<ConnectionInfo> cs = ListConnections();
+            foreach(ConnectionInfo c in cs)
             {
                 CloseConnection(c.Pid);
             }

--- a/projects/client/Unit/src/unit/TestBasicProperties.cs
+++ b/projects/client/Unit/src/unit/TestBasicProperties.cs
@@ -92,13 +92,13 @@ namespace RabbitMQ.Client.Unit
             subject.MessageId = messageId;
 
             // Assert
-            var isClusterIdPresent = clusterId != null;
+            bool isClusterIdPresent = clusterId != null;
             Assert.AreEqual(isClusterIdPresent, subject.IsClusterIdPresent());
 
-            var isCorrelationIdPresent = correlationId != null;
+            bool isCorrelationIdPresent = correlationId != null;
             Assert.AreEqual(isCorrelationIdPresent, subject.IsCorrelationIdPresent());
 
-            var isMessageIdPresent = messageId != null;
+            bool isMessageIdPresent = messageId != null;
             Assert.AreEqual(isMessageIdPresent, subject.IsMessageIdPresent());
 
             using (var outputStream = new MemoryStream())

--- a/projects/client/Unit/src/unit/TestBasicPublishBatch.cs
+++ b/projects/client/Unit/src/unit/TestBasicPublishBatch.cs
@@ -51,14 +51,14 @@ namespace RabbitMQ.Client.Unit
             Model.ConfirmSelect();
             Model.QueueDeclare(queue: "test-message-batch-a", durable: false);
             Model.QueueDeclare(queue: "test-message-batch-b", durable: false);
-            var batch = Model.CreateBasicPublishBatch();
+            IBasicPublishBatch batch = Model.CreateBasicPublishBatch();
             batch.Add("", "test-message-batch-a", false, null, new byte [] {});
             batch.Add("", "test-message-batch-b", false, null, new byte [] {});
             batch.Publish();
             Model.WaitForConfirmsOrDie(TimeSpan.FromSeconds(15));
-            var resultA = Model.BasicGet("test-message-batch-a", true);
+            BasicGetResult resultA = Model.BasicGet("test-message-batch-a", true);
             Assert.NotNull(resultA);
-            var resultB = Model.BasicGet("test-message-batch-b", true);
+            BasicGetResult resultB = Model.BasicGet("test-message-batch-b", true);
             Assert.NotNull(resultB);
         }
     }

--- a/projects/client/Unit/src/unit/TestBlockingCell.cs
+++ b/projects/client/Unit/src/unit/TestBlockingCell.cs
@@ -98,7 +98,7 @@ namespace RabbitMQ.Client.Unit
             k.ContinueWithValue(123);
 
             ResetTimer();
-            var v = k.WaitForValue(TimingInterval);
+            int v = k.WaitForValue(TimingInterval);
             Assert.Greater(SafetyMargin, ElapsedMs());
             Assert.AreEqual(123, v);
         }
@@ -126,7 +126,7 @@ namespace RabbitMQ.Client.Unit
             SetAfter(TimingInterval, k, 123);
 
             ResetTimer();
-            var v = k.WaitForValue(Timeout.InfiniteTimeSpan);
+            int v = k.WaitForValue(Timeout.InfiniteTimeSpan);
             Assert.Less(TimingInterval - SafetyMargin, ElapsedMs());
             Assert.AreEqual(123, v);
         }
@@ -138,7 +138,7 @@ namespace RabbitMQ.Client.Unit
             SetAfter(TimingInterval, k, 123);
 
             ResetTimer();
-            var v = k.WaitForValue(TimingInterval * 2);
+            int v = k.WaitForValue(TimingInterval * 2);
             Assert.Less(TimingInterval - SafetyMargin, ElapsedMs());
             Assert.AreEqual(123, v);
         }
@@ -150,7 +150,7 @@ namespace RabbitMQ.Client.Unit
             SetAfter(TimingInterval, k, 123);
 
             ResetTimer();
-            var v = k.WaitForValue(TimingInterval * 2);
+            int v = k.WaitForValue(TimingInterval * 2);
             Assert.Less(TimingInterval - SafetyMargin, ElapsedMs());
             Assert.AreEqual(123, v);
         }
@@ -162,8 +162,8 @@ namespace RabbitMQ.Client.Unit
             SetAfter(TimingInterval, k, 123);
 
             ResetTimer();
-            var infiniteTimeSpan = Timeout.InfiniteTimeSpan;
-            var v = k.WaitForValue(infiniteTimeSpan);
+            TimeSpan infiniteTimeSpan = Timeout.InfiniteTimeSpan;
+            int v = k.WaitForValue(infiniteTimeSpan);
             Assert.Less(TimingInterval - SafetyMargin, ElapsedMs());
             Assert.AreEqual(123, v);
         }

--- a/projects/client/Unit/src/unit/TestConcurrentAccessWithSharedConnection.cs
+++ b/projects/client/Unit/src/unit/TestConcurrentAccessWithSharedConnection.cs
@@ -154,7 +154,7 @@ namespace RabbitMQ.Client.Unit
         {
             TestConcurrentChannelOperations((conn) =>
             {
-                var ch = conn.CreateModel();
+                IModel ch = conn.CreateModel();
                 ch.Close();
             }, 50);
         }
@@ -181,9 +181,9 @@ namespace RabbitMQ.Client.Unit
             {
                 // publishing on a shared channel is not supported
                 // and would missing the point of this test anyway
-                var ch = Conn.CreateModel();
+                IModel ch = Conn.CreateModel();
                 ch.ConfirmSelect();
-                foreach (var j in Enumerable.Range(0, 200))
+                foreach (int j in Enumerable.Range(0, 200))
                 {
                     ch.BasicPublish(exchange: "", routingKey: "_______", basicProperties: ch.CreateBasicProperties(), body: body);
                 }
@@ -200,11 +200,11 @@ namespace RabbitMQ.Client.Unit
         internal void TestConcurrentChannelOperations(Action<IConnection> actions,
             int iterations, TimeSpan timeout)
         {
-            var tasks = Enumerable.Range(0, threads).Select(x =>
+            Task[] tasks = Enumerable.Range(0, threads).Select(x =>
             {
                 return Task.Run(() =>
                 {
-                    foreach (var j in Enumerable.Range(0, iterations))
+                    foreach (int j in Enumerable.Range(0, iterations))
                     {
                         actions(Conn);
                     }

--- a/projects/client/Unit/src/unit/TestConnectionFactory.cs
+++ b/projects/client/Unit/src/unit/TestConnectionFactory.cs
@@ -50,11 +50,11 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void TestProperties()
         {
-            var u  = "username";
-            var pw = "password";
-            var v  = "vhost";
-            var h  = "192.168.0.1";
-            var p  = 5674;
+            string u  = "username";
+            string pw = "password";
+            string v  = "vhost";
+            string h  = "192.168.0.1";
+            int p  = 5674;
 
             var cf = new ConnectionFactory();
             cf.UserName = u;
@@ -79,7 +79,7 @@ namespace RabbitMQ.Client.Unit
             cf.Port = 1234;
             Assert.That(() =>
                     {
-                        using(var conn = cf.CreateConnection()) {}
+                        using(IConnection conn = cf.CreateConnection()) {}
                     }, Throws.TypeOf<BrokerUnreachableException>());
         }
 
@@ -92,7 +92,7 @@ namespace RabbitMQ.Client.Unit
             cf.Port = 1234;
             Assert.That(() =>
                     {
-                        using(var conn = cf.CreateConnection("some_name")) {}
+                        using(IConnection conn = cf.CreateConnection("some_name")) {}
                     }, Throws.TypeOf<BrokerUnreachableException>());
         }
 
@@ -102,7 +102,7 @@ namespace RabbitMQ.Client.Unit
             var cf = new ConnectionFactory();
             cf.AutomaticRecoveryEnabled = false;
             cf.ClientProvidedName = "some_name";
-            using (var conn = cf.CreateConnection())
+            using (IConnection conn = cf.CreateConnection())
             {
                 Assert.AreEqual("some_name", conn.ClientProvidedName);
                 Assert.AreEqual("some_name", conn.ClientProperties["connection_name"]);
@@ -114,7 +114,7 @@ namespace RabbitMQ.Client.Unit
         {
             var cf = new ConnectionFactory();
             cf.AutomaticRecoveryEnabled = false;
-            using(var conn = cf.CreateConnection("some_name"))
+            using(IConnection conn = cf.CreateConnection("some_name"))
             {
                 Assert.AreEqual("some_name", conn.ClientProvidedName);
                 Assert.AreEqual("some_name", conn.ClientProperties["connection_name"]);
@@ -126,7 +126,7 @@ namespace RabbitMQ.Client.Unit
         {
             var cf = new ConnectionFactory();
             cf.AutomaticRecoveryEnabled = true;
-            using(var conn = cf.CreateConnection("some_name"))
+            using(IConnection conn = cf.CreateConnection("some_name"))
             {
                 Assert.AreEqual("some_name", conn.ClientProvidedName);
                 Assert.AreEqual("some_name", conn.ClientProperties["connection_name"]);
@@ -139,7 +139,7 @@ namespace RabbitMQ.Client.Unit
             var cf = new ConnectionFactory();
             cf.AutomaticRecoveryEnabled = true;
             var xs = new System.Collections.Generic.List<AmqpTcpEndpoint> { new AmqpTcpEndpoint("localhost") };
-            using(var conn = cf.CreateConnection(xs, "some_name"))
+            using(IConnection conn = cf.CreateConnection(xs, "some_name"))
             {
               Assert.AreEqual("some_name", conn.ClientProvidedName);
               Assert.AreEqual("some_name", conn.ClientProperties["connection_name"]);
@@ -152,7 +152,7 @@ namespace RabbitMQ.Client.Unit
             var cf = new ConnectionFactory();
             cf.AutomaticRecoveryEnabled = true;
             cf.HostName = "localhost";
-            using(var conn = cf.CreateConnection()){
+            using(IConnection conn = cf.CreateConnection()){
                 Assert.AreEqual(5672, conn.Endpoint.Port);
             }
         }
@@ -163,7 +163,7 @@ namespace RabbitMQ.Client.Unit
             var cf = new ConnectionFactory();
             cf.AutomaticRecoveryEnabled = false;
             cf.HostName = "not_localhost";
-            var conn = cf.CreateConnection(new System.Collections.Generic.List<string> { "localhost" }, "oregano");
+            IConnection conn = cf.CreateConnection(new System.Collections.Generic.List<string> { "localhost" }, "oregano");
             conn.Close();
             conn.Dispose();
             Assert.AreEqual("not_localhost", cf.HostName);
@@ -178,7 +178,7 @@ namespace RabbitMQ.Client.Unit
             cf.HostName = "not_localhost";
             cf.Port = 1234 ;
             var ep = new AmqpTcpEndpoint("localhost");
-            using(var conn = cf.CreateConnection(new System.Collections.Generic.List<AmqpTcpEndpoint> { ep })) {}
+            using(IConnection conn = cf.CreateConnection(new System.Collections.Generic.List<AmqpTcpEndpoint> { ep })) {}
         }
 
         [Test]
@@ -189,7 +189,7 @@ namespace RabbitMQ.Client.Unit
             var ep = new AmqpTcpEndpoint("localhost", 1234);
             Assert.That(() =>
                     {
-                        using(var conn = cf.CreateConnection(new System.Collections.Generic.List<AmqpTcpEndpoint> { ep })){}
+                        using(IConnection conn = cf.CreateConnection(new System.Collections.Generic.List<AmqpTcpEndpoint> { ep })){}
                     }, Throws.TypeOf<BrokerUnreachableException>());
         }
 
@@ -200,7 +200,7 @@ namespace RabbitMQ.Client.Unit
             cf.HostName = "not_localhost";
             cf.Port = 1234 ;
             var ep = new AmqpTcpEndpoint("localhost");
-            using(var conn = cf.CreateConnection(new System.Collections.Generic.List<AmqpTcpEndpoint> { ep })) {}
+            using(IConnection conn = cf.CreateConnection(new System.Collections.Generic.List<AmqpTcpEndpoint> { ep })) {}
         }
 
         [Test]
@@ -211,7 +211,7 @@ namespace RabbitMQ.Client.Unit
             var ep = new AmqpTcpEndpoint("localhost");
             ep.AddressFamily = System.Net.Sockets.AddressFamily.InterNetwork;
             cf.Endpoint = ep;
-            using(var conn = cf.CreateConnection()){};
+            using(IConnection conn = cf.CreateConnection()){};
         }
 
         [Test]
@@ -221,7 +221,7 @@ namespace RabbitMQ.Client.Unit
             var ep = new AmqpTcpEndpoint("localhost", 1234);
             Assert.That(() =>
                     {
-                        using(var conn = cf.CreateConnection(new System.Collections.Generic.List<AmqpTcpEndpoint> { ep })) {}
+                        using(IConnection conn = cf.CreateConnection(new System.Collections.Generic.List<AmqpTcpEndpoint> { ep })) {}
                     }, Throws.TypeOf<BrokerUnreachableException>());
         }
 
@@ -231,7 +231,7 @@ namespace RabbitMQ.Client.Unit
             var cf = new ConnectionFactory();
             var invalidEp = new AmqpTcpEndpoint("not_localhost");
             var ep = new AmqpTcpEndpoint("localhost");
-            using(var conn = cf.CreateConnection(new List<AmqpTcpEndpoint> { invalidEp, ep })) {};
+            using(IConnection conn = cf.CreateConnection(new List<AmqpTcpEndpoint> { invalidEp, ep })) {};
         }
     }
 }

--- a/projects/client/Unit/src/unit/TestConsumerCancelNotify.cs
+++ b/projects/client/Unit/src/unit/TestConsumerCancelNotify.cs
@@ -99,7 +99,7 @@ namespace RabbitMQ.Client.Unit
         {
             Model.QueueDeclare(queue, false, true, false, null);
             IBasicConsumer consumer = new CancelNotificationConsumer(Model, this, EventMode);
-            var actualConsumerTag = Model.BasicConsume(queue, false, consumer);
+            string actualConsumerTag = Model.BasicConsume(queue, false, consumer);
 
             Model.QueueDelete(queue);
             WaitOn(lockObject);

--- a/projects/client/Unit/src/unit/TestConsumerCount.cs
+++ b/projects/client/Unit/src/unit/TestConsumerCount.cs
@@ -48,11 +48,11 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void TestConsumerCountMethod()
         {
-            var q = GenerateQueueName();
+            string q = GenerateQueueName();
             Model.QueueDeclare(queue: q, durable: false, exclusive: true, autoDelete: false, arguments: null);
             Assert.AreEqual(0, Model.ConsumerCount(q));
 
-            var tag = Model.BasicConsume(q, true, new EventingBasicConsumer(Model));
+            string tag = Model.BasicConsume(q, true, new EventingBasicConsumer(Model));
             Assert.AreEqual(1, Model.ConsumerCount(q));
 
             Model.BasicCancel(tag);

--- a/projects/client/Unit/src/unit/TestConsumerExceptions.cs
+++ b/projects/client/Unit/src/unit/TestConsumerExceptions.cs
@@ -116,7 +116,7 @@ namespace RabbitMQ.Client.Unit
         protected void TestExceptionHandlingWith(IBasicConsumer consumer,
             Action<IModel, string, IBasicConsumer, string> action)
         {
-            var o = new object();
+            object o = new object();
             bool notified = false;
             string q = Model.QueueDeclare();
 

--- a/projects/client/Unit/src/unit/TestConsumerOperationDispatch.cs
+++ b/projects/client/Unit/src/unit/TestConsumerOperationDispatch.cs
@@ -66,7 +66,7 @@ namespace RabbitMQ.Client.Unit
         [TearDown]
         protected override void ReleaseResources()
         {
-            foreach (var ch in channels)
+            foreach (IModel ch in channels)
             {
                 if (ch.IsOpen)
                 {
@@ -110,13 +110,13 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void TestDeliveryOrderingWithSingleChannel()
         {
-            var Ch = Conn.CreateModel();
+            IModel Ch = Conn.CreateModel();
             Ch.ExchangeDeclare(x, "fanout", durable: false);
 
             for (int i = 0; i < y; i++)
             {
-                var ch = Conn.CreateModel();
-                var q = ch.QueueDeclare("", durable: false, exclusive: true, autoDelete: true, arguments: null);
+                IModel ch = Conn.CreateModel();
+                QueueDeclareOk q = ch.QueueDeclare("", durable: false, exclusive: true, autoDelete: true, arguments: null);
                 ch.QueueBind(queue: q, exchange: x, routingKey: "");
                 channels.Add(ch);
                 queues.Add(q);
@@ -133,16 +133,16 @@ namespace RabbitMQ.Client.Unit
             }
             counter.Wait(TimeSpan.FromSeconds(120));
 
-            foreach (var cons in consumers)
+            foreach (CollectingConsumer cons in consumers)
             {
                 Assert.That(cons.DeliveryTags, Has.Count.EqualTo(n));
-                var ary = cons.DeliveryTags.ToArray();
+                ulong[] ary = cons.DeliveryTags.ToArray();
                 Assert.AreEqual(ary[0], 1);
                 Assert.AreEqual(ary[n - 1], n);
                 for (int i = 0; i < (n - 1); i++)
                 {
-                    var a = ary[i];
-                    var b = ary[i + 1];
+                    ulong a = ary[i];
+                    ulong b = ary[i + 1];
 
                     Assert.IsTrue(a < b);
                 }
@@ -153,12 +153,12 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void TestChannelShutdownDoesNotShutDownDispatcher()
         {
-            var ch1 = Conn.CreateModel();
-            var ch2 = Conn.CreateModel();
+            IModel ch1 = Conn.CreateModel();
+            IModel ch2 = Conn.CreateModel();
             Model.ExchangeDeclare(x, "fanout", durable: false);
 
-            var q1 = ch1.QueueDeclare().QueueName;
-            var q2 = ch2.QueueDeclare().QueueName;
+            string q1 = ch1.QueueDeclare().QueueName;
+            string q2 = ch2.QueueDeclare().QueueName;
             ch2.QueueBind(queue: q2, exchange: x, routingKey: "");
 
             var latch = new ManualResetEvent(false);
@@ -203,7 +203,7 @@ namespace RabbitMQ.Client.Unit
         {
             var latch = new ManualResetEvent(false);
             var duplicateLatch = new ManualResetEvent(false);
-            var q = Model.QueueDeclare().QueueName;
+            string q = Model.QueueDeclare().QueueName;
             var c = new ShutdownLatchConsumer(latch, duplicateLatch);
 
             Model.BasicConsume(queue: q, autoAck: true, consumer: c);

--- a/projects/client/Unit/src/unit/TestExceptionMessages.cs
+++ b/projects/client/Unit/src/unit/TestExceptionMessages.cs
@@ -50,7 +50,7 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void TestAlreadyClosedExceptionMessage()
         {
-            var uuid = System.Guid.NewGuid().ToString();
+            string uuid = System.Guid.NewGuid().ToString();
             try
             {
                 Model.QueueDeclarePassive(uuid);

--- a/projects/client/Unit/src/unit/TestHeartbeats.cs
+++ b/projects/client/Unit/src/unit/TestHeartbeats.cs
@@ -100,17 +100,17 @@ namespace RabbitMQ.Client.Unit
             List<IConnection> xs = new List<IConnection>();
             // Since we are using the ThreadPool, let's set MinThreads to a high-enough value.
             ThreadPool.SetMinThreads(200, 200);
-            for (var i = 0; i < 200; i++)
+            for (int i = 0; i < 200; i++)
             {
-                var n = Convert.ToUInt16(rnd.Next(2, 6));
+                ushort n = Convert.ToUInt16(rnd.Next(2, 6));
                 var cf = new ConnectionFactory()
                 {
                     RequestedHeartbeat = TimeSpan.FromSeconds(n),
                     AutomaticRecoveryEnabled = false
                 };
-                var conn = cf.CreateConnection();
+                IConnection conn = cf.CreateConnection();
                 xs.Add(conn);
-                var ch = conn.CreateModel();
+                IModel ch = conn.CreateModel();
 
                 conn.ConnectionShutdown += (sender, evt) =>
                     {
@@ -120,7 +120,7 @@ namespace RabbitMQ.Client.Unit
 
             SleepFor(60);
 
-            foreach (var x in xs)
+            foreach (IConnection x in xs)
             {
                 x.Close();
             }
@@ -128,8 +128,8 @@ namespace RabbitMQ.Client.Unit
 
         protected void RunSingleConnectionTest(ConnectionFactory cf)
         {
-            var conn = cf.CreateConnection();
-            var ch = conn.CreateModel();
+            IConnection conn = cf.CreateConnection();
+            IModel ch = conn.CreateModel();
             bool wasShutdown = false;
 
             conn.ConnectionShutdown += (sender, evt) =>
@@ -156,7 +156,7 @@ namespace RabbitMQ.Client.Unit
             if (InitiatedByPeerOrLibrary(evt))
             {
                 Console.WriteLine(((Exception)evt.Cause).StackTrace);
-                var s = string.Format("Shutdown: {0}, initiated by: {1}",
+                string s = string.Format("Shutdown: {0}, initiated by: {1}",
                                       evt, evt.Initiator);
                 Console.WriteLine(s);
                 Assert.Fail(s);
@@ -165,7 +165,7 @@ namespace RabbitMQ.Client.Unit
 
         private bool LongRunningTestsEnabled()
         {
-            var s = Environment.GetEnvironmentVariable("RABBITMQ_LONG_RUNNING_TESTS");
+            string s = Environment.GetEnvironmentVariable("RABBITMQ_LONG_RUNNING_TESTS");
             if (s == null || s.Equals(""))
             {
                 return false;

--- a/projects/client/Unit/src/unit/TestIEndpointResolverExtensions.cs
+++ b/projects/client/Unit/src/unit/TestIEndpointResolverExtensions.cs
@@ -78,7 +78,7 @@ namespace RabbitMQ.Client.Unit
         public void SelectOneShouldRaiseThrownExceptionWhenThereAreOnlyInaccessibleEndpoints()
         {
             var ep = new TestEndpointResolver(new List<AmqpTcpEndpoint> { new AmqpTcpEndpoint()});
-            var thrown = Assert.Throws<AggregateException>(() => ep.SelectOne<AmqpTcpEndpoint>((x) => { throw new TestEndpointException("bananas"); }));
+            AggregateException thrown = Assert.Throws<AggregateException>(() => ep.SelectOne<AmqpTcpEndpoint>((x) => { throw new TestEndpointException("bananas"); }));
             Assert.That(thrown.InnerExceptions, Has.Exactly(1).TypeOf<TestEndpointException>());
         }
 

--- a/projects/client/Unit/src/unit/TestInitialConnection.cs
+++ b/projects/client/Unit/src/unit/TestInitialConnection.cs
@@ -50,7 +50,7 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void TestBasicConnectionRecoveryWithHostnameList()
         {
-            var c = CreateAutorecoveringConnection(new List<string>() { "127.0.0.1", "localhost" });
+            Framing.Impl.AutorecoveringConnection c = CreateAutorecoveringConnection(new List<string>() { "127.0.0.1", "localhost" });
             Assert.IsTrue(c.IsOpen);
             c.Close();
         }
@@ -58,7 +58,7 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void TestBasicConnectionRecoveryWithHostnameListAndUnreachableHosts()
         {
-            var c = CreateAutorecoveringConnection(new List<string>() { "191.72.44.22", "127.0.0.1", "localhost" });
+            Framing.Impl.AutorecoveringConnection c = CreateAutorecoveringConnection(new List<string>() { "191.72.44.22", "127.0.0.1", "localhost" });
             Assert.IsTrue(c.IsOpen);
             c.Close();
         }

--- a/projects/client/Unit/src/unit/TestMessageCount.cs
+++ b/projects/client/Unit/src/unit/TestMessageCount.cs
@@ -49,7 +49,7 @@ namespace RabbitMQ.Client.Unit
         public void TestMessageCountMethod()
         {
             Model.ConfirmSelect();
-            var q = GenerateQueueName();
+            string q = GenerateQueueName();
             Model.QueueDeclare(queue: q, durable: false, exclusive: true, autoDelete: false, arguments: null);
             Assert.AreEqual(0, Model.MessageCount(q));
 

--- a/projects/client/Unit/src/unit/TestPublishValidation.cs
+++ b/projects/client/Unit/src/unit/TestPublishValidation.cs
@@ -50,7 +50,7 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void TestNullRoutingKeyIsRejected()
         {
-            var ch = Conn.CreateModel();
+            IModel ch = Conn.CreateModel();
             Assert.Throws(typeof(ArgumentNullException), () => ch.BasicPublish("", null, null, encoding.GetBytes("msg")));
         }
     }

--- a/projects/client/Unit/src/unit/TestPublisherConfirms.cs
+++ b/projects/client/Unit/src/unit/TestPublisherConfirms.cs
@@ -82,7 +82,7 @@ namespace RabbitMQ.Client.Unit
         {
             TestWaitForConfirms(200, (ch) =>
             {
-                var message = ch.BasicGet(QueueName, false);
+                BasicGetResult message = ch.BasicGet(QueueName, false);
 
                 var fullModel = ch as IFullModel;
                 fullModel.HandleBasicNack(message.DeliveryTag, false, false);
@@ -94,13 +94,13 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void TestWaitForConfirmsWithEvents()
         {
-            var ch = Conn.CreateModel();
+            IModel ch = Conn.CreateModel();
             ch.ConfirmSelect();
 
             ch.QueueDeclare(QueueName);
-            var n = 200;
+            int n = 200;
             // number of event handler invocations
-            var c = 0;
+            int c = 0;
 
             ch.BasicAcks += (_, args) =>
             {
@@ -130,7 +130,7 @@ namespace RabbitMQ.Client.Unit
 
         protected void TestWaitForConfirms(int numberOfMessagesToPublish, Action<IModel> fn)
         {
-            var ch = Conn.CreateModel();
+            IModel ch = Conn.CreateModel();
             ch.ConfirmSelect();
 
             ch.QueueDeclare(QueueName);

--- a/projects/client/Unit/src/unit/TestRpcContinuationQueue.cs
+++ b/projects/client/Unit/src/unit/TestRpcContinuationQueue.cs
@@ -53,7 +53,7 @@ namespace RabbitMQ.Client.Unit
             RpcContinuationQueue queue = new RpcContinuationQueue();
             var inputContinuation = new SimpleBlockingRpcContinuation();
             queue.Enqueue(inputContinuation);
-            var outputContinuation = queue.Next();
+            IRpcContinuation outputContinuation = queue.Next();
             Assert.AreEqual(outputContinuation, inputContinuation);
         }
 
@@ -63,9 +63,9 @@ namespace RabbitMQ.Client.Unit
             RpcContinuationQueue queue = new RpcContinuationQueue();
             var inputContinuation = new SimpleBlockingRpcContinuation();
             queue.Enqueue(inputContinuation);
-            var outputContinuation = queue.Next();
+            IRpcContinuation outputContinuation = queue.Next();
             Assert.AreEqual(outputContinuation, inputContinuation);
-            var outputContinuation1 = queue.Next();
+            IRpcContinuation outputContinuation1 = queue.Next();
             Assert.AreNotEqual(outputContinuation1, inputContinuation);
         }
 

--- a/projects/client/Unit/src/unit/TestTcpClientAdapter.cs
+++ b/projects/client/Unit/src/unit/TestTcpClientAdapter.cs
@@ -51,7 +51,7 @@ namespace RabbitMQ.Client.Unit
         public void TcpClientAdapterHelperGetMatchingHostReturnNoAddressIfFamilyDoesNotMatch()
         {
             var address = IPAddress.Parse("127.0.0.1");
-            var matchingAddress = TcpClientAdapterHelper.GetMatchingHost(new[] { address }, AddressFamily.InterNetworkV6);
+            IPAddress matchingAddress = TcpClientAdapterHelper.GetMatchingHost(new[] { address }, AddressFamily.InterNetworkV6);
             Assert.IsNull(matchingAddress);
         }
 
@@ -59,7 +59,7 @@ namespace RabbitMQ.Client.Unit
         public void TcpClientAdapterHelperGetMatchingHostReturnsSingleAddressIfFamilyIsUnspecified()
         {
             var address = IPAddress.Parse("1.1.1.1");
-            var matchingAddress = TcpClientAdapterHelper.GetMatchingHost(new[] { address }, AddressFamily.Unspecified);
+            IPAddress matchingAddress = TcpClientAdapterHelper.GetMatchingHost(new[] { address }, AddressFamily.Unspecified);
             Assert.AreEqual(address, matchingAddress);
         }
 
@@ -68,7 +68,7 @@ namespace RabbitMQ.Client.Unit
         {
             var address = IPAddress.Parse("1.1.1.1");
             var address2 = IPAddress.Parse("2.2.2.2");
-            var matchingAddress = TcpClientAdapterHelper.GetMatchingHost(new[] { address, address2 }, AddressFamily.Unspecified);
+            IPAddress matchingAddress = TcpClientAdapterHelper.GetMatchingHost(new[] { address, address2 }, AddressFamily.Unspecified);
             Assert.IsNull(matchingAddress);
         }
     }

--- a/projects/client/Unit/src/unit/TestUpdateSecret.cs
+++ b/projects/client/Unit/src/unit/TestUpdateSecret.cs
@@ -63,12 +63,12 @@ namespace RabbitMQ.Client.Unit
 
         private bool RabbitMQ380OrHigher()
         {
-            var properties = Conn.ServerProperties;
+            System.Collections.Generic.IDictionary<string, object> properties = Conn.ServerProperties;
 
-            if (properties.TryGetValue("version", out var versionVal))
+            if (properties.TryGetValue("version", out object versionVal))
             {
-                var versionStr = Encoding.UTF8.GetString((byte[])versionVal);
-                if (Version.TryParse(versionStr, out var version))
+                string versionStr = Encoding.UTF8.GetString((byte[])versionVal);
+                if (Version.TryParse(versionStr, out Version version))
                 {
                     return version >= new Version(3, 8);
                 }


### PR DESCRIPTION
## Proposed Changes

This PR changes `var` declarations to use explicit types when the type is not immediately apparent (construction or direct cast). This is to make the code more readable and understandable.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [X] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories