### PR TITLE
Fall back to TLSv1.2 when System.Security.Authentication.SslProtocols.None is disabled/unavailable

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/api/AmqpTcpEndpoint.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/AmqpTcpEndpoint.cs
@@ -184,11 +184,6 @@ namespace RabbitMQ.Client
         /// </summary>
         public SslOption Ssl { get; set; }
 
-        public SslOption Tls { 
-            get { return this.Ssl; }
-            set { this.Ssl = value; }
-        }
-
         /// <summary>
         /// Construct an instance from a protocol and an address in "hostname:port" format.
         /// </summary>

--- a/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/ConnectionFactory.cs
@@ -246,14 +246,6 @@ namespace RabbitMQ.Client
         public SslOption Ssl { get; set; } = new SslOption();
 
         /// <summary>
-        /// TLS options setting.
-        /// </summary>
-        public SslOption Tls {
-            get { return this.Ssl; }
-            set { this.Ssl = value; }
-        }
-
-        /// <summary>
         /// Set to false to make automatic connection recovery not recover topology (exchanges, queues, bindings, etc).
         /// Defaults to true.
         /// </summary>

--- a/projects/client/RabbitMQ.Client/src/client/api/SslOption.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/SslOption.cs
@@ -149,5 +149,16 @@ namespace RabbitMQ.Client
         /// Retrieve or set the Ssl protocol version.
         /// </summary>
         public SslProtocols Version { get; set; }
+
+        /// <summary>
+        /// Reconfigures the instance to enable/use TLSv1.2.
+        /// Only used in environments where System.Security.Authentication.SslProtocols.None
+        /// is unavailable or effectively disabled, as reported by System.Net.ServicePointManager.
+        /// </summary>
+        public SslProtocols UseFallbackTlsVersions()
+        {
+            this.Version = SslProtocols.Tls12;
+            return Version;
+        }
     }
 }

--- a/projects/client/RabbitMQ.Client/src/client/api/SslOption.cs
+++ b/projects/client/RabbitMQ.Client/src/client/api/SslOption.cs
@@ -75,7 +75,7 @@ namespace RabbitMQ.Client
         }
 
         /// <summary>
-        /// Retrieve or set the set of ssl policy errors that are deemed acceptable.
+        /// Retrieve or set the set of TLS policy errors that are deemed acceptable.
         /// </summary>
         public SslPolicyErrors AcceptablePolicyErrors { get; set; }
 
@@ -90,13 +90,13 @@ namespace RabbitMQ.Client
         public string CertPath { get; set; }
 
         /// <summary>
-        /// An optional client specified SSL certificate selection callback.  If this is not specified,
+        /// An optional client specified TLS certificate selection callback.  If this is not specified,
         /// the first valid certificate found will be used.
         /// </summary>
         public LocalCertificateSelectionCallback CertificateSelectionCallback { get; set; }
 
         /// <summary>
-        /// An optional client specified SSL certificate validation callback.  If this is not specified,
+        /// An optional client specified TLS certificate validation callback.  If this is not specified,
         /// the default callback will be used in conjunction with the <see cref="AcceptablePolicyErrors"/> property to
         /// determine if the remote server certificate is valid.
         /// </summary>
@@ -135,13 +135,13 @@ namespace RabbitMQ.Client
         public bool CheckCertificateRevocation { get; set; }
 
         /// <summary>
-        /// Flag specifying if Ssl should indeed be used.
+        /// Flag specifying if TLS should indeed be used.
         /// </summary>
         public bool Enabled { get; set; }
 
         /// <summary>
         /// Retrieve or set server's Canonical Name.
-        /// This MUST match the CN on the Certificate else the SSL connection will fail.
+        /// This MUST match the Subject Alternative Name or CN on the Certificate else the TLS connection will fail.
         /// </summary>
         public string ServerName { get; set; }
 
@@ -155,7 +155,7 @@ namespace RabbitMQ.Client
         /// Only used in environments where System.Security.Authentication.SslProtocols.None
         /// is unavailable or effectively disabled, as reported by System.Net.ServicePointManager.
         /// </summary>
-        public SslProtocols UseFallbackTlsVersions()
+        internal SslProtocols UseFallbackTlsVersions()
         {
             this.Version = SslProtocols.Tls12;
             return Version;

--- a/projects/client/Unit/src/unit/APIApproval.Approve.approved.txt
+++ b/projects/client/Unit/src/unit/APIApproval.Approve.approved.txt
@@ -15,7 +15,6 @@ namespace RabbitMQ.Client
         public int Port { get; set; }
         public RabbitMQ.Client.IProtocol Protocol { get; }
         public RabbitMQ.Client.SslOption Ssl { get; set; }
-        public RabbitMQ.Client.SslOption Tls { get; set; }
         public object Clone() { }
         public RabbitMQ.Client.AmqpTcpEndpoint CloneWithHostname(string hostname) { }
         public override bool Equals(object obj) { }
@@ -113,7 +112,6 @@ namespace RabbitMQ.Client
         public System.TimeSpan SocketReadTimeout { get; set; }
         public System.TimeSpan SocketWriteTimeout { get; set; }
         public RabbitMQ.Client.SslOption Ssl { get; set; }
-        public RabbitMQ.Client.SslOption Tls { get; set; }
         public bool TopologyRecoveryEnabled { get; set; }
         public System.Uri Uri { get; set; }
         public bool UseBackgroundThreadsForIO { get; set; }

--- a/projects/client/Unit/src/unit/APIApproval.Approve.approved.txt
+++ b/projects/client/Unit/src/unit/APIApproval.Approve.approved.txt
@@ -15,6 +15,7 @@ namespace RabbitMQ.Client
         public int Port { get; set; }
         public RabbitMQ.Client.IProtocol Protocol { get; }
         public RabbitMQ.Client.SslOption Ssl { get; set; }
+        public RabbitMQ.Client.SslOption Tls { get; set; }
         public object Clone() { }
         public RabbitMQ.Client.AmqpTcpEndpoint CloneWithHostname(string hostname) { }
         public override bool Equals(object obj) { }
@@ -112,6 +113,7 @@ namespace RabbitMQ.Client
         public System.TimeSpan SocketReadTimeout { get; set; }
         public System.TimeSpan SocketWriteTimeout { get; set; }
         public RabbitMQ.Client.SslOption Ssl { get; set; }
+        public RabbitMQ.Client.SslOption Tls { get; set; }
         public bool TopologyRecoveryEnabled { get; set; }
         public System.Uri Uri { get; set; }
         public bool UseBackgroundThreadsForIO { get; set; }
@@ -548,7 +550,7 @@ namespace RabbitMQ.Client
     }
     public class SslHelper
     {
-        public static System.IO.Stream TcpUpgrade(System.IO.Stream tcpStream, RabbitMQ.Client.SslOption sslOption) { }
+        public static System.IO.Stream TcpUpgrade(System.IO.Stream tcpStream, RabbitMQ.Client.SslOption options) { }
     }
     public class SslOption
     {

--- a/projects/client/Unit/src/unit/TestAmqpUri.cs
+++ b/projects/client/Unit/src/unit/TestAmqpUri.cs
@@ -172,10 +172,10 @@ namespace RabbitMQ.Client.Unit
             Assert.AreEqual(password, cf.Password);
             Assert.AreEqual(port, cf.Port);
             Assert.AreEqual(vhost, cf.VirtualHost);
-            Assert.AreEqual(tlsEnabled, cf.Tls.Enabled);
+            Assert.AreEqual(tlsEnabled, cf.Ssl.Enabled);
 
             Assert.AreEqual(port, cf.Endpoint.Port);
-            Assert.AreEqual(tlsEnabled, cf.Endpoint.Tls.Enabled);
+            Assert.AreEqual(tlsEnabled, cf.Endpoint.Ssl.Enabled);
         }
 
         private void ParseFailWith<T>(string uri) where T : Exception


### PR DESCRIPTION
## Proposed Changes

See #764 for the background. In some environments, we cannot assume
that SslProtocols.None will behave as expected:

 * It can be disabled via app context and other means
 * Its effective behavior is different between .NET versions according
   to .NET community blog posts and GitHub issues

So we borrow from [1] and special case this exception to retry with an
explicitly defined version (TLSv1.2, same as modern .NET default).

The discussion in [2] should also be mentioned as they have led us
to a much better understanding of many aspects of this intricate setting.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #764)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Should address #764.

1. https://github.com/mysql-net/MySqlConnector/commit/715c3b542a1862b308f8afbb535ba1fee34afb93
2. https://github.com/robinrodricks/FluentFTP/issues/452#issuecomment-563965519

