### PR TITLE
Frame optimizations

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -1005,7 +1005,7 @@ entry.ToString());
         {
             EnsureIsOpen();
             ISession session = CreateSession();
-            var model = (IFullModel)Protocol.CreateModel(session);
+            var model = (IFullModel)Protocol.CreateModel(session, ConsumerWorkService);
             model.ContinuationTimeout = _factory.ContinuationTimeout;
             model._Private_ChannelOpen("");
             return model;

--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -948,11 +948,6 @@ entry.ToString());
             _frameHandler.WriteFrame(f);
         }
 
-        public void WriteFrameSet(IList<OutboundFrame> f)
-        {
-            _frameHandler.WriteFrameSet(f);
-        }
-
         public void UpdateSecret(string newSecret, string reason)
         {
             _model0.UpdateSecret(newSecret, reason);
@@ -1010,7 +1005,7 @@ entry.ToString());
         {
             EnsureIsOpen();
             ISession session = CreateSession();
-            var model = (IFullModel)Protocol.CreateModel(session, ConsumerWorkService);
+            var model = (IFullModel)Protocol.CreateModel(session);
             model.ContinuationTimeout = _factory.ContinuationTimeout;
             model._Private_ChannelOpen("");
             return model;

--- a/projects/RabbitMQ.Client/client/impl/IFrameHandler.cs
+++ b/projects/RabbitMQ.Client/client/impl/IFrameHandler.cs
@@ -71,8 +71,6 @@ namespace RabbitMQ.Client.Impl
 
         void SendHeader();
 
-        void WriteFrame(OutboundFrame frame, bool flush = true);
-
-        void WriteFrameSet(IList<OutboundFrame> frames);
+        void WriteFrame(OutboundFrame frame);
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/SessionBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/SessionBase.cs
@@ -191,9 +191,14 @@ namespace RabbitMQ.Client.Impl
             // of frames within a channel.  But that is fixed in socket frame handler instead, so no need to lock.
             cmd.Transmit(ChannelNumber, Connection);
         }
+
         public virtual void Transmit(IList<Command> commands)
         {
-            Connection.WriteFrameSet(Command.CalculateFrames(ChannelNumber, Connection, commands));
+            for (int i = 0; i < commands.Count; i++)
+            {
+                Command command = commands[i];
+                command.Transmit(ChannelNumber, Connection);
+            }
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

- Buffers outbound frames using a Channel, and create a background task that consumes from that channel and writes to the socket. This makes for more efficient buffering of outbound frames as well as removes that write-lock from the SocketFrameHandler since there is only ever one writer accessing the socket.
- As a result, we also get rid of a temporary list allocation when writing frame sets, and we can simplify the command->frame splitting code as well as simplify the socket writers.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories