### PR TITLE
AutorecoveringConnection uses ContinuationTimeout from ConnectionFactory

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.cs
@@ -299,6 +299,7 @@ namespace RabbitMQ.Client.Framing.Impl
         {
             ISession session = _delegate.CreateSession();
             var result = new RecoveryAwareModel(session);
+            result.ContinuationTimeout = _factory.ContinuationTimeout;
             result._Private_ChannelOpen("");
             return result;
         }

--- a/projects/Unit/Fixtures.cs
+++ b/projects/Unit/Fixtures.cs
@@ -165,6 +165,16 @@ namespace RabbitMQ.Client.Unit
             return cf.CreateConnection($"UNIT_CONN:{Guid.NewGuid()}");
         }
 
+        internal IConnection CreateConnectionWithContinuationTimeout(bool automaticRecoveryEnabled, TimeSpan continuationTimeout)
+        {
+            var cf = new ConnectionFactory
+            {
+                AutomaticRecoveryEnabled = automaticRecoveryEnabled,
+                ContinuationTimeout = continuationTimeout
+            };
+            return cf.CreateConnection($"UNIT_CONN:{Guid.NewGuid()}");
+        }
+
         //
         // Channels
         //

--- a/projects/Unit/TestConnectionFactoryContinuationTimeout.cs
+++ b/projects/Unit/TestConnectionFactoryContinuationTimeout.cs
@@ -1,0 +1,69 @@
+﻿// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 1.1.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2020 VMware, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       https://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v1.1:
+//
+//---------------------------------------------------------------------------
+//  The contents of this file are subject to the Mozilla Public License
+//  Version 1.1 (the "License"); you may not use this file except in
+//  compliance with the License. You may obtain a copy of the License
+//  at https://www.mozilla.org/MPL/
+//
+//  Software distributed under the License is distributed on an "AS IS"
+//  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+//  the License for the specific language governing rights and
+//  limitations under the License.
+//
+//  The Original Code is RabbitMQ.
+//
+//  The Initial Developer of the Original Code is Pivotal Software, Inc.
+//  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
+//---------------------------------------------------------------------------
+
+using System;
+using NUnit.Framework;
+
+namespace RabbitMQ.Client.Unit
+{
+    [TestFixture]
+    internal class TestConnectionFactoryContinuationTimeout : IntegrationFixture
+    {
+        [Test]
+        public void TestConnectionFactoryContinuationTimeoutOnRecoveringConnection()
+        {
+            var continuationTimeout = TimeSpan.FromSeconds(777);
+            using (IConnection c = CreateConnectionWithContinuationTimeout(true, continuationTimeout))
+            {
+                Assert.AreEqual(continuationTimeout, c.CreateModel().ContinuationTimeout);
+            }
+        }
+
+        [Test]
+        public void TestConnectionFactoryContinuationTimeoutOnNonRecoveringConnection()
+        {
+            var continuationTimeout = TimeSpan.FromSeconds(777);
+            using (IConnection c = CreateConnectionWithContinuationTimeout(false, continuationTimeout))
+            {
+                Assert.AreEqual(continuationTimeout, c.CreateModel().ContinuationTimeout);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes

This is to address issue #821. ContinuationTimeout set on Connection Factory was ignored if AutomaticRecoveryEnabled was set to `true`. Exact same behavior is already implemented for non-auto recovery connection:

https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/93cdd66867c92cb281f01243d4b278c09f3c87bd/projects/client/RabbitMQ.Client/src/client/impl/Connection.cs#L1207

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #821 )
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
