### PR TITLE
Introduce PublicationAddress.TryParse and switch BasicProperties.ReplyToAddress to use it

### DIFF
--- a/projects/RabbitMQ.Client/client/api/IBasicProperties.cs
+++ b/projects/RabbitMQ.Client/client/api/IBasicProperties.cs
@@ -121,9 +121,9 @@ namespace RabbitMQ.Client
         string ReplyTo { get; set; }
 
         /// <summary>
-        /// Convenience property; parses <see cref="ReplyTo"/> property using <see cref="PublicationAddress.Parse"/>,
+        /// Convenience property; parses <see cref="ReplyTo"/> property using <see cref="PublicationAddress.TryParse"/>,
         /// and serializes it using <see cref="PublicationAddress.ToString"/>.
-        /// Returns null if <see cref="ReplyTo"/> property cannot be parsed by <see cref="PublicationAddress.Parse"/>.
+        /// Returns null if <see cref="ReplyTo"/> property cannot be parsed by <see cref="PublicationAddress.TryParse"/>.
         /// </summary>
         PublicationAddress ReplyToAddress { get; set; }
 

--- a/projects/RabbitMQ.Client/client/api/PublicationAddress.cs
+++ b/projects/RabbitMQ.Client/client/api/PublicationAddress.cs
@@ -106,14 +106,6 @@ namespace RabbitMQ.Client
         /// </summary>
         public static PublicationAddress Parse(string uriLikeString)
         {
-            // Callers such as IBasicProperties.ReplyToAddress
-            // expect null result for invalid input.
-            // The regex.Match() throws on null arguments so we perform explicit check here
-            if (uriLikeString == null)
-            {
-                return null;
-            }
-
             Match match = PSEUDO_URI_PARSER.Match(uriLikeString);
             if (match.Success)
             {
@@ -122,6 +114,22 @@ namespace RabbitMQ.Client
                     match.Groups[3].Value);
             }
             return null;
+        }
+
+        public static PublicationAddress TryParse(string uriLikeString) {
+            // Callers such as IBasicProperties.ReplyToAddress
+            // expect null result for invalid input.
+            // The regex.Match() throws on null arguments so we perform explicit check here
+            if (uriLikeString == null)
+            {
+                return null;
+            } else {
+                try {
+                    return Parse(uriLikeString);
+                } catch {
+                    return null;
+                }
+            }
         }
 
         /// <summary>

--- a/projects/RabbitMQ.Client/client/api/PublicationAddress.cs
+++ b/projects/RabbitMQ.Client/client/api/PublicationAddress.cs
@@ -106,6 +106,14 @@ namespace RabbitMQ.Client
         /// </summary>
         public static PublicationAddress Parse(string uriLikeString)
         {
+            // Callers such as IBasicProperties.ReplyToAddress
+            // expect null result for invalid input.
+            // The regex.Match() throws on null arguments so we perform explicit check here
+            if (uriLikeString == null)
+            {
+                return null;
+            }
+
             Match match = PSEUDO_URI_PARSER.Match(uriLikeString);
             if (match.Success)
             {

--- a/projects/RabbitMQ.Client/client/api/PublicationAddress.cs
+++ b/projects/RabbitMQ.Client/client/api/PublicationAddress.cs
@@ -116,7 +116,8 @@ namespace RabbitMQ.Client
             return null;
         }
 
-        public static PublicationAddress TryParse(string uriLikeString) {
+        public static PublicationAddress TryParse(string uriLikeString)
+        {
             // Callers such as IBasicProperties.ReplyToAddress
             // expect null result for invalid input.
             // The regex.Match() throws on null arguments so we perform explicit check here

--- a/projects/RabbitMQ.Client/client/api/PublicationAddress.cs
+++ b/projects/RabbitMQ.Client/client/api/PublicationAddress.cs
@@ -116,19 +116,23 @@ namespace RabbitMQ.Client
             return null;
         }
 
-        public static PublicationAddress TryParse(string uriLikeString)
+        public static bool TryParse(string uriLikeString, out PublicationAddress result)
         {
             // Callers such as IBasicProperties.ReplyToAddress
             // expect null result for invalid input.
             // The regex.Match() throws on null arguments so we perform explicit check here
             if (uriLikeString == null)
             {
-                return null;
+                result = null;
+                return false;
             } else {
                 try {
-                    return Parse(uriLikeString);
+                    var res = Parse(uriLikeString);
+                    result = res;
+                    return true;
                 } catch {
-                    return null;
+                    result = null;
+                    return false;
                 }
             }
         }

--- a/projects/RabbitMQ.Client/client/api/PublicationAddress.cs
+++ b/projects/RabbitMQ.Client/client/api/PublicationAddress.cs
@@ -125,12 +125,17 @@ namespace RabbitMQ.Client
             {
                 result = null;
                 return false;
-            } else {
-                try {
+            }
+            else
+            {
+                try
+                {
                     var res = Parse(uriLikeString);
                     result = res;
                     return true;
-                } catch {
+                }
+                catch
+                {
                     result = null;
                     return false;
                 }

--- a/projects/RabbitMQ.Client/client/impl/BasicProperties.cs
+++ b/projects/RabbitMQ.Client/client/impl/BasicProperties.cs
@@ -109,9 +109,9 @@ namespace RabbitMQ.Client.Impl
         public abstract string ReplyTo { get; set; }
 
         /// <summary>
-        /// Convenience property; parses <see cref="ReplyTo"/> property using <see cref="PublicationAddress.Parse"/>,
+        /// Convenience property; parses <see cref="ReplyTo"/> property using <see cref="PublicationAddress.TryParse"/>,
         /// and serializes it using <see cref="PublicationAddress.ToString"/>.
-        /// Returns null if <see cref="ReplyTo"/> property cannot be parsed by <see cref="PublicationAddress.Parse"/>.
+        /// Returns null if <see cref="ReplyTo"/> property cannot be parsed by <see cref="PublicationAddress.TryParse"/>.
         /// </summary>
         public PublicationAddress ReplyToAddress
         {

--- a/projects/RabbitMQ.Client/client/impl/BasicProperties.cs
+++ b/projects/RabbitMQ.Client/client/impl/BasicProperties.cs
@@ -115,7 +115,11 @@ namespace RabbitMQ.Client.Impl
         /// </summary>
         public PublicationAddress ReplyToAddress
         {
-            get { return PublicationAddress.TryParse(ReplyTo); }
+            get { 
+                PublicationAddress result;
+                PublicationAddress.TryParse(ReplyTo, out result);
+                return result;
+            }
             set { ReplyTo = value.ToString(); }
         }
 

--- a/projects/RabbitMQ.Client/client/impl/BasicProperties.cs
+++ b/projects/RabbitMQ.Client/client/impl/BasicProperties.cs
@@ -115,7 +115,8 @@ namespace RabbitMQ.Client.Impl
         /// </summary>
         public PublicationAddress ReplyToAddress
         {
-            get { 
+            get
+            {
                 PublicationAddress result;
                 PublicationAddress.TryParse(ReplyTo, out result);
                 return result;

--- a/projects/RabbitMQ.Client/client/impl/BasicProperties.cs
+++ b/projects/RabbitMQ.Client/client/impl/BasicProperties.cs
@@ -115,7 +115,7 @@ namespace RabbitMQ.Client.Impl
         /// </summary>
         public PublicationAddress ReplyToAddress
         {
-            get { return PublicationAddress.Parse(ReplyTo); }
+            get { return PublicationAddress.TryParse(ReplyTo); }
             set { ReplyTo = value.ToString(); }
         }
 

--- a/projects/RabbitMQ.Client/client/impl/BasicProperties.cs
+++ b/projects/RabbitMQ.Client/client/impl/BasicProperties.cs
@@ -115,10 +115,8 @@ namespace RabbitMQ.Client.Impl
         /// </summary>
         public PublicationAddress ReplyToAddress
         {
-            get
-            {
-                PublicationAddress result;
-                PublicationAddress.TryParse(ReplyTo, out result);
+            get { 
+                PublicationAddress.TryParse(ReplyTo, out var result);
                 return result;
             }
             set { ReplyTo = value.ToString(); }

--- a/projects/Unit/APIApproval.Approve.verified.txt
+++ b/projects/Unit/APIApproval.Approve.verified.txt
@@ -483,6 +483,7 @@ namespace RabbitMQ.Client
         public string RoutingKey { get; }
         public override string ToString() { }
         public static RabbitMQ.Client.PublicationAddress Parse(string uriLikeString) { }
+        public static bool TryParse(string uriLikeString, out RabbitMQ.Client.PublicationAddress result) { }
     }
     public class QueueDeclareOk
     {

--- a/projects/Unit/TestBasicProperties.cs
+++ b/projects/Unit/TestBasicProperties.cs
@@ -135,7 +135,9 @@ namespace RabbitMQ.Client.Unit
 
             // Assert
             bool isReplyToPresent = replyTo != null;
-            string replyToAddress = PublicationAddress.TryParse(replyTo)?.ToString();
+            PublicationAddress result;
+            PublicationAddress.TryParse(replyTo, out result);
+            string replyToAddress = result?.ToString();
             Assert.AreEqual(isReplyToPresent, subject.IsReplyToPresent());
 
             var writer = new Impl.ContentHeaderPropertyWriter(new byte[1024]);

--- a/projects/Unit/TestBasicProperties.cs
+++ b/projects/Unit/TestBasicProperties.cs
@@ -120,5 +120,36 @@ namespace RabbitMQ.Client.Unit
             Assert.AreEqual(isCorrelationIdPresent, propertiesFromStream.IsCorrelationIdPresent());
             Assert.AreEqual(isMessageIdPresent, propertiesFromStream.IsMessageIdPresent());
         }
+
+        [Test]
+        public void TestProperties_ReplyTo(
+            [Values(null, "foo_1", "fanout://name/key")] string replyTo
+            )
+        {
+            // Arrange
+            var subject = new Framing.BasicProperties
+            {
+
+                // Act
+                ReplyTo = replyTo,
+            };
+
+            // Assert
+            bool isReplyToPresent = replyTo != null;
+            string replyToAddress = PublicationAddress.Parse(replyTo)?.ToString();
+            Assert.AreEqual(isReplyToPresent, subject.IsReplyToPresent());
+
+            var writer = new Impl.ContentHeaderPropertyWriter(new byte[1024]);
+            subject.WritePropertiesTo(ref writer);
+
+            // Read from Stream
+            var propertiesFromStream = new Framing.BasicProperties();
+            var reader = new Impl.ContentHeaderPropertyReader(writer.Memory.Slice(0, writer.Offset));
+            propertiesFromStream.ReadPropertiesFrom(ref reader);
+
+            Assert.AreEqual(replyTo, propertiesFromStream.ReplyTo);
+            Assert.AreEqual(isReplyToPresent, propertiesFromStream.IsReplyToPresent());
+            Assert.AreEqual(replyToAddress, propertiesFromStream.ReplyToAddress?.ToString());
+        }
     }
 }

--- a/projects/Unit/TestBasicProperties.cs
+++ b/projects/Unit/TestBasicProperties.cs
@@ -122,9 +122,7 @@ namespace RabbitMQ.Client.Unit
         }
 
         [Test]
-        public void TestProperties_ReplyTo(
-            [Values(null, "foo_1", "fanout://name/key")] string replyTo
-            )
+        public void TestProperties_ReplyTo([Values(null, "foo_1", "fanout://name/key")] string replyTo)
         {
             // Arrange
             var subject = new Framing.BasicProperties

--- a/projects/Unit/TestBasicProperties.cs
+++ b/projects/Unit/TestBasicProperties.cs
@@ -52,7 +52,6 @@ namespace RabbitMQ.Client.Unit
             // Arrange
             var subject = new Framing.BasicProperties
             {
-
                 // Act
                 Persistent = true
             };

--- a/projects/Unit/TestBasicProperties.cs
+++ b/projects/Unit/TestBasicProperties.cs
@@ -129,14 +129,13 @@ namespace RabbitMQ.Client.Unit
             // Arrange
             var subject = new Framing.BasicProperties
             {
-
                 // Act
                 ReplyTo = replyTo,
             };
 
             // Assert
             bool isReplyToPresent = replyTo != null;
-            string replyToAddress = PublicationAddress.Parse(replyTo)?.ToString();
+            string replyToAddress = PublicationAddress.TryParse(replyTo)?.ToString();
             Assert.AreEqual(isReplyToPresent, subject.IsReplyToPresent());
 
             var writer = new Impl.ContentHeaderPropertyWriter(new byte[1024]);

--- a/projects/Unit/TestPropertiesClone.cs
+++ b/projects/Unit/TestPropertiesClone.cs
@@ -68,10 +68,10 @@ namespace RabbitMQ.Client.Unit
             bp.ContentType = "foo_1";
             bp.ContentEncoding = "foo_2";
             bp.Headers = new Dictionary<string, object>
-        {
-            { "foo_3", "foo_4" },
-            { "foo_5", "foo_6" }
-        };
+            {
+                { "foo_3", "foo_4" },
+                { "foo_5", "foo_6" }
+            };
             bp.DeliveryMode = 2;
             // Persistent also changes DeliveryMode's value to 2
             bp.Persistent = true;
@@ -123,6 +123,7 @@ namespace RabbitMQ.Client.Unit
             Assert.AreEqual(12, bpClone.Priority);
             Assert.AreEqual("foo_7", bpClone.CorrelationId);
             Assert.AreEqual("foo_8", bpClone.ReplyTo);
+            Assert.AreEqual(null, bpClone.ReplyToAddress);
             Assert.AreEqual("foo_9", bpClone.Expiration);
             Assert.AreEqual("foo_10", bpClone.MessageId);
             Assert.AreEqual(new AmqpTimestamp(123), bpClone.Timestamp);
@@ -141,10 +142,10 @@ namespace RabbitMQ.Client.Unit
             bp.ContentType = "foo_1";
             bp.ContentEncoding = "foo_2";
             bp.Headers = new Dictionary<string, object>
-        {
-            { "foo_3", "foo_4" },
-            { "foo_5", "foo_6" }
-        };
+            {
+                { "foo_3", "foo_4" },
+                { "foo_5", "foo_6" }
+            };
             bp.DeliveryMode = 2;
             // Persistent also changes DeliveryMode's value to 2
             bp.Persistent = true;

--- a/projects/Unit/TestPublicationAddress.cs
+++ b/projects/Unit/TestPublicationAddress.cs
@@ -59,6 +59,7 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void TestParseFail()
         {
+            Assert.IsNull(PublicationAddress.Parse(null));
             Assert.IsNull(PublicationAddress.Parse("not a valid uri"));
         }
 

--- a/projects/Unit/TestPublicationAddress.cs
+++ b/projects/Unit/TestPublicationAddress.cs
@@ -57,10 +57,23 @@ namespace RabbitMQ.Client.Unit
         }
 
         [Test]
-        public void TestParseFail()
+        public void TestParseFailWithANE()
         {
-            Assert.IsNull(PublicationAddress.Parse(null));
-            Assert.IsNull(PublicationAddress.Parse("not a valid uri"));
+            Assert.That(()=> PublicationAddress.Parse(null), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void TestParseFailWithUnparseableInput()
+        {
+            Assert.IsNull(PublicationAddress.Parse("not a valid URI"));
+        }
+
+        [Test]
+        public void TestTryParseFail()
+        {
+            Assert.IsNull(PublicationAddress.TryParse(null));
+            Assert.IsNull(PublicationAddress.TryParse("not a valid URI"));
+            Assert.IsNull(PublicationAddress.TryParse("}}}}}}}}"));
         }
 
         [Test]

--- a/projects/Unit/TestPublicationAddress.cs
+++ b/projects/Unit/TestPublicationAddress.cs
@@ -71,9 +71,15 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void TestTryParseFail()
         {
-            Assert.IsNull(PublicationAddress.TryParse(null));
-            Assert.IsNull(PublicationAddress.TryParse("not a valid URI"));
-            Assert.IsNull(PublicationAddress.TryParse("}}}}}}}}"));
+            PublicationAddress result;
+            PublicationAddress.TryParse(null, out result);
+            Assert.IsNull(result);
+
+            PublicationAddress.TryParse("not a valid URI", out result);
+            Assert.IsNull(result);
+
+            PublicationAddress.TryParse("}}}}}}}}", out result);
+            Assert.IsNull(result);
         }
 
         [Test]


### PR DESCRIPTION
## Proposed Changes

This is an alternative to #828 (with @ig-sinicyn's test case retained for credit) which does
not change the behavior of `PublicationAddress.Parse` and instead introduces `PublicationAddress.TryParse` which is then used by `BasicProperties.ReplyToAddress`.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #827)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

