### PR TITLE
Add ReadOnlyMemory overload to BasicPublish

### DIFF
--- a/projects/Apigen/apigen/Apigen.cs
+++ b/projects/Apigen/apigen/Apigen.cs
@@ -1108,11 +1108,11 @@ $@"namespace {ApiNamespaceBase}
 
         public string SanitisedFullName(Type t)
         {
-            if (t.FullName.StartsWith("System.Collections.Generic.IDictionary`2[[System.String"))
+            if (t.Equals(typeof(IDictionary<string, object>)))
             {
                 return "IDictionary<string, object>";
             }
-            if (t.FullName.StartsWith("System.ReadOnlyMemory`1[[System.Byte"))
+            if (t.Equals(typeof(ReadOnlyMemory<byte>)))
             {
                 return "ReadOnlyMemory<byte>";
             }

--- a/projects/Apigen/apigen/Apigen.cs
+++ b/projects/Apigen/apigen/Apigen.cs
@@ -1112,6 +1112,10 @@ $@"namespace {ApiNamespaceBase}
             {
                 return "IDictionary<string, object>";
             }
+            if (t.FullName.StartsWith("System.ReadOnlyMemory`1[[System.Byte"))
+            {
+                return "ReadOnlyMemory<byte>";
+            }
 
             switch (t.FullName)
             {

--- a/projects/RabbitMQ.Client/client/api/IModel.cs
+++ b/projects/RabbitMQ.Client/client/api/IModel.cs
@@ -231,18 +231,6 @@ namespace RabbitMQ.Client
         /// </remarks>
         [AmqpMethodDoNotImplement(null)]
         void BasicPublish(string exchange, string routingKey, bool mandatory,
-            IBasicProperties basicProperties, byte[] body);
-
-        /// <summary>
-        /// Publishes a message.
-        /// </summary>
-        /// <remarks>
-        ///   <para>
-        ///     Routing key must be shorter than 255 bytes.
-        ///   </para>
-        /// </remarks>
-        [AmqpMethodDoNotImplement(null)]
-        void BasicPublish(string exchange, string routingKey, bool mandatory,
             IBasicProperties basicProperties, ReadOnlyMemory<byte> body);
 
         /// <summary>

--- a/projects/RabbitMQ.Client/client/api/IModel.cs
+++ b/projects/RabbitMQ.Client/client/api/IModel.cs
@@ -234,6 +234,18 @@ namespace RabbitMQ.Client
             IBasicProperties basicProperties, byte[] body);
 
         /// <summary>
+        /// Publishes a message.
+        /// </summary>
+        /// <remarks>
+        ///   <para>
+        ///     Routing key must be shorter than 255 bytes.
+        ///   </para>
+        /// </remarks>
+        [AmqpMethodDoNotImplement(null)]
+        void BasicPublish(string exchange, string routingKey, bool mandatory,
+            IBasicProperties basicProperties, ReadOnlyMemory<byte> body);
+
+        /// <summary>
         /// Configures QoS parameters of the Basic content-class.
         /// </summary>
         void BasicQos(uint prefetchSize, ushort prefetchCount, bool global);

--- a/projects/RabbitMQ.Client/client/api/IModelExtensions.cs
+++ b/projects/RabbitMQ.Client/client/api/IModelExtensions.cs
@@ -38,6 +38,7 @@
 //  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 
 namespace RabbitMQ.Client
@@ -97,6 +98,17 @@ namespace RabbitMQ.Client
         /// (Extension method) Convenience overload of BasicPublish.
         /// </summary>
         /// <remarks>
+        /// The publication occurs with mandatory=false and immediate=false.
+        /// </remarks>
+        public static void BasicPublish(this IModel model, PublicationAddress addr, IBasicProperties basicProperties, ReadOnlyMemory<byte> body)
+        {
+            model.BasicPublish(addr.ExchangeName, addr.RoutingKey, basicProperties: basicProperties, body: body);
+        }
+
+        /// <summary>
+        /// (Extension method) Convenience overload of BasicPublish.
+        /// </summary>
+        /// <remarks>
         /// The publication occurs with mandatory=false
         /// </remarks>
         public static void BasicPublish(this IModel model, string exchange, string routingKey, IBasicProperties basicProperties, byte[] body)
@@ -105,9 +117,28 @@ namespace RabbitMQ.Client
         }
 
         /// <summary>
+        /// (Extension method) Convenience overload of BasicPublish.
+        /// </summary>
+        /// <remarks>
+        /// The publication occurs with mandatory=false
+        /// </remarks>
+        public static void BasicPublish(this IModel model, string exchange, string routingKey, IBasicProperties basicProperties, ReadOnlyMemory<byte> body)
+        {
+            model.BasicPublish(exchange, routingKey, false, basicProperties, body);
+        }
+
+        /// <summary>
         /// (Spec method) Convenience overload of BasicPublish.
         /// </summary>
         public static void BasicPublish(this IModel model, string exchange, string routingKey, bool mandatory = false, IBasicProperties basicProperties = null, byte[] body = null)
+        {
+            model.BasicPublish(exchange, routingKey, mandatory, basicProperties, body);
+        }
+
+        /// <summary>
+        /// (Spec method) Convenience overload of BasicPublish.
+        /// </summary>
+        public static void BasicPublish(this IModel model, string exchange, string routingKey, bool mandatory = false, IBasicProperties basicProperties = null, ReadOnlyMemory<byte> body = default)
         {
             model.BasicPublish(exchange, routingKey, mandatory, basicProperties, body);
         }

--- a/projects/RabbitMQ.Client/client/api/IModelExtensions.cs
+++ b/projects/RabbitMQ.Client/client/api/IModelExtensions.cs
@@ -89,17 +89,6 @@ namespace RabbitMQ.Client
         /// <remarks>
         /// The publication occurs with mandatory=false and immediate=false.
         /// </remarks>
-        public static void BasicPublish(this IModel model, PublicationAddress addr, IBasicProperties basicProperties, byte[] body)
-        {
-            model.BasicPublish(addr.ExchangeName, addr.RoutingKey, basicProperties: basicProperties, body: body);
-        }
-
-        /// <summary>
-        /// (Extension method) Convenience overload of BasicPublish.
-        /// </summary>
-        /// <remarks>
-        /// The publication occurs with mandatory=false and immediate=false.
-        /// </remarks>
         public static void BasicPublish(this IModel model, PublicationAddress addr, IBasicProperties basicProperties, ReadOnlyMemory<byte> body)
         {
             model.BasicPublish(addr.ExchangeName, addr.RoutingKey, basicProperties: basicProperties, body: body);
@@ -111,28 +100,9 @@ namespace RabbitMQ.Client
         /// <remarks>
         /// The publication occurs with mandatory=false
         /// </remarks>
-        public static void BasicPublish(this IModel model, string exchange, string routingKey, IBasicProperties basicProperties, byte[] body)
-        {
-            model.BasicPublish(exchange, routingKey, false, basicProperties, body);
-        }
-
-        /// <summary>
-        /// (Extension method) Convenience overload of BasicPublish.
-        /// </summary>
-        /// <remarks>
-        /// The publication occurs with mandatory=false
-        /// </remarks>
         public static void BasicPublish(this IModel model, string exchange, string routingKey, IBasicProperties basicProperties, ReadOnlyMemory<byte> body)
         {
             model.BasicPublish(exchange, routingKey, false, basicProperties, body);
-        }
-
-        /// <summary>
-        /// (Spec method) Convenience overload of BasicPublish.
-        /// </summary>
-        public static void BasicPublish(this IModel model, string exchange, string routingKey, bool mandatory = false, IBasicProperties basicProperties = null, byte[] body = null)
-        {
-            model.BasicPublish(exchange, routingKey, mandatory, basicProperties, body);
         }
 
         /// <summary>

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
@@ -806,15 +806,6 @@ namespace RabbitMQ.Client.Impl
             string routingKey,
             bool mandatory,
             IBasicProperties basicProperties,
-            byte[] body)
-        {
-            BasicPublish(exchange, routingKey, mandatory, basicProperties, new ReadOnlyMemory<byte>(body));
-        }
-
-        public void BasicPublish(string exchange,
-            string routingKey,
-            bool mandatory,
-            IBasicProperties basicProperties,
             ReadOnlyMemory<byte> body)
         {
             if (routingKey == null)

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
@@ -556,7 +556,7 @@ namespace RabbitMQ.Client.Impl
             string routingKey,
             bool mandatory,
             IBasicProperties basicProperties,
-            byte[] body)
+            ReadOnlyMemory<byte> body)
         {
             if (routingKey == null)
             {
@@ -807,6 +807,15 @@ namespace RabbitMQ.Client.Impl
             bool mandatory,
             IBasicProperties basicProperties,
             byte[] body)
+        {
+            BasicPublish(exchange, routingKey, mandatory, basicProperties, new ReadOnlyMemory<byte>(body));
+        }
+
+        public void BasicPublish(string exchange,
+            string routingKey,
+            bool mandatory,
+            IBasicProperties basicProperties,
+            ReadOnlyMemory<byte> body)
         {
             if (routingKey == null)
             {

--- a/projects/RabbitMQ.Client/client/impl/IFullModel.cs
+++ b/projects/RabbitMQ.Client/client/impl/IFullModel.cs
@@ -227,7 +227,7 @@ namespace RabbitMQ.Client.Impl
             string routingKey,
             bool mandatory,
             [AmqpContentHeaderMapping] IBasicProperties basicProperties,
-            [AmqpContentBodyMapping] byte[] body);
+            [AmqpContentBodyMapping] ReadOnlyMemory<byte> body);
 
         [AmqpForceOneWay]
         [AmqpMethodMapping(null, "basic", "recover")]

--- a/projects/RabbitMQ.Client/client/impl/ModelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ModelBase.cs
@@ -349,7 +349,7 @@ namespace RabbitMQ.Client.Impl
             }
         }
 
-        public void ModelSend(MethodBase method, ContentHeaderBase header, byte[] body)
+        public void ModelSend(MethodBase method, ContentHeaderBase header, ReadOnlyMemory<byte> body)
         {
             if (method.HasContent)
             {
@@ -905,7 +905,7 @@ namespace RabbitMQ.Client.Impl
             string routingKey,
             bool mandatory,
             IBasicProperties basicProperties,
-            byte[] body);
+            ReadOnlyMemory<byte> body);
 
         public abstract void _Private_BasicRecover(bool requeue);
 
@@ -1101,6 +1101,15 @@ namespace RabbitMQ.Client.Impl
             bool mandatory,
             IBasicProperties basicProperties,
             byte[] body)
+        {
+            BasicPublish(exchange, routingKey, mandatory, basicProperties, new ReadOnlyMemory<byte>(body));
+        }
+
+        public void BasicPublish(string exchange,
+            string routingKey,
+            bool mandatory,
+            IBasicProperties basicProperties,
+            ReadOnlyMemory<byte> body)
         {
             if (routingKey == null)
             {

--- a/projects/RabbitMQ.Client/client/impl/ModelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ModelBase.cs
@@ -1100,15 +1100,6 @@ namespace RabbitMQ.Client.Impl
             string routingKey,
             bool mandatory,
             IBasicProperties basicProperties,
-            byte[] body)
-        {
-            BasicPublish(exchange, routingKey, mandatory, basicProperties, new ReadOnlyMemory<byte>(body));
-        }
-
-        public void BasicPublish(string exchange,
-            string routingKey,
-            bool mandatory,
-            IBasicProperties basicProperties,
             ReadOnlyMemory<byte> body)
         {
             if (routingKey == null)

--- a/projects/Unit/APIApproval.Approve.approved.txt
+++ b/projects/Unit/APIApproval.Approve.approved.txt
@@ -354,6 +354,7 @@ namespace RabbitMQ.Client
         RabbitMQ.Client.BasicGetResult BasicGet(string queue, bool autoAck);
         void BasicNack(ulong deliveryTag, bool multiple, bool requeue);
         void BasicPublish(string exchange, string routingKey, bool mandatory, RabbitMQ.Client.IBasicProperties basicProperties, byte[] body);
+        void BasicPublish(string exchange, string routingKey, bool mandatory, RabbitMQ.Client.IBasicProperties basicProperties, System.ReadOnlyMemory<byte> body);
         void BasicQos(uint prefetchSize, ushort prefetchCount, bool global);
         void BasicRecover(bool requeue);
         void BasicRecoverAsync(bool requeue);
@@ -399,8 +400,11 @@ namespace RabbitMQ.Client
         public static string BasicConsume(this RabbitMQ.Client.IModel model, string queue, bool autoAck, string consumerTag, System.Collections.Generic.IDictionary<string, object> arguments, RabbitMQ.Client.IBasicConsumer consumer) { }
         public static string BasicConsume(this RabbitMQ.Client.IModel model, RabbitMQ.Client.IBasicConsumer consumer, string queue, bool autoAck = false, string consumerTag = "", bool noLocal = false, bool exclusive = false, System.Collections.Generic.IDictionary<string, object> arguments = null) { }
         public static void BasicPublish(this RabbitMQ.Client.IModel model, RabbitMQ.Client.PublicationAddress addr, RabbitMQ.Client.IBasicProperties basicProperties, byte[] body) { }
+        public static void BasicPublish(this RabbitMQ.Client.IModel model, RabbitMQ.Client.PublicationAddress addr, RabbitMQ.Client.IBasicProperties basicProperties, System.ReadOnlyMemory<byte> body) { }
         public static void BasicPublish(this RabbitMQ.Client.IModel model, string exchange, string routingKey, RabbitMQ.Client.IBasicProperties basicProperties, byte[] body) { }
+        public static void BasicPublish(this RabbitMQ.Client.IModel model, string exchange, string routingKey, RabbitMQ.Client.IBasicProperties basicProperties, System.ReadOnlyMemory<byte> body) { }
         public static void BasicPublish(this RabbitMQ.Client.IModel model, string exchange, string routingKey, bool mandatory = false, RabbitMQ.Client.IBasicProperties basicProperties = null, byte[] body = null) { }
+        public static void BasicPublish(this RabbitMQ.Client.IModel model, string exchange, string routingKey, bool mandatory = false, RabbitMQ.Client.IBasicProperties basicProperties = null, System.ReadOnlyMemory<byte> body = default) { }
         public static void ExchangeBind(this RabbitMQ.Client.IModel model, string destination, string source, string routingKey, System.Collections.Generic.IDictionary<string, object> arguments = null) { }
         public static void ExchangeBindNoWait(this RabbitMQ.Client.IModel model, string destination, string source, string routingKey, System.Collections.Generic.IDictionary<string, object> arguments = null) { }
         public static void ExchangeDeclare(this RabbitMQ.Client.IModel model, string exchange, string type, bool durable = false, bool autoDelete = false, System.Collections.Generic.IDictionary<string, object> arguments = null) { }

--- a/projects/Unit/APIApproval.Approve.approved.txt
+++ b/projects/Unit/APIApproval.Approve.approved.txt
@@ -353,7 +353,6 @@ namespace RabbitMQ.Client
         string BasicConsume(string queue, bool autoAck, string consumerTag, bool noLocal, bool exclusive, System.Collections.Generic.IDictionary<string, object> arguments, RabbitMQ.Client.IBasicConsumer consumer);
         RabbitMQ.Client.BasicGetResult BasicGet(string queue, bool autoAck);
         void BasicNack(ulong deliveryTag, bool multiple, bool requeue);
-        void BasicPublish(string exchange, string routingKey, bool mandatory, RabbitMQ.Client.IBasicProperties basicProperties, byte[] body);
         void BasicPublish(string exchange, string routingKey, bool mandatory, RabbitMQ.Client.IBasicProperties basicProperties, System.ReadOnlyMemory<byte> body);
         void BasicQos(uint prefetchSize, ushort prefetchCount, bool global);
         void BasicRecover(bool requeue);
@@ -399,11 +398,8 @@ namespace RabbitMQ.Client
         public static string BasicConsume(this RabbitMQ.Client.IModel model, string queue, bool autoAck, string consumerTag, RabbitMQ.Client.IBasicConsumer consumer) { }
         public static string BasicConsume(this RabbitMQ.Client.IModel model, string queue, bool autoAck, string consumerTag, System.Collections.Generic.IDictionary<string, object> arguments, RabbitMQ.Client.IBasicConsumer consumer) { }
         public static string BasicConsume(this RabbitMQ.Client.IModel model, RabbitMQ.Client.IBasicConsumer consumer, string queue, bool autoAck = false, string consumerTag = "", bool noLocal = false, bool exclusive = false, System.Collections.Generic.IDictionary<string, object> arguments = null) { }
-        public static void BasicPublish(this RabbitMQ.Client.IModel model, RabbitMQ.Client.PublicationAddress addr, RabbitMQ.Client.IBasicProperties basicProperties, byte[] body) { }
         public static void BasicPublish(this RabbitMQ.Client.IModel model, RabbitMQ.Client.PublicationAddress addr, RabbitMQ.Client.IBasicProperties basicProperties, System.ReadOnlyMemory<byte> body) { }
-        public static void BasicPublish(this RabbitMQ.Client.IModel model, string exchange, string routingKey, RabbitMQ.Client.IBasicProperties basicProperties, byte[] body) { }
         public static void BasicPublish(this RabbitMQ.Client.IModel model, string exchange, string routingKey, RabbitMQ.Client.IBasicProperties basicProperties, System.ReadOnlyMemory<byte> body) { }
-        public static void BasicPublish(this RabbitMQ.Client.IModel model, string exchange, string routingKey, bool mandatory = false, RabbitMQ.Client.IBasicProperties basicProperties = null, byte[] body = null) { }
         public static void BasicPublish(this RabbitMQ.Client.IModel model, string exchange, string routingKey, bool mandatory = false, RabbitMQ.Client.IBasicProperties basicProperties = null, System.ReadOnlyMemory<byte> body = default) { }
         public static void ExchangeBind(this RabbitMQ.Client.IModel model, string destination, string source, string routingKey, System.Collections.Generic.IDictionary<string, object> arguments = null) { }
         public static void ExchangeBindNoWait(this RabbitMQ.Client.IModel model, string destination, string source, string routingKey, System.Collections.Generic.IDictionary<string, object> arguments = null) { }

--- a/projects/Unit/TestBasicPublish.cs
+++ b/projects/Unit/TestBasicPublish.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using RabbitMQ.Client.Events;
+
+namespace RabbitMQ.Client.Unit
+{
+    [TestFixture]
+    public class TestBasicPublish
+    {
+        [Test]
+        public void TestBasicRoundtripArray()
+        {
+            var cf = new ConnectionFactory();
+            using(IConnection c = cf.CreateConnection())
+            using(IModel m = c.CreateModel())
+            {
+                QueueDeclareOk q = m.QueueDeclare();
+                IBasicProperties bp = m.CreateBasicProperties();
+                byte[] sendBody = System.Text.Encoding.UTF8.GetBytes("hi");
+                byte[] consumeBody = null;
+                var consumer = new EventingBasicConsumer(m);
+                var are = new AutoResetEvent(false);
+                consumer.Received += async (o, a) =>
+                {
+                    consumeBody = a.Body.ToArray();
+                    are.Set();
+                    await Task.Yield();
+                };
+                string tag = m.BasicConsume(q.QueueName, true, consumer);
+
+
+                m.BasicPublish("", q.QueueName, bp, sendBody);
+                bool waitResFalse = are.WaitOne(2000);
+                m.BasicCancel(tag);
+
+
+                Assert.IsTrue(waitResFalse);
+                Assert.AreEqual(sendBody, consumeBody);
+            }
+        }
+
+        [Test]
+        public void TestBasicRoundtripReadOnlyMemory()
+        {
+            var cf = new ConnectionFactory();
+            using(IConnection c = cf.CreateConnection())
+            using(IModel m = c.CreateModel())
+            {
+                QueueDeclareOk q = m.QueueDeclare();
+                IBasicProperties bp = m.CreateBasicProperties();
+                byte[] sendBody = System.Text.Encoding.UTF8.GetBytes("hi");
+                byte[] consumeBody = null;
+                var consumer = new EventingBasicConsumer(m);
+                var are = new AutoResetEvent(false);
+                consumer.Received += async (o, a) =>
+                {
+                    consumeBody = a.Body.ToArray();
+                    are.Set();
+                    await Task.Yield();
+                };
+                string tag = m.BasicConsume(q.QueueName, true, consumer);
+
+
+                m.BasicPublish("", q.QueueName, bp, new ReadOnlyMemory<byte>(sendBody));
+                bool waitResFalse = are.WaitOne(2000);
+                m.BasicCancel(tag);
+
+
+                Assert.IsTrue(waitResFalse);
+                Assert.AreEqual(sendBody, consumeBody);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes
Add ReadOnlyMemory overload to BasicPublish.
That allows to send part of the array without creating a new one.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
