### PR TITLE
Replacing usage of ManualResetEvent with ManualResetEventSlim

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -64,7 +64,7 @@ namespace RabbitMQ.Client.Framing.Impl
         ///<summary>Heartbeat frame for transmission. Reusable across connections.</summary>
         private readonly EmptyOutboundFrame _heartbeatFrame = new EmptyOutboundFrame();
 
-        private readonly ManualResetEvent _appContinuation = new ManualResetEvent(false);
+        private readonly ManualResetEventSlim _appContinuation = new ManualResetEventSlim(false);
 
         private volatile ShutdownEventArgs _closeReason = null;
         private volatile bool _closed = false;
@@ -346,8 +346,7 @@ namespace RabbitMQ.Client.Framing.Impl
                 }
             }
 
-            bool receivedSignal = _appContinuation.WaitOne(timeout);
-
+            bool receivedSignal = _appContinuation.Wait(timeout);
             if (!receivedSignal)
             {
                 _frameHandler.Close();

--- a/projects/RabbitMQ.Client/client/impl/ModelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ModelBase.cs
@@ -66,7 +66,7 @@ namespace RabbitMQ.Client.Impl
         private TimeSpan _continuationTimeout = TimeSpan.FromSeconds(20);
 
         private readonly RpcContinuationQueue _continuationQueue = new RpcContinuationQueue();
-        private readonly ManualResetEvent _flowControlBlock = new ManualResetEvent(true);
+        private readonly ManualResetEventSlim _flowControlBlock = new ManualResetEventSlim(true);
 
         private readonly object _shutdownLock = new object();
         private readonly object _rpcLock = new object();
@@ -353,7 +353,7 @@ namespace RabbitMQ.Client.Impl
         {
             if (method.HasContent)
             {
-                _flowControlBlock.WaitOne();
+                _flowControlBlock.Wait();
                 Session.Transmit(new Command(method, header, body));
             }
             else
@@ -1410,7 +1410,7 @@ namespace RabbitMQ.Client.Impl
 
         internal void SendCommands(IList<Command> commands)
         {
-            _flowControlBlock.WaitOne();
+            _flowControlBlock.Wait();
             AllocatatePublishSeqNos(commands.Count);
             Session.Transmit(commands);
         }

--- a/projects/Unit/Fixtures.cs
+++ b/projects/Unit/Fixtures.cs
@@ -698,14 +698,14 @@ namespace RabbitMQ.Client.Unit
         // Concurrency and Coordination
         //
 
-        internal void Wait(ManualResetEvent latch)
+        internal void Wait(ManualResetEventSlim latch)
         {
-            Assert.IsTrue(latch.WaitOne(TimeSpan.FromSeconds(10)), "waiting on a latch timed out");
+            Assert.IsTrue(latch.Wait(TimeSpan.FromSeconds(10)), "waiting on a latch timed out");
         }
 
-        internal void Wait(ManualResetEvent latch, TimeSpan timeSpan)
+        internal void Wait(ManualResetEventSlim latch, TimeSpan timeSpan)
         {
-            Assert.IsTrue(latch.WaitOne(timeSpan), "waiting on a latch timed out");
+            Assert.IsTrue(latch.Wait(timeSpan), "waiting on a latch timed out");
         }
 
         //

--- a/projects/Unit/TestConnectionShutdown.cs
+++ b/projects/Unit/TestConnectionShutdown.cs
@@ -53,7 +53,7 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void TestShutdownSignalPropagationToChannels()
         {
-            var latch = new ManualResetEvent(false);
+            var latch = new ManualResetEventSlim(false);
 
             Model.ModelShutdown += (model, args) => {
                 latch.Set();
@@ -67,7 +67,7 @@ namespace RabbitMQ.Client.Unit
         public void TestConsumerDispatcherShutdown()
         {
             var m = (AutorecoveringModel)Model;
-            var latch = new ManualResetEvent(false);
+            var latch = new ManualResetEventSlim(false);
 
             Model.ModelShutdown += (model, args) =>
             {

--- a/projects/Unit/TestEventingConsumer.cs
+++ b/projects/Unit/TestEventingConsumer.cs
@@ -54,9 +54,9 @@ namespace RabbitMQ.Client.Unit
         {
             string q = Model.QueueDeclare();
 
-            var registeredLatch = new ManualResetEvent(false);
+            var registeredLatch = new ManualResetEventSlim(false);
             object registeredSender = null;
-            var unregisteredLatch = new ManualResetEvent(false);
+            var unregisteredLatch = new ManualResetEventSlim(false);
             object unregisteredSender = null;
 
             EventingBasicConsumer ec = new EventingBasicConsumer(Model);

--- a/projects/Unit/TestModelShutdown.cs
+++ b/projects/Unit/TestModelShutdown.cs
@@ -54,7 +54,7 @@ namespace RabbitMQ.Client.Unit
         public void TestConsumerDispatcherShutdown()
         {
             var m = (AutorecoveringModel)Model;
-            var latch = new ManualResetEvent(false);
+            var latch = new ManualResetEventSlim(false);
 
             Model.ModelShutdown += (model, args) =>
             {


### PR DESCRIPTION
## Proposed Changes

Since the client never does cross-appdomain or cross-process communication internally, there is no need to use ManualResetEvent instead of ManualResetEventSlim.

ManualResetEventSlim can often avoid allocating a kernel-level object by using a spinlock wait mechanism for a short duration before switching so it can often stay inside the managed code boundaries.

See detailed description and performance characteristics here: https://download.microsoft.com/download/B/C/F/BCFD4868-1354-45E3-B71B-B851CD78733D/PerformanceCharacteristicsOfSyncPrimitives.pdf

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
