### PR TITLE
Yield to prevent deadlocks

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/Work.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/Work.cs
@@ -16,6 +16,7 @@ namespace RabbitMQ.Client.Impl
         {
             try
             {
+                await Task.Yield();
                 await Execute(model, _asyncConsumer).ConfigureAwait(false);
             }
             catch (Exception)


### PR DESCRIPTION
Based on this comment by @danielmarbach:

> So the solution here is to do a Yield at the beginning of the event handler or for safety precaution reasons it would be possible to modify to Work class to do it uniformly

Fixes #341