### PR TITLE
Do not throw on invalid ReplyTo address

### DIFF
--- a/projects/RabbitMQ.Client/client/api/PublicationAddress.cs
+++ b/projects/RabbitMQ.Client/client/api/PublicationAddress.cs
@@ -106,6 +106,14 @@ namespace RabbitMQ.Client
         /// </summary>
         public static PublicationAddress Parse(string uriLikeString)
         {
+            // Callers such as IBasicProperties.ReplyToAddress
+            // expect null result for invalid input.
+            // The regex.Match() throws on null arguments so we perform explicit check here
+            if (uriLikeString == null)
+            {
+                return null;
+            }
+
             Match match = PSEUDO_URI_PARSER.Match(uriLikeString);
             if (match.Success)
             {

--- a/projects/Unit/TestBasicProperties.cs
+++ b/projects/Unit/TestBasicProperties.cs
@@ -120,5 +120,36 @@ namespace RabbitMQ.Client.Unit
             Assert.AreEqual(isCorrelationIdPresent, propertiesFromStream.IsCorrelationIdPresent());
             Assert.AreEqual(isMessageIdPresent, propertiesFromStream.IsMessageIdPresent());
         }
+
+        [Test]
+        public void TestProperties_ReplyTo(
+            [Values(null, "foo_1", "fanout://name/key")] string replyTo
+            )
+        {
+            // Arrange
+            var subject = new Framing.BasicProperties
+            {
+
+                // Act
+                ReplyTo = replyTo,
+            };
+
+            // Assert
+            bool isReplyToPresent = replyTo != null;
+            string replyToAddress = PublicationAddress.Parse(replyTo)?.ToString();
+            Assert.AreEqual(isReplyToPresent, subject.IsReplyToPresent());
+
+            var writer = new Impl.ContentHeaderPropertyWriter(new byte[1024]);
+            subject.WritePropertiesTo(ref writer);
+
+            // Read from Stream
+            var propertiesFromStream = new Framing.BasicProperties();
+            var reader = new Impl.ContentHeaderPropertyReader(writer.Memory.Slice(0, writer.Offset));
+            propertiesFromStream.ReadPropertiesFrom(ref reader);
+
+            Assert.AreEqual(replyTo, propertiesFromStream.ReplyTo);
+            Assert.AreEqual(isReplyToPresent, propertiesFromStream.IsReplyToPresent());
+            Assert.AreEqual(replyToAddress, propertiesFromStream.ReplyToAddress?.ToString());
+        }
     }
 }

--- a/projects/Unit/TestPropertiesClone.cs
+++ b/projects/Unit/TestPropertiesClone.cs
@@ -68,10 +68,10 @@ namespace RabbitMQ.Client.Unit
             bp.ContentType = "foo_1";
             bp.ContentEncoding = "foo_2";
             bp.Headers = new Dictionary<string, object>
-        {
-            { "foo_3", "foo_4" },
-            { "foo_5", "foo_6" }
-        };
+            {
+                { "foo_3", "foo_4" },
+                { "foo_5", "foo_6" }
+            };
             bp.DeliveryMode = 2;
             // Persistent also changes DeliveryMode's value to 2
             bp.Persistent = true;
@@ -123,6 +123,7 @@ namespace RabbitMQ.Client.Unit
             Assert.AreEqual(12, bpClone.Priority);
             Assert.AreEqual("foo_7", bpClone.CorrelationId);
             Assert.AreEqual("foo_8", bpClone.ReplyTo);
+            Assert.AreEqual(null, bpClone.ReplyToAddress);
             Assert.AreEqual("foo_9", bpClone.Expiration);
             Assert.AreEqual("foo_10", bpClone.MessageId);
             Assert.AreEqual(new AmqpTimestamp(123), bpClone.Timestamp);
@@ -141,10 +142,10 @@ namespace RabbitMQ.Client.Unit
             bp.ContentType = "foo_1";
             bp.ContentEncoding = "foo_2";
             bp.Headers = new Dictionary<string, object>
-        {
-            { "foo_3", "foo_4" },
-            { "foo_5", "foo_6" }
-        };
+            {
+                { "foo_3", "foo_4" },
+                { "foo_5", "foo_6" }
+            };
             bp.DeliveryMode = 2;
             // Persistent also changes DeliveryMode's value to 2
             bp.Persistent = true;

--- a/projects/Unit/TestPublicationAddress.cs
+++ b/projects/Unit/TestPublicationAddress.cs
@@ -59,6 +59,7 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void TestParseFail()
         {
+            Assert.IsNull(PublicationAddress.Parse(null));
             Assert.IsNull(PublicationAddress.Parse("not a valid uri"));
         }
 


### PR DESCRIPTION
## Proposed Changes

Do not throw ArgumentNullException from `ReplyToAddress` getter and `PublicationAddress.Parse()` call. See #827 for more details.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #827 )
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories (no such changes)

## Further Comments

I've decided to add fix into the `PublicationAddress.Parse()` method as `ReplyToAddress` documentation states 
>  /// Returns null if ReplyTo property cannot be parsed by PublicationAddress.Parse
