### PR TITLE
Fixing possible premature disposal of pooled memory

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/AsyncConsumerDispatcher.cs
+++ b/projects/RabbitMQ.Client/client/impl/AsyncConsumerDispatcher.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.Threading.Tasks;
 
 namespace RabbitMQ.Client.Impl
@@ -46,7 +47,9 @@ namespace RabbitMQ.Client.Impl
             IBasicProperties basicProperties,
             ReadOnlyMemory<byte> body)
         {
-            ScheduleUnlessShuttingDown(new BasicDeliver(consumer, consumerTag, deliveryTag, redelivered, exchange, routingKey, basicProperties, body));
+            IMemoryOwner<byte> bodyCopy = MemoryPool<byte>.Shared.Rent(body.Length);
+            body.CopyTo(bodyCopy.Memory);
+            ScheduleUnlessShuttingDown(new BasicDeliver(consumer, consumerTag, deliveryTag, redelivered, exchange, routingKey, basicProperties, bodyCopy, body.Length));
         }
 
         public void HandleBasicCancelOk(IBasicConsumer consumer, string consumerTag)


### PR DESCRIPTION
## Proposed Changes

This should fix an issue where pooled memory used in message bodies might be prematurely disposed. This is fixed by copying the message body when work is scheduled and disposing the new pool when the job processing is completed.

## Types of Changes

What types of changes does your code introduce to this project?
- [X] Bug fix (non-breaking change which fixes issue #802)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories