### PR TITLE
Graceful stop of worker services

### DIFF
--- a/projects/client/RabbitMQ.Client/src/client/impl/AsyncConsumerDispatcher.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AsyncConsumerDispatcher.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace RabbitMQ.Client.Impl
 {
@@ -19,9 +20,9 @@ namespace RabbitMQ.Client.Impl
             IsShutdown = true;
         }
 
-        public void Shutdown(IModel model)
+        public Task Shutdown(IModel model)
         {
-            _workService.Stop(model);
+            return _workService.Stop(model);
         }
 
         public bool IsShutdown

--- a/projects/client/RabbitMQ.Client/src/client/impl/AsyncConsumerWorkService.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AsyncConsumerWorkService.cs
@@ -78,7 +78,7 @@ namespace RabbitMQ.Client.Impl
                         // Swallowing the task cancellation in case we are stopping work.
                     }
 
-                    while (_tokenSource.IsCancellationRequested == false && _workQueue.TryDequeue(out Work work))
+                    while (_workQueue.TryDequeue(out Work work))
                     {
                         await work.Execute(_model).ConfigureAwait(false);
                     }

--- a/projects/client/RabbitMQ.Client/src/client/impl/AsyncConsumerWorkService.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AsyncConsumerWorkService.cs
@@ -20,12 +20,14 @@ namespace RabbitMQ.Client.Impl
             return newWorkPool;
         }
 
-        public void Stop(IModel model)
+        public Task Stop(IModel model)
         {
             if (_workPools.TryRemove(model, out WorkPool workPool))
             {
-                workPool.Stop();
+                return workPool.Stop();
             }
+
+            return Task.CompletedTask;
         }
 
         class WorkPool
@@ -77,10 +79,11 @@ namespace RabbitMQ.Client.Impl
                 }
             }
 
-            public void Stop()
+            public Task Stop()
             {
                 _tokenSource.Cancel();
                 _tokenRegistration.Dispose();
+                return _worker;
             }
         }
     }

--- a/projects/client/RabbitMQ.Client/src/client/impl/AsyncConsumerWorkService.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AsyncConsumerWorkService.cs
@@ -28,14 +28,6 @@ namespace RabbitMQ.Client.Impl
             }
         }
 
-        public void Stop()
-        {
-            foreach (IModel model in _workPools.Keys)
-            {
-                Stop(model);
-            }
-        }
-
         class WorkPool
         {
             readonly ConcurrentQueue<Work> _workQueue;

--- a/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/AutorecoveringModel.cs
@@ -279,7 +279,7 @@ namespace RabbitMQ.Client.Impl
         {
             try
             {
-                _delegate.Close(reason, abort);
+                _delegate.Close(reason, abort).GetAwaiter().GetResult();;
             }
             finally
             {

--- a/projects/client/RabbitMQ.Client/src/client/impl/ConcurrentConsumerDispatcher.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ConcurrentConsumerDispatcher.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-
+using System.Threading.Tasks;
 using RabbitMQ.Client.Events;
 
 namespace RabbitMQ.Client.Impl
@@ -22,9 +22,9 @@ namespace RabbitMQ.Client.Impl
             IsShutdown = true;
         }
 
-        public void Shutdown(IModel model)
+        public Task Shutdown(IModel model)
         {
-            _workService.StopWork(model);
+            return _workService.StopWork(model);
         }
 
         public bool IsShutdown

--- a/projects/client/RabbitMQ.Client/src/client/impl/ConcurrentConsumerDispatcher.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ConcurrentConsumerDispatcher.cs
@@ -24,7 +24,7 @@ namespace RabbitMQ.Client.Impl
 
         public Task Shutdown(IModel model)
         {
-            return _workService.StopWork(model);
+            return _workService.StopWorkAsync(model);
         }
 
         public bool IsShutdown

--- a/projects/client/RabbitMQ.Client/src/client/impl/ConsumerWorkService.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ConsumerWorkService.cs
@@ -21,7 +21,20 @@ namespace RabbitMQ.Client.Impl
             return newWorkPool;
         }
 
-        public Task StopWork(IModel model)
+        public void StopWork()
+        {
+            foreach (IModel model in _workPools.Keys)
+            {
+                StopWork(model);
+            }
+        }
+
+        public void StopWork(IModel model)
+        {
+            StopWorkAsync(model).GetAwaiter().GetResult();
+        }
+
+        internal Task StopWorkAsync(IModel model)
         {
             if (_workPools.TryRemove(model, out WorkPool workPool))
             {

--- a/projects/client/RabbitMQ.Client/src/client/impl/ConsumerWorkService.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ConsumerWorkService.cs
@@ -29,14 +29,6 @@ namespace RabbitMQ.Client.Impl
             }
         }
 
-        public void StopWork()
-        {
-            foreach (IModel model in _workPools.Keys)
-            {
-                StopWork(model);
-            }
-        }
-
         class WorkPool
         {
             readonly ConcurrentQueue<Action> _actions;

--- a/projects/client/RabbitMQ.Client/src/client/impl/ConsumerWorkService.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ConsumerWorkService.cs
@@ -77,7 +77,7 @@ namespace RabbitMQ.Client.Impl
                         // Swallowing the task cancellation exception for the semaphore in case we are stopping.
                     }
 
-                    while (_tokenSource.IsCancellationRequested == false && _actions.TryDequeue(out Action action))
+                    while (_actions.TryDequeue(out Action action))
                     {
                         try
                         {

--- a/projects/client/RabbitMQ.Client/src/client/impl/ConsumerWorkService.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/ConsumerWorkService.cs
@@ -21,12 +21,14 @@ namespace RabbitMQ.Client.Impl
             return newWorkPool;
         }
 
-        public void StopWork(IModel model)
+        public Task StopWork(IModel model)
         {
             if (_workPools.TryRemove(model, out WorkPool workPool))
             {
-                workPool.Stop();
+                return workPool.Stop();
             }
+
+            return Task.CompletedTask;
         }
 
         class WorkPool
@@ -83,10 +85,11 @@ namespace RabbitMQ.Client.Impl
                 }
             }
 
-            public void Stop()
+            public Task Stop()
             {
                 _tokenSource.Cancel();
                 _tokenRegistration.Dispose();
+                return _worker;
             }
         }
     }

--- a/projects/client/RabbitMQ.Client/src/client/impl/IConsumerDispatcher.cs
+++ b/projects/client/RabbitMQ.Client/src/client/impl/IConsumerDispatcher.cs
@@ -39,6 +39,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 
 namespace RabbitMQ.Client.Impl
 {
@@ -69,6 +70,6 @@ namespace RabbitMQ.Client.Impl
 
         void Quiesce();
 
-        void Shutdown(IModel model);
+        Task Shutdown(IModel model);
     }
 }


### PR DESCRIPTION
## Proposed Changes

As discussed in https://github.com/rabbitmq/rabbitmq-dotnet-client/pull/771 this makes sure any work that is left is executed and stop only exits after the worker has exited.

The reintroduces the necessary evil `GetAwaiter().GetResult()` on the highest entry level possible to make the underlying call stack async all the way.

The caveats of this have been discussed in the mentioned PR and seemed to have been outweighed against the benefits of finalizing the work. 