### PR TITLE
Made WorkService more responsive to stop signals under load

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/AsyncConsumerWorkService.cs
+++ b/projects/RabbitMQ.Client/client/impl/AsyncConsumerWorkService.cs
@@ -49,7 +49,10 @@ namespace RabbitMQ.Client.Impl
 
             public void Start()
             {
-                _worker = Task.Run(Loop, CancellationToken.None);
+                _worker = Task.Run(Loop, _tokenSource.Token)
+                // continuation ignores TaskCancelledException
+                // (the Stop had been called before Loop started execution) 
+                    .ContinueWith((originalTask) => {}, TaskContinuationOptions.ExecuteSynchronously);
             }
 
             public void Enqueue(Work work)


### PR DESCRIPTION
##  Proposed Changes

If the system is under load and has many tasks scheduled, the `Loop` can be scheduled but not started. The consumer of the class that tries to stop the loop by calling `Stop` has to wait until the thread pool gets to process the `Loop`. Passing the cancellation token to `Task.Run` lets the `_worker` task that is being returned from the `Stop` call to be completed faster, so the consumer no longer has to wait for the thread pool to process the `Loop`.

The synchronous continuation is added to ignore the cancellation exception in this scenario. The `Loop` code does not throw for now, but if it will, the continuation can be modified to re-throw the "inner" exceptions with `ExceptionDispatchInfo`.  

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments
