### PR TITLE
Optimized cross-platform binary (de)serialization

### DIFF
--- a/projects/client/RabbitMQ.Client/RabbitMQ.Client.csproj
+++ b/projects/client/RabbitMQ.Client/RabbitMQ.Client.csproj
@@ -53,6 +53,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(Configuration)' == 'SignedRelease' ">

--- a/projects/client/RabbitMQ.Client/src/client/content/BytesWireFormatting.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/BytesWireFormatting.cs
@@ -38,7 +38,9 @@
 //  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
+using System.Buffers;
 using System.Text;
+
 using RabbitMQ.Util;
 
 namespace RabbitMQ.Client.Content
@@ -66,7 +68,7 @@ namespace RabbitMQ.Client.Content
 
         public static char ReadChar(NetworkBinaryReader reader)
         {
-            return (char) reader.ReadUInt16();
+            return (char)reader.ReadUInt16();
         }
 
         public static double ReadDouble(NetworkBinaryReader reader)
@@ -118,7 +120,7 @@ namespace RabbitMQ.Client.Content
 
         public static void WriteChar(NetworkBinaryWriter writer, char value)
         {
-            writer.Write((ushort) value);
+            writer.Write((ushort)value);
         }
 
         public static void WriteDouble(NetworkBinaryWriter writer, double value)
@@ -148,9 +150,18 @@ namespace RabbitMQ.Client.Content
 
         public static void WriteString(NetworkBinaryWriter writer, string value)
         {
-            byte[] bytes = Encoding.UTF8.GetBytes(value);
-            writer.Write((ushort) bytes.Length);
-            writer.Write(bytes);
+            int maxLength = Encoding.UTF8.GetMaxByteCount(value.Length);
+            byte[] bytes = ArrayPool<byte>.Shared.Rent(maxLength);
+            try
+            {
+                int bytesUsed = Encoding.UTF8.GetBytes(value, 0, value.Length, bytes, 0);
+                writer.Write((ushort)bytesUsed);
+                writer.Write(bytes, 0, bytesUsed);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(bytes);
+            }
         }
     }
 }

--- a/projects/client/RabbitMQ.Client/src/client/content/StreamWireFormatting.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/StreamWireFormatting.cs
@@ -38,8 +38,10 @@
 //  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
+using System.Buffers;
 using System.IO;
 using System.Text;
+
 using RabbitMQ.Util;
 
 namespace RabbitMQ.Client.Content
@@ -74,11 +76,11 @@ namespace RabbitMQ.Client.Content
             object value = ReadNonnullObject("bool", reader);
             if (value is bool)
             {
-                return (bool) value;
+                return (bool)value;
             }
             if (value is string)
             {
-                return PrimitiveParser.ParseBool((string) value);
+                return PrimitiveParser.ParseBool((string)value);
             }
             throw PrimitiveParser.CreateProtocolViolationException("bool", value);
         }
@@ -88,11 +90,11 @@ namespace RabbitMQ.Client.Content
             object value = ReadNonnullObject("byte", reader);
             if (value is byte)
             {
-                return (byte) value;
+                return (byte)value;
             }
             if (value is string)
             {
-                return PrimitiveParser.ParseByte((string) value);
+                return PrimitiveParser.ParseByte((string)value);
             }
             throw PrimitiveParser.CreateProtocolViolationException("byte", value);
         }
@@ -106,7 +108,7 @@ namespace RabbitMQ.Client.Content
             }
             if (value is byte[])
             {
-                return (byte[]) value;
+                return (byte[])value;
             }
             throw PrimitiveParser.CreateProtocolViolationException("byte[]", value);
         }
@@ -116,7 +118,7 @@ namespace RabbitMQ.Client.Content
             object value = ReadNonnullObject("char", reader);
             if (value is char)
             {
-                return (char) value;
+                return (char)value;
             }
             throw PrimitiveParser.CreateProtocolViolationException("char", value);
         }
@@ -126,11 +128,11 @@ namespace RabbitMQ.Client.Content
             object value = ReadNonnullObject("double", reader);
             if (value is double || value is float)
             {
-                return (double) value;
+                return (double)value;
             }
             if (value is string)
             {
-                return PrimitiveParser.ParseDouble((string) value);
+                return PrimitiveParser.ParseDouble((string)value);
             }
             throw PrimitiveParser.CreateProtocolViolationException("double", value);
         }
@@ -140,11 +142,11 @@ namespace RabbitMQ.Client.Content
             object value = ReadNonnullObject("short", reader);
             if (value is short || value is byte)
             {
-                return (short) value;
+                return (short)value;
             }
             if (value is string)
             {
-                return PrimitiveParser.ParseShort((string) value);
+                return PrimitiveParser.ParseShort((string)value);
             }
             throw PrimitiveParser.CreateProtocolViolationException("short", value);
         }
@@ -154,11 +156,11 @@ namespace RabbitMQ.Client.Content
             object value = ReadNonnullObject("int", reader);
             if (value is int || value is short || value is byte)
             {
-                return (int) value;
+                return (int)value;
             }
             if (value is string)
             {
-                return PrimitiveParser.ParseInt((string) value);
+                return PrimitiveParser.ParseInt((string)value);
             }
             throw PrimitiveParser.CreateProtocolViolationException("int", value);
         }
@@ -168,11 +170,11 @@ namespace RabbitMQ.Client.Content
             object value = ReadNonnullObject("long", reader);
             if (value is long || value is int || value is short || value is byte)
             {
-                return (long) value;
+                return (long)value;
             }
             if (value is string)
             {
-                return PrimitiveParser.ParseLong((string) value);
+                return PrimitiveParser.ParseLong((string)value);
             }
             throw PrimitiveParser.CreateProtocolViolationException("long", value);
         }
@@ -194,71 +196,72 @@ namespace RabbitMQ.Client.Content
         public static object ReadObject(NetworkBinaryReader reader)
         {
             int typeTag = reader.ReadByte();
-            switch (typeTag)
+            if (typeTag == -1)
             {
-                case -1:
-                    throw new EndOfStreamException("End of StreamMessage reached");
-
-                case (int) StreamWireFormattingTag.Bool:
-                {
-                    byte value = reader.ReadByte();
-                    switch (value)
+                throw new EndOfStreamException("End of StreamMessage reached");
+            }
+            switch ((StreamWireFormattingTag)typeTag)
+            {
+                case StreamWireFormattingTag.Bool:
                     {
-                        case 0x00:
-                            return false;
-                        case 0x01:
-                            return true;
-                        default:
+                        byte value = reader.ReadByte();
+                        switch (value)
                         {
-                            string message =
-                                string.Format("Invalid boolean value in StreamMessage: {0}", value);
-                            throw new ProtocolViolationException(message);
+                            case 0x00:
+                                return false;
+                            case 0x01:
+                                return true;
+                            default:
+                                {
+                                    string message =
+                                        string.Format("Invalid boolean value in StreamMessage: {0}", value);
+                                    throw new ProtocolViolationException(message);
+                                }
                         }
                     }
-                }
 
-                case (int) StreamWireFormattingTag.Byte:
+                case StreamWireFormattingTag.Byte:
                     return reader.ReadByte();
 
-                case (int) StreamWireFormattingTag.Bytes:
-                {
-                    int length = reader.ReadInt32();
-                    if (length == -1)
+                case StreamWireFormattingTag.Bytes:
                     {
-                        return null;
+                        int length = reader.ReadInt32();
+                        if (length == -1)
+                        {
+                            return null;
+                        }
+                        return reader.ReadBytes(length);
                     }
-                    return reader.ReadBytes(length);
-                }
 
-                case (int) StreamWireFormattingTag.Int16:
+                case StreamWireFormattingTag.Int16:
                     return reader.ReadInt16();
 
-                case (int) StreamWireFormattingTag.Char:
-                    return (char) reader.ReadUInt16();
+                case StreamWireFormattingTag.Char:
+                    return (char)reader.ReadUInt16();
 
-                case (int) StreamWireFormattingTag.Int32:
+                case StreamWireFormattingTag.Int32:
                     return reader.ReadInt32();
 
-                case (int) StreamWireFormattingTag.Int64:
+                case StreamWireFormattingTag.Int64:
                     return reader.ReadInt64();
 
-                case (int) StreamWireFormattingTag.Single:
+                case StreamWireFormattingTag.Single:
                     return reader.ReadSingle();
 
-                case (int) StreamWireFormattingTag.Double:
+                case StreamWireFormattingTag.Double:
                     return reader.ReadDouble();
 
-                case (int) StreamWireFormattingTag.String:
+                case StreamWireFormattingTag.String:
                     return ReadUntypedString(reader);
 
-                case (int) StreamWireFormattingTag.Null:
+                case StreamWireFormattingTag.Null:
                     return null;
 
                 default:
-                {
-                    string message = string.Format("Invalid type tag in StreamMessage: {0}", typeTag);
-                    throw new ProtocolViolationException(message);
-                }
+                    {
+                        string message = string.Format("Invalid type tag in StreamMessage: {0}", typeTag);
+                        throw new ProtocolViolationException(message);
+                    }
             }
         }
 
@@ -267,11 +270,11 @@ namespace RabbitMQ.Client.Content
             object value = ReadNonnullObject("float", reader);
             if (value is float)
             {
-                return (float) value;
+                return (float)value;
             }
             if (value is string)
             {
-                return PrimitiveParser.ParseFloat((string) value);
+                return PrimitiveParser.ParseFloat((string)value);
             }
             throw PrimitiveParser.CreateProtocolViolationException("float", value);
         }
@@ -307,13 +310,13 @@ namespace RabbitMQ.Client.Content
 
         public static void WriteBool(NetworkBinaryWriter writer, bool value)
         {
-            writer.Write((byte) StreamWireFormattingTag.Bool);
-            writer.Write(value ? (byte) 0x01 : (byte) 0x00);
+            writer.Write((byte)StreamWireFormattingTag.Bool);
+            writer.Write(value ? (byte)0x01 : (byte)0x00);
         }
 
         public static void WriteByte(NetworkBinaryWriter writer, byte value)
         {
-            writer.Write((byte) StreamWireFormattingTag.Byte);
+            writer.Write((byte)StreamWireFormattingTag.Byte);
             writer.Write(value);
         }
 
@@ -322,7 +325,7 @@ namespace RabbitMQ.Client.Content
             int offset,
             int length)
         {
-            writer.Write((byte) StreamWireFormattingTag.Bytes);
+            writer.Write((byte)StreamWireFormattingTag.Bytes);
             writer.Write(length);
             writer.Write(value, offset, length);
         }
@@ -334,31 +337,31 @@ namespace RabbitMQ.Client.Content
 
         public static void WriteChar(NetworkBinaryWriter writer, char value)
         {
-            writer.Write((byte) StreamWireFormattingTag.Char);
-            writer.Write((ushort) value);
+            writer.Write((byte)StreamWireFormattingTag.Char);
+            writer.Write((ushort)value);
         }
 
         public static void WriteDouble(NetworkBinaryWriter writer, double value)
         {
-            writer.Write((byte) StreamWireFormattingTag.Double);
+            writer.Write((byte)StreamWireFormattingTag.Double);
             writer.Write(value);
         }
 
         public static void WriteInt16(NetworkBinaryWriter writer, short value)
         {
-            writer.Write((byte) StreamWireFormattingTag.Int16);
+            writer.Write((byte)StreamWireFormattingTag.Int16);
             writer.Write(value);
         }
 
         public static void WriteInt32(NetworkBinaryWriter writer, int value)
         {
-            writer.Write((byte) StreamWireFormattingTag.Int32);
+            writer.Write((byte)StreamWireFormattingTag.Int32);
             writer.Write(value);
         }
 
         public static void WriteInt64(NetworkBinaryWriter writer, long value)
         {
-            writer.Write((byte) StreamWireFormattingTag.Int64);
+            writer.Write((byte)StreamWireFormattingTag.Int64);
             writer.Write(value);
         }
 
@@ -367,48 +370,48 @@ namespace RabbitMQ.Client.Content
         {
             if (value is bool)
             {
-                WriteBool(writer, (bool) value);
+                WriteBool(writer, (bool)value);
             }
             else if (value is int)
             {
-                WriteInt32(writer, (int) value);
+                WriteInt32(writer, (int)value);
             }
             else if (value is short)
             {
-                WriteInt16(writer, (short) value);
+                WriteInt16(writer, (short)value);
             }
             else if (value is byte)
             {
-                WriteByte(writer, (byte) value);
+                WriteByte(writer, (byte)value);
             }
             else if (value is char)
             {
-                WriteChar(writer, (char) value);
+                WriteChar(writer, (char)value);
             }
             else if (value is long)
             {
-                WriteInt64(writer, (long) value);
+                WriteInt64(writer, (long)value);
             }
             else if (value is float)
             {
-                WriteSingle(writer, (float) value);
+                WriteSingle(writer, (float)value);
             }
             else if (value is double)
             {
-                WriteDouble(writer, (double) value);
+                WriteDouble(writer, (double)value);
             }
             else if (value is byte[])
             {
-                WriteBytes(writer, (byte[]) value);
+                WriteBytes(writer, (byte[])value);
             }
             else if (value is BinaryTableValue)
             {
                 WriteBytes(writer,
-                    ((BinaryTableValue) value).Bytes);
+                    ((BinaryTableValue)value).Bytes);
             }
             else if (value is string)
             {
-                WriteString(writer, (string) value);
+                WriteString(writer, (string)value);
             }
             else
             {
@@ -419,20 +422,30 @@ namespace RabbitMQ.Client.Content
 
         public static void WriteSingle(NetworkBinaryWriter writer, float value)
         {
-            writer.Write((byte) StreamWireFormattingTag.Single);
+            writer.Write((byte)StreamWireFormattingTag.Single);
             writer.Write(value);
         }
 
         public static void WriteString(NetworkBinaryWriter writer, string value)
         {
-            writer.Write((byte) StreamWireFormattingTag.String);
+            writer.Write((byte)StreamWireFormattingTag.String);
             WriteUntypedString(writer, value);
         }
 
         public static void WriteUntypedString(NetworkBinaryWriter writer, string value)
         {
-            writer.Write(Encoding.UTF8.GetBytes(value));
-            writer.Write((byte) 0);
+            int maxLength = Encoding.UTF8.GetMaxByteCount(value.Length);
+            byte[] bytes = ArrayPool<byte>.Shared.Rent(maxLength + 1);
+            try
+            {
+                int bytesUsed = Encoding.UTF8.GetBytes(value, 0, value.Length, bytes, 0);
+                bytes[bytesUsed + 1] = 0;
+                writer.Write(bytes, 0, bytesUsed + 1);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(bytes);
+            }
         }
     }
 }

--- a/projects/client/RabbitMQ.Client/src/client/content/StreamWireFormatting.cs
+++ b/projects/client/RabbitMQ.Client/src/client/content/StreamWireFormatting.cs
@@ -200,6 +200,7 @@ namespace RabbitMQ.Client.Content
             {
                 throw new EndOfStreamException("End of StreamMessage reached");
             }
+
             switch ((StreamWireFormattingTag)typeTag)
             {
                 case StreamWireFormattingTag.Bool:
@@ -439,7 +440,7 @@ namespace RabbitMQ.Client.Content
             try
             {
                 int bytesUsed = Encoding.UTF8.GetBytes(value, 0, value.Length, bytes, 0);
-                bytes[bytesUsed + 1] = 0;
+                bytes[bytesUsed] = 0;
                 writer.Write(bytes, 0, bytesUsed + 1);
             }
             finally

--- a/projects/client/RabbitMQ.Client/src/client/impl/WireFormatting.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/WireFormatting.cs
@@ -38,6 +38,7 @@
 //  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
+using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -116,7 +117,7 @@ namespace RabbitMQ.Client.Impl
 
         public static object ReadFieldValue(NetworkBinaryReader reader)
         {
-            switch((char)reader.ReadByte())
+            switch ((char)reader.ReadByte())
             {
                 case 'S':
                     return ReadLongstr(reader);
@@ -268,7 +269,17 @@ namespace RabbitMQ.Client.Impl
                     break;
                 case string val:
                     WriteOctet(writer, (byte)'S');
-                    WriteLongstr(writer, Encoding.UTF8.GetBytes(val));
+                    int maxLength = Encoding.UTF8.GetMaxByteCount(val.Length);
+                    byte[] bytes = ArrayPool<byte>.Shared.Rent(maxLength);
+                    try
+                    {
+                        int bytesUsed = Encoding.UTF8.GetBytes(val, 0, val.Length, bytes, 0);
+                        WriteLongstr(writer, bytes, 0, bytesUsed);
+                    }
+                    finally
+                    {
+                        ArrayPool<byte>.Shared.Return(bytes);
+                    }
                     break;
                 case byte[] val:
                     WriteOctet(writer, (byte)'S');
@@ -353,6 +364,12 @@ namespace RabbitMQ.Client.Impl
             writer.Write(val);
         }
 
+        public static void WriteLongstr(NetworkBinaryWriter writer, byte[] val, int index, int count)
+        {
+            WriteLong(writer, (uint)val.Length);
+            writer.Write(val, index, count);
+        }
+
         public static void WriteOctet(NetworkBinaryWriter writer, byte val)
         {
             writer.Write(val);
@@ -365,17 +382,23 @@ namespace RabbitMQ.Client.Impl
 
         public static void WriteShortstr(NetworkBinaryWriter writer, string val)
         {
-            byte[] bytes = Encoding.UTF8.GetBytes(val);
-            int length = bytes.Length;
-
-            if (length > 255)
+            int maxLength = Encoding.UTF8.GetMaxByteCount(val.Length);
+            byte[] bytes = ArrayPool<byte>.Shared.Rent(maxLength);
+            try
             {
-                throw new WireFormattingException("Short string too long; " +
-                                                  "UTF-8 encoded length=" + length + ", max=255");
-            }
+                int bytesUsed = Encoding.UTF8.GetBytes(val, 0, val.Length, bytes, 0);
+                if (bytesUsed > 255)
+                {
+                    throw new WireFormattingException($"Short string too long; UTF-8 encoded length={bytesUsed}, max=255");
+                }
 
-            writer.Write((byte)length);
-            writer.Write(bytes);
+                writer.Write((byte)bytesUsed);
+                writer.Write(bytes, 0, bytesUsed);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(bytes);
+            }
         }
 
         ///<summary>Writes an AMQP "table" to the writer.</summary>

--- a/projects/client/RabbitMQ.Client/src/client/impl/WireFormatting.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/WireFormatting.cs
@@ -366,7 +366,7 @@ namespace RabbitMQ.Client.Impl
 
         public static void WriteLongstr(NetworkBinaryWriter writer, byte[] val, int index, int count)
         {
-            WriteLong(writer, (uint)val.Length);
+            WriteLong(writer, (uint)count);
             writer.Write(val, index, count);
         }
 

--- a/projects/client/RabbitMQ.Client/src/util/NetworkBinaryReader.cs
+++ b/projects/client/RabbitMQ.Client/src/util/NetworkBinaryReader.cs
@@ -38,6 +38,8 @@
 //  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
+using System;
+using System.Buffers.Binary;
 using System.IO;
 using System.Text;
 
@@ -54,8 +56,6 @@ namespace RabbitMQ.Util
     /// </remarks>
     public class NetworkBinaryReader : BinaryReader
     {
-        private static readonly Encoding s_encoding = new UTF8Encoding();
-
         // Not particularly efficient. To be more efficient, we could
         // reuse BinaryReader's implementation details: m_buffer and
         // FillBuffer, if they weren't private
@@ -66,23 +66,8 @@ namespace RabbitMQ.Util
         /// <summary>
         /// Construct a NetworkBinaryReader over the given input stream.
         /// </summary>
-        public NetworkBinaryReader(Stream input) : base(input, s_encoding)
+        public NetworkBinaryReader(Stream input) : base(input, Encoding.UTF8)
         {
-        }
-
-        /// <summary>
-        /// Construct a NetworkBinaryReader over the given input
-        /// stream, reading strings using the given encoding.
-        /// </summary>
-        public NetworkBinaryReader(Stream input, Encoding encoding) : base(input, encoding)
-        {
-        }
-
-        ///<summary>Helper method for constructing a temporary
-        ///BinaryReader over a byte[].</summary>
-        public static BinaryReader TemporaryBinaryReader(byte[] bytes)
-        {
-            return new BinaryReader(new MemoryStream(bytes));
         }
 
         /// <summary>
@@ -90,20 +75,8 @@ namespace RabbitMQ.Util
         /// </summary>
         public override double ReadDouble()
         {
-            byte[] bytes = ReadBytes(8);
-            byte temp = bytes[0];
-            bytes[0] = bytes[7];
-            bytes[7] = temp;
-            temp = bytes[1];
-            bytes[1] = bytes[6];
-            bytes[6] = temp;
-            temp = bytes[2];
-            bytes[2] = bytes[5];
-            bytes[5] = temp;
-            temp = bytes[3];
-            bytes[3] = bytes[4];
-            bytes[4] = temp;
-            return TemporaryBinaryReader(bytes).ReadDouble();
+            long val = BinaryPrimitives.ReadInt64BigEndian(ReadBytes(8));
+            return BitConverter.Int64BitsToDouble(val);
         }
 
         /// <summary>
@@ -111,9 +84,7 @@ namespace RabbitMQ.Util
         /// </summary>
         public override short ReadInt16()
         {
-            uint i = base.ReadUInt16();
-            return (short)(((i & 0xFF00) >> 8) |
-                           ((i & 0x00FF) << 8));
+            return BinaryPrimitives.ReadInt16BigEndian(ReadBytes(2));
         }
 
         /// <summary>
@@ -121,11 +92,7 @@ namespace RabbitMQ.Util
         /// </summary>
         public override int ReadInt32()
         {
-            uint i = base.ReadUInt32();
-            return (int)(((i & 0xFF000000) >> 24) |
-                         ((i & 0x00FF0000) >> 8) |
-                         ((i & 0x0000FF00) << 8) |
-                         ((i & 0x000000FF) << 24));
+            return BinaryPrimitives.ReadInt32BigEndian(ReadBytes(4));
         }
 
         /// <summary>
@@ -133,15 +100,7 @@ namespace RabbitMQ.Util
         /// </summary>
         public override long ReadInt64()
         {
-            ulong i = base.ReadUInt64();
-            return (long)(((i & 0xFF00000000000000) >> 56) |
-                          ((i & 0x00FF000000000000) >> 40) |
-                          ((i & 0x0000FF0000000000) >> 24) |
-                          ((i & 0x000000FF00000000) >> 8) |
-                          ((i & 0x00000000FF000000) << 8) |
-                          ((i & 0x0000000000FF0000) << 24) |
-                          ((i & 0x000000000000FF00) << 40) |
-                          ((i & 0x00000000000000FF) << 56));
+            return BinaryPrimitives.ReadInt64BigEndian(ReadBytes(8));
         }
 
         /// <summary>
@@ -150,13 +109,12 @@ namespace RabbitMQ.Util
         public override float ReadSingle()
         {
             byte[] bytes = ReadBytes(4);
-            byte temp = bytes[0];
-            bytes[0] = bytes[3];
-            bytes[3] = temp;
-            temp = bytes[1];
-            bytes[1] = bytes[2];
-            bytes[2] = temp;
-            return TemporaryBinaryReader(bytes).ReadSingle();
+            if (BitConverter.IsLittleEndian)
+            {
+                bytes.AsSpan().Reverse();
+            }
+
+            return BitConverter.ToSingle(bytes, 0);
         }
 
         /// <summary>
@@ -164,9 +122,7 @@ namespace RabbitMQ.Util
         /// </summary>
         public override ushort ReadUInt16()
         {
-            uint i = base.ReadUInt16();
-            return (ushort)(((i & 0xFF00) >> 8) |
-                            ((i & 0x00FF) << 8));
+            return BinaryPrimitives.ReadUInt16BigEndian(ReadBytes(2));
         }
 
         /// <summary>
@@ -174,11 +130,7 @@ namespace RabbitMQ.Util
         /// </summary>
         public override uint ReadUInt32()
         {
-            uint i = base.ReadUInt32();
-            return ((i & 0xFF000000) >> 24) |
-                    ((i & 0x00FF0000) >> 8) |
-                    ((i & 0x0000FF00) << 8) |
-                    ((i & 0x000000FF) << 24);
+            return BinaryPrimitives.ReadUInt32BigEndian(ReadBytes(4));
         }
 
         /// <summary>
@@ -186,15 +138,7 @@ namespace RabbitMQ.Util
         /// </summary>
         public override ulong ReadUInt64()
         {
-            ulong i = base.ReadUInt64();
-            return ((i & 0xFF00000000000000) >> 56) |
-                    ((i & 0x00FF000000000000) >> 40) |
-                    ((i & 0x0000FF0000000000) >> 24) |
-                    ((i & 0x000000FF00000000) >> 8) |
-                    ((i & 0x00000000FF000000) << 8) |
-                    ((i & 0x0000000000FF0000) << 24) |
-                    ((i & 0x000000000000FF00) << 40) |
-                    ((i & 0x00000000000000FF) << 56);
+            return BinaryPrimitives.ReadUInt64BigEndian(ReadBytes(8));
         }
     }
 }

--- a/projects/client/Unit/src/unit/APIApproval.Approve.approved.txt
+++ b/projects/client/Unit/src/unit/APIApproval.Approve.approved.txt
@@ -2330,6 +2330,7 @@ namespace RabbitMQ.Client.Impl
         public static void WriteLong(RabbitMQ.Util.NetworkBinaryWriter writer, uint val) { }
         public static void WriteLonglong(RabbitMQ.Util.NetworkBinaryWriter writer, ulong val) { }
         public static void WriteLongstr(RabbitMQ.Util.NetworkBinaryWriter writer, byte[] val) { }
+        public static void WriteLongstr(RabbitMQ.Util.NetworkBinaryWriter writer, byte[] val, int index, int count) { }
         public static void WriteOctet(RabbitMQ.Util.NetworkBinaryWriter writer, byte val) { }
         public static void WriteShort(RabbitMQ.Util.NetworkBinaryWriter writer, ushort val) { }
         public static void WriteShortstr(RabbitMQ.Util.NetworkBinaryWriter writer, string val) { }

--- a/projects/client/Unit/src/unit/APIApproval.Approve.approved.txt
+++ b/projects/client/Unit/src/unit/APIApproval.Approve.approved.txt
@@ -2427,7 +2427,6 @@ namespace RabbitMQ.Util
     public class NetworkBinaryReader : System.IO.BinaryReader
     {
         public NetworkBinaryReader(System.IO.Stream input) { }
-        public NetworkBinaryReader(System.IO.Stream input, System.Text.Encoding encoding) { }
         public override double ReadDouble() { }
         public override short ReadInt16() { }
         public override int ReadInt32() { }
@@ -2436,7 +2435,6 @@ namespace RabbitMQ.Util
         public override ushort ReadUInt16() { }
         public override uint ReadUInt32() { }
         public override ulong ReadUInt64() { }
-        public static System.IO.BinaryReader TemporaryBinaryReader(byte[] bytes) { }
     }
     public class NetworkBinaryWriter : System.IO.BinaryWriter
     {


### PR DESCRIPTION
## Proposed Changes

This PR makes the (de)serialization of data to/from the network stream cross platform, taking the endianness of the running system into account as well as using array pooling for the serialization work reducing memory allocations. This will also unlock the ability to get rid of NetworkBinary(Reader/Writer) and simply create a class that can work directly cross-platform on bytes/spans/memory provided by Streams/Sockets/Pipelines which would decouple the serialization from the transport layer.

This also resolves #449.

**Contains changes to the public API (methods that are no longer used internally)**

**Please note that this adds a reference to the System.Memory NuGet package. This package should be safe to use for .NET Framework targets, for example it is currently referenced by very big packages such as [Google.Protobuf](https://www.nuget.org/packages/Google.Protobuf/), [Npgsql ](https://www.nuget.org/packages/Npgsql/)and [System.Diagnostics.DiagnosticSource](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource/4.7.0), so it is well tested**

Tagging @bording for visibility.

## Types of Changes

- [X] Bug fix (non-breaking change which fixes issue #449 )
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
