### PR TITLE
Schedule instead of GetAwaiter().GetResult()

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/AsyncConsumerDispatcher.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AsyncConsumerDispatcher.cs
@@ -61,7 +61,7 @@ namespace RabbitMQ.Client.Impl
         public void HandleModelShutdown(IBasicConsumer consumer, ShutdownEventArgs reason)
         {
             // the only case where we ignore the shutdown flag.
-            new ModelShutdown(consumer, reason).Execute(_model).GetAwaiter().GetResult();
+            Schedule(new ModelShutdown(consumer, reason));
         }
 
         private void ScheduleUnlessShuttingDown<TWork>(TWork work)


### PR DESCRIPTION
## Proposed Changes
Any reasons why we can't directly use Schedule instead of `GetAwaiter().GetResul()`?
