### PR TITLE
Use EndpointResolverFactory as indicated in XML comments

### DIFF
--- a/projects/RabbitMQ.Client/client/api/ConnectionFactory.cs
+++ b/projects/RabbitMQ.Client/client/api/ConnectionFactory.cs
@@ -355,7 +355,7 @@ namespace RabbitMQ.Client
         /// </exception>
         public IConnection CreateConnection()
         {
-            return CreateConnection(EndpointResolverFactory(LocalEndpoints()), ClientProvidedName);
+            return CreateConnection(ClientProvidedName);
         }
 
         /// <summary>
@@ -419,7 +419,7 @@ namespace RabbitMQ.Client
         public IConnection CreateConnection(IList<string> hostnames, string clientProvidedName)
         {
             IEnumerable<AmqpTcpEndpoint> endpoints = hostnames.Select(h => new AmqpTcpEndpoint(h, Port, Ssl));
-            return CreateConnection(new DefaultEndpointResolver(endpoints), clientProvidedName);
+            return CreateConnection(EndpointResolverFactory(endpoints), clientProvidedName);
         }
 
         /// <summary>
@@ -461,7 +461,7 @@ namespace RabbitMQ.Client
         /// </exception>
         public IConnection CreateConnection(IList<AmqpTcpEndpoint> endpoints, string clientProvidedName)
         {
-            return CreateConnection(new DefaultEndpointResolver(endpoints), clientProvidedName);
+            return CreateConnection(EndpointResolverFactory(endpoints), clientProvidedName);
         }
 
         /// <summary>


### PR DESCRIPTION
## Proposed Changes

While reviewing the `ConnectionFactory` code for other reasons, I noticed that the `EndpointResolverFactory` wasn't being used in all the places it should be. The XML comments for those `CreateConnection` overloads indicate that the resolver can be controlled via the factory, so this makes that true.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
