### PR TITLE
Catch ObjectDisposedException case

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs
@@ -901,6 +901,7 @@ entry.ToString());
                 if (!_closed)
                 {
                     WriteFrame(_heartbeatFrame);
+                    _heartbeatWriteTimer?.Change((int)_heartbeatTimeSpan.TotalMilliseconds, Timeout.Infinite);
                 }
             }
             catch (ObjectDisposedException)
@@ -912,11 +913,6 @@ entry.ToString());
             {
                 // ignore, let the read callback detect
                 // peer unavailability. See rabbitmq/rabbitmq-dotnet-client#638 for details.
-            }
-
-            if (_closed == false)
-            {
-                _heartbeatWriteTimer?.Change((int)_heartbeatTimeSpan.TotalMilliseconds, Timeout.Infinite);
             }
         }
 


### PR DESCRIPTION
Prevent this exception from happening:

```
√ TestUnthrottledFloodPublishing [3m 5s]
Test run in progress...
The active test run was aborted. Reason: Test host process crashed : Unhandled Exception: System.ObjectDisposedException: Cannot access a disposed object.
   at System.Threading.TimerQueueTimer.Change(UInt32 dueTime, UInt32 period)
   at RabbitMQ.Client.Framing.Impl.Connection.HeartbeatWriteTimerCallback(Object state) in /tmp/build/a94a8fe5/rabbitmq_dotnet_client/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs:line 1140
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location where exception was thrown ---
   at System.Threading.TimerQueueTimer.CallCallback()
   at System.Threading.TimerQueueTimer.Fire()
   at System.Threading.TimerQueue.FireNextTimers()
```