### PR TITLE
Fix consumer loop

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/ConsumerWorkService.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ConsumerWorkService.cs
@@ -77,7 +77,7 @@ namespace RabbitMQ.Client
                         // Swallowing the task cancellation exception for the semaphore in case we are stopping.
                     }
 
-                    while (_tokenSource.IsCancellationRequested && _actions.TryDequeue(out Action action))
+                    while (_tokenSource.IsCancellationRequested == false && _actions.TryDequeue(out Action action))
                     {
                         try
                         {
@@ -88,7 +88,6 @@ namespace RabbitMQ.Client
                             // ignored
                         }
                     }
-
                 }
             }
 

--- a/projects/client/RabbitMQ.Client/src/client/impl/ConsumerWorkService.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ConsumerWorkService.cs
@@ -40,25 +40,27 @@ namespace RabbitMQ.Client
         class WorkPool
         {
             readonly ConcurrentQueue<Action> _actions;
-            readonly SemaphoreSlim _semaphore = new SemaphoreSlim(0);
             readonly CancellationTokenSource _tokenSource;
+            CancellationTokenRegistration _tokenRegistration;
+            volatile TaskCompletionSource<bool> _syncSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             private Task _worker;
 
             public WorkPool()
             {
                 _actions = new ConcurrentQueue<Action>();
                 _tokenSource = new CancellationTokenSource();
+                _tokenRegistration = _tokenSource.Token.Register(() => _syncSource.TrySetCanceled());
             }
 
             public void Start()
             {
-                _worker = Task.Run(Loop);
+                _worker = Task.Run(Loop, CancellationToken.None);
             }
 
             public void Enqueue(Action action)
             {
                 _actions.Enqueue(action);
-                _semaphore.Release();
+                _syncSource.TrySetResult(true);
             }
 
             async Task Loop()
@@ -67,14 +69,15 @@ namespace RabbitMQ.Client
                 {
                     try
                     {
-                        await _semaphore.WaitAsync(_tokenSource.Token).ConfigureAwait(false);
+                        await _syncSource.Task.ConfigureAwait(false);
+                        _syncSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                     }
                     catch (TaskCanceledException)
                     {
                         // Swallowing the task cancellation exception for the semaphore in case we are stopping.
                     }
 
-                    if (!_tokenSource.IsCancellationRequested && _actions.TryDequeue(out Action action))
+                    while (_tokenSource.IsCancellationRequested && _actions.TryDequeue(out Action action))
                     {
                         try
                         {
@@ -82,6 +85,7 @@ namespace RabbitMQ.Client
                         }
                         catch (Exception)
                         {
+                            // ignored
                         }
                     }
 
@@ -91,6 +95,7 @@ namespace RabbitMQ.Client
             public void Stop()
             {
                 _tokenSource.Cancel();
+                _tokenRegistration.Dispose();
             }
         }
     }


### PR DESCRIPTION
Replaces #771 by restoring a safer consumer work pool shutdown behavior where it would dequeue and process all pending operations before shutting down.