### PR TITLE
Serialization optimizations

### DIFF
--- a/projects/RabbitMQ.Client/util/NetworkOrderDeserializer.cs
+++ b/projects/RabbitMQ.Client/util/NetworkOrderDeserializer.cs
@@ -116,7 +116,9 @@ namespace RabbitMQ.Util
                 throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to decode UInt64 from memory.");
             }
 
-            return ((ulong)span[0] << 56) | ((ulong)span[1] << 48) | ((ulong)span[2] << 40) | ((ulong)span[3] << 32) | ((ulong)span[4] << 24) | ((ulong)span[5] << 16) | ((ulong)span[6] << 8) | span[7];
+            uint num1 = (uint)((span[0] << 24) | (span[1] << 16) | (span[2] << 8) | span[3]);
+            uint num2 = (uint)((span[4] << 24) | (span[5] << 16) | (span[6] << 8) | span[7]);
+            return ((ulong)num1 << 32) | num2;
         }
     }
 }

--- a/projects/RabbitMQ.Client/util/NetworkOrderDeserializer.cs
+++ b/projects/RabbitMQ.Client/util/NetworkOrderDeserializer.cs
@@ -1,13 +1,14 @@
 ﻿using System;
-using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 
 namespace RabbitMQ.Util
 {
     internal static class NetworkOrderDeserializer
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static double ReadDouble(ReadOnlyMemory<byte> memory) => ReadDouble(memory.Span);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static double ReadDouble(ReadOnlySpan<byte> span)
         {
             if (span.Length < 8)
@@ -15,12 +16,14 @@ namespace RabbitMQ.Util
                 throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to decode Double from memory.");
             }
 
-            long val = BinaryPrimitives.ReadInt64BigEndian(span);
-            return Unsafe.As<long, double>(ref val);
+            ulong val = ReadUInt64(span);
+            return Unsafe.As<ulong, double>(ref val);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static short ReadInt16(ReadOnlyMemory<byte> memory) => ReadInt16(memory.Span);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static short ReadInt16(ReadOnlySpan<byte> span)
         {
             if (span.Length < 2)
@@ -28,11 +31,13 @@ namespace RabbitMQ.Util
                 throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to decode Int16 from memory.");
             }
 
-            return BinaryPrimitives.ReadInt16BigEndian(span);
+            return (short)ReadUInt16(span);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int ReadInt32(ReadOnlyMemory<byte> memory) => ReadInt32(memory.Span);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int ReadInt32(ReadOnlySpan<byte> span)
         {
             if (span.Length < 4)
@@ -40,11 +45,13 @@ namespace RabbitMQ.Util
                 throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to decode Int32 from memory.");
             }
 
-            return BinaryPrimitives.ReadInt32BigEndian(span);
+            return (int)ReadUInt32(span);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static long ReadInt64(ReadOnlyMemory<byte> memory) => ReadInt64(memory.Span);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static long ReadInt64(ReadOnlySpan<byte> span)
         {
             if (span.Length < 8)
@@ -52,11 +59,13 @@ namespace RabbitMQ.Util
                 throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to decode Int64 from memory.");
             }
 
-            return BinaryPrimitives.ReadInt64BigEndian(span);
+            return (long)ReadUInt64(span);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static float ReadSingle(ReadOnlyMemory<byte> memory) => ReadSingle(memory.Span);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static float ReadSingle(ReadOnlySpan<byte> span)
         {
             if (span.Length < 4)
@@ -64,12 +73,14 @@ namespace RabbitMQ.Util
                 throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to decode Single from memory.");
             }
 
-            int num = BinaryPrimitives.ReadInt32BigEndian(span);
-            return Unsafe.As<int, float>(ref num);
+            uint num = ReadUInt32(span);
+            return Unsafe.As<uint, float>(ref num);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static ushort ReadUInt16(ReadOnlyMemory<byte> memory) => ReadUInt16(memory.Span);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static ushort ReadUInt16(ReadOnlySpan<byte> span)
         {
             if (span.Length < 2)
@@ -77,11 +88,13 @@ namespace RabbitMQ.Util
                 throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to decode UInt16 from memory.");
             }
 
-            return BinaryPrimitives.ReadUInt16BigEndian(span);
+            return (ushort)((span[0] << 8) | span[1]);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static uint ReadUInt32(ReadOnlyMemory<byte> memory) => ReadUInt32(memory.Span);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static uint ReadUInt32(ReadOnlySpan<byte> span)
         {
             if (span.Length < 4)
@@ -89,11 +102,13 @@ namespace RabbitMQ.Util
                 throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to decode UInt32 from memory.");
             }
 
-            return BinaryPrimitives.ReadUInt32BigEndian(span);
+            return (uint)((span[0] << 24) | (span[1] << 16) | (span[2] << 8) | span[3]);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static ulong ReadUInt64(ReadOnlyMemory<byte> memory) => ReadUInt64(memory.Span);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static ulong ReadUInt64(ReadOnlySpan<byte> span)
         {
             if (span.Length < 8)
@@ -101,7 +116,7 @@ namespace RabbitMQ.Util
                 throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to decode UInt64 from memory.");
             }
 
-            return BinaryPrimitives.ReadUInt64BigEndian(span);
+            return ((ulong)span[0] << 56) | ((ulong)span[1] << 48) | ((ulong)span[2] << 40) | ((ulong)span[3] << 32) | ((ulong)span[4] << 24) | ((ulong)span[5] << 16) | ((ulong)span[6] << 8) | span[7];
         }
     }
 }

--- a/projects/RabbitMQ.Client/util/NetworkOrderSerializer.cs
+++ b/projects/RabbitMQ.Client/util/NetworkOrderSerializer.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace RabbitMQ.Util
 {
     internal static class NetworkOrderSerializer
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void WriteDouble(Memory<byte> memory, double val)
         {
             if (memory.Length < 8)
@@ -12,9 +15,11 @@ namespace RabbitMQ.Util
                 throw new ArgumentOutOfRangeException(nameof(memory), "Insufficient length to write Double to memory.");
             }
 
-            BinaryPrimitives.WriteInt64BigEndian(memory.Span, BitConverter.DoubleToInt64Bits(val));
+            long tempVal = BitConverter.DoubleToInt64Bits(val);
+            SerializeInt64(memory.Span, tempVal);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void WriteInt16(Memory<byte> memory, short val)
         {
             if (memory.Length < 2)
@@ -22,9 +27,10 @@ namespace RabbitMQ.Util
                 throw new ArgumentOutOfRangeException(nameof(memory), "Insufficient length to write Int16 to memory.");
             }
 
-            BinaryPrimitives.WriteInt16BigEndian(memory.Span, val);
+            SerializeInt16(memory.Span, val);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void WriteInt32(Memory<byte> memory, int val)
         {
             if (memory.Length < 4)
@@ -32,9 +38,10 @@ namespace RabbitMQ.Util
                 throw new ArgumentOutOfRangeException(nameof(memory), "Insufficient length to write Int32 to memory.");
             }
 
-            BinaryPrimitives.WriteInt32BigEndian(memory.Span, val);
+            SerializeInt32(memory.Span, val);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void WriteInt64(Memory<byte> memory, long val)
         {
             if (memory.Length < 8)
@@ -42,9 +49,10 @@ namespace RabbitMQ.Util
                 throw new ArgumentOutOfRangeException(nameof(memory), "Insufficient length to write Int64 to memory.");
             }
 
-            BinaryPrimitives.WriteInt64BigEndian(memory.Span, val);
-        }
+            SerializeInt64(memory.Span, val);
+        }        
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void WriteSingle(Memory<byte> memory, float val)
         {
             if (memory.Length < 4)
@@ -52,15 +60,11 @@ namespace RabbitMQ.Util
                 throw new ArgumentOutOfRangeException(nameof(memory), "Insufficient length to write Single to memory.");
             }
 
-            byte[] bytes = BitConverter.GetBytes(val);
-            if (BitConverter.IsLittleEndian)
-            {
-                Array.Reverse(bytes);
-            }
-
-            bytes.AsMemory().CopyTo(memory);
+            int tempVal = Unsafe.As<float, int>(ref val);
+            SerializeInt32(memory.Span, tempVal);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void WriteUInt16(Memory<byte> memory, ushort val)
         {
             if (memory.Length < 2)
@@ -68,9 +72,10 @@ namespace RabbitMQ.Util
                 throw new ArgumentOutOfRangeException(nameof(memory), "Insufficient length to write UInt16 to memory.");
             }
 
-            BinaryPrimitives.WriteUInt16BigEndian(memory.Span, val);
+            SerializeUInt16(memory.Span, val);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void WriteUInt32(Memory<byte> memory, uint val)
         {
             if (memory.Length < 4)
@@ -78,9 +83,11 @@ namespace RabbitMQ.Util
                 throw new ArgumentOutOfRangeException(nameof(memory), "Insufficient length to write UInt32 to memory.");
             }
 
-            BinaryPrimitives.WriteUInt32BigEndian(memory.Span, val);
+            SerializeUInt32(memory.Span, val);
         }
 
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void WriteUInt64(Memory<byte> memory, ulong val)
         {
             if (memory.Length < 8)
@@ -88,7 +95,54 @@ namespace RabbitMQ.Util
                 throw new ArgumentOutOfRangeException(nameof(memory), "Insufficient length to write UInt64 from memory.");
             }
 
-            BinaryPrimitives.WriteUInt64BigEndian(memory.Span, val);
+            SerializeUInt64(memory.Span, val);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void SerializeInt16(Span<byte> memory, short val)
+        {
+            SerializeUInt16(memory, (ushort)val);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void SerializeUInt16(Span<byte> memory, ushort val)
+        {
+            memory[0] = (byte)((val >> 8) & 0xFF);
+            memory[1] = (byte)(val & 0xFF);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void SerializeInt32(Span<byte> memory, int val)
+        {
+            SerializeUInt32(memory, (uint)val);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void SerializeUInt32(Span<byte> memory, uint val)
+        {
+            memory[0] = (byte)((val >> 24) & 0xFF);
+            memory[1] = (byte)((val >> 16) & 0xFF);
+            memory[2] = (byte)((val >> 8) & 0xFF);
+            memory[3] = (byte)(val & 0xFF);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void SerializeInt64(Span<byte> memory, long val)
+        {
+            SerializeUInt64(memory, (ulong)val);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void SerializeUInt64(Span<byte> memory, ulong val)
+        {
+            memory[0] = (byte)((val >> 56) & 0xFF);
+            memory[1] = (byte)((val >> 48) & 0xFF);
+            memory[2] = (byte)((val >> 40) & 0xFF);
+            memory[3] = (byte)((val >> 32) & 0xFF);
+            memory[4] = (byte)((val >> 24) & 0xFF);
+            memory[5] = (byte)((val >> 16) & 0xFF);
+            memory[6] = (byte)((val >> 8) & 0xFF);
+            memory[7] = (byte)(val & 0xFF);
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

Optimizations for (de)serialization of short, ushort, int, uint, long and ulong, basically forcing Network-Order at all times, regardless of architecture. This gets rid of a lot of redundant endianness checks making the code a bit more verbose but performing a lot better. Some code in here had actually regressed quite a bit from the original implementation from a pure serialization perspective, although it was still faster due to overhead in the old NetworkBinaryReader class. This should bring best of both worlds :)

## Types of Changes

What types of changes does your code introduce to this project?
- [X] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

