### PR TITLE
Wrapped concurrentqueue + semaphore pair together for readability, an…

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringConnection.cs
@@ -47,7 +47,7 @@ using System.Threading.Tasks;
 
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Impl;
-using RabbitMQ.Client.src.util;
+using RabbitMQ.Util;
 
 namespace RabbitMQ.Client.Framing.Impl
 {

--- a/projects/client/RabbitMQ.Client/src/util/AsyncConcurrentQueue.cs
+++ b/projects/client/RabbitMQ.Client/src/util/AsyncConcurrentQueue.cs
@@ -51,7 +51,7 @@ namespace RabbitMQ.Client.src.util
     ///   support.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class AsyncConcurrentQueue<T>
+    class AsyncConcurrentQueue<T>
     {
         private readonly ConcurrentQueue<T> _internalQueue = new ConcurrentQueue<T>();
         private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(0);

--- a/projects/client/RabbitMQ.Client/src/util/AsyncConcurrentQueue.cs
+++ b/projects/client/RabbitMQ.Client/src/util/AsyncConcurrentQueue.cs
@@ -61,7 +61,7 @@ namespace RabbitMQ.Client.src.util
         /// </summary>
         /// <param name="token"></param>
         /// <returns></returns>
-        public async Task<T> DequeueAsync(CancellationToken token)
+        public async Task<T> DequeueAsync(CancellationToken token = default)
         {
             await _semaphore.WaitAsync(token).ConfigureAwait(false);
 

--- a/projects/client/RabbitMQ.Client/src/util/AsyncConcurrentQueue.cs
+++ b/projects/client/RabbitMQ.Client/src/util/AsyncConcurrentQueue.cs
@@ -43,7 +43,7 @@ using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace RabbitMQ.Client.src.util
+namespace RabbitMQ.Util
 {
     /// <summary>
     /// A concurrent queue where Dequeue waits for something to be inserted if the queue is empty and Enqueue signals
@@ -51,7 +51,7 @@ namespace RabbitMQ.Client.src.util
     ///   support.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    class AsyncConcurrentQueue<T>
+    internal class AsyncConcurrentQueue<T>
     {
         private readonly ConcurrentQueue<T> _internalQueue = new ConcurrentQueue<T>();
         private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(0);

--- a/projects/client/RabbitMQ.Client/src/util/AsyncConcurrentQueue.cs
+++ b/projects/client/RabbitMQ.Client/src/util/AsyncConcurrentQueue.cs
@@ -1,0 +1,86 @@
+﻿// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 1.1.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2020 VMware, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       https://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v1.1:
+//
+//---------------------------------------------------------------------------
+//  The contents of this file are subject to the Mozilla Public License
+//  Version 1.1 (the "License"); you may not use this file except in
+//  compliance with the License. You may obtain a copy of the License
+//  at https://www.mozilla.org/MPL/
+//
+//  Software distributed under the License is distributed on an "AS IS"
+//  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+//  the License for the specific language governing rights and
+//  limitations under the License.
+//
+//  The Original Code is RabbitMQ.
+//
+//  The Initial Developer of the Original Code is Pivotal Software, Inc.
+//  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
+//---------------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RabbitMQ.Client.src.util
+{
+    /// <summary>
+    /// A concurrent queue where Dequeue waits for something to be inserted if the queue is empty and Enqueue signals
+    ///   that something has been added. Similar in function to a BlockingCollection but with async/await
+    ///   support.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class AsyncConcurrentQueue<T>
+    {
+        private readonly ConcurrentQueue<T> _internalQueue = new ConcurrentQueue<T>();
+        private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(0);
+
+        /// <summary>
+        /// Returns a Task that is completed when an object can be returned from the beginning of the queue.
+        /// </summary>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        public async Task<T> DequeueAsync(CancellationToken token)
+        {
+            await _semaphore.WaitAsync(token).ConfigureAwait(false);
+
+            if (!_internalQueue.TryDequeue(out var command))
+            {
+                throw new InvalidOperationException("Internal queue empty despite signaled enqueue.");
+            }
+
+            return command;
+        }
+
+        /// <summary>
+        /// Add an object to the end of the queue.
+        /// </summary>
+        /// <param name="item"></param>
+        public void Enqueue(T item)
+        {
+            _internalQueue.Enqueue(item);
+            _semaphore.Release();
+        }
+    }
+}


### PR DESCRIPTION
…d unblocked recovery main loop during retry delay.

## Proposed Changes

In the process of changing the AutorecoveringConnection to run via the TPL versus having its own dedicated thread I noticed that the Task.Delay operations for recovery retries were being awaited. My expectation with the RecoveryLoop was that it would be able to process commands that came in during the delay, which it cannot do if it's awaiting the delay inside of a command handler.

I also think that if we're awaiting a Task.Delay without passing it a cancellation token then we won't be able to easily cancel out of an auto-recovering connection that's in a Delay, it will instead timeout in `StopRecoveryLoop` if `RequestConnectionTimeout` is less than `NetworkRecoveryInterval` and log a warning. I solved this by not awaiting the Task.Delay operation, it could also be solved by passing a CancellationToken.

Also I wrapped the semaphore and concurrentqueue together in a class to clarify that they were acting together (i.e. Enqueue should be followed by semaphore.Release()). This improved the readability in my opinion, but I'd be happy to take this part out if it's not popular.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ x] I have read the `CONTRIBUTING.md` document
- [ x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

@stebet Thank you for you changes, I learned from them.
