### PR TITLE
getting rid of a Func allocation

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/AsyncConsumerWorkService.cs
+++ b/projects/RabbitMQ.Client/client/impl/AsyncConsumerWorkService.cs
@@ -16,8 +16,7 @@ namespace RabbitMQ.Client.Impl
             /*
              * rabbitmq/rabbitmq-dotnet-client#841
              * https://docs.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentdictionary-2.getoradd
-             * Note that the value delegate is not atomic but instances of this class are not meant to be used by
-             * multiple threads.
+             * Note that the value delegate is not atomic but the Schedule method will not be called concurrently.
              */
             WorkPool workPool = _workPools.GetOrAdd(model, _startNewWorkPoolFunc);
             workPool.Enqueue(work);

--- a/projects/RabbitMQ.Client/client/impl/AsyncConsumerWorkService.cs
+++ b/projects/RabbitMQ.Client/client/impl/AsyncConsumerWorkService.cs
@@ -8,11 +8,18 @@ namespace RabbitMQ.Client.Impl
 {
     internal sealed class AsyncConsumerWorkService : ConsumerWorkService
     {
-        private readonly ConcurrentDictionary<IModel, WorkPool> _workPools = new ConcurrentDictionary<IModel, WorkPool>();
+        private readonly ConcurrentDictionary<IModel, WorkPool> _workPools;
+        private readonly Func<IModel, WorkPool> _startNewWorkPoolAction;
+
+        public AsyncConsumerWorkService()
+        {
+            _workPools = new ConcurrentDictionary<IModel, WorkPool>();
+            _startNewWorkPoolAction = model => StartNewWorkPool(model);
+        }
 
         public void Schedule<TWork>(ModelBase model, TWork work) where TWork : Work
         {
-            _workPools.GetOrAdd(model, StartNewWorkPool).Enqueue(work);
+            _workPools.GetOrAdd(model, _startNewWorkPoolAction).Enqueue(work);
         }
 
         private WorkPool StartNewWorkPool(IModel model)

--- a/projects/RabbitMQ.Client/client/impl/ConsumerWorkService.cs
+++ b/projects/RabbitMQ.Client/client/impl/ConsumerWorkService.cs
@@ -15,8 +15,7 @@ namespace RabbitMQ.Client.Impl
             /*
              * rabbitmq/rabbitmq-dotnet-client#841
              * https://docs.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentdictionary-2.getoradd
-             * Note that the value delegate is not atomic but instances of this class are not meant to be used by
-             * multiple threads.
+             * Note that the value delegate is not atomic but the AddWork method will not be called concurrently.
              */
             WorkPool workPool = _workPools.GetOrAdd(model, _startNewWorkPoolFunc);
             workPool.Enqueue(fn);


### PR DESCRIPTION
## Proposed Changes

The AsyncConsumerWorkService was allocating a new Func for each call to Schedule<TWork> (Also spotted in the images of [#824](https://github.com/rabbitmq/rabbitmq-dotnet-client/pull/824#issuecomment-623544094) due to [this roslyn bug](https://github.com/dotnet/roslyn/issues/5835)

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

I haven't verified these changes myself, as I just stumbled upon this while looking for some other answer and I quickly edited it in Github only. 