### PR TITLE
simplify WriteShortstr

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/WireFormatting.cs
+++ b/projects/RabbitMQ.Client/client/impl/WireFormatting.cs
@@ -293,11 +293,11 @@ namespace RabbitMQ.Client.Impl
             {
                 case string val:
                     memory.Span[0] = (byte)'S';
-                    if (MemoryMarshal.TryGetArray(memory.Slice(5, Encoding.UTF8.GetByteCount(val)), out ArraySegment<byte> segment))
+                    if (MemoryMarshal.TryGetArray(memory, out ArraySegment<byte> segment))
                     {
-                        NetworkOrderSerializer.WriteUInt32(slice, (uint)segment.Count);
-                        Encoding.UTF8.GetBytes(val, 0, val.Length, segment.Array, segment.Offset);
-                        return segment.Count + 5;
+                        int bytesWritten = Encoding.UTF8.GetBytes(val, 0, val.Length, segment.Array, segment.Offset +  5);
+                        NetworkOrderSerializer.WriteUInt32(slice, (uint)bytesWritten);
+                        return 5 + bytesWritten;
                     }
 
                     throw new WireFormattingException("Unable to get array segment from memory.");
@@ -429,12 +429,11 @@ namespace RabbitMQ.Client.Impl
 
         public static int WriteShortstr(Memory<byte> memory, string val)
         {
-            int stringBytesNeeded = Encoding.UTF8.GetByteCount(val);
-            if (MemoryMarshal.TryGetArray(memory.Slice(1, stringBytesNeeded), out ArraySegment<byte> segment))
+            if (MemoryMarshal.TryGetArray(memory, out ArraySegment<byte> segment))
             {
-                memory.Span[0] = (byte)stringBytesNeeded;
-                Encoding.UTF8.GetBytes(val, 0, val.Length, segment.Array, segment.Offset);
-                return stringBytesNeeded + 1;
+                int bytesWritten = Encoding.UTF8.GetBytes(val, 0, val.Length, segment.Array, segment.Offset + 1);
+                memory.Span[0] = (byte)bytesWritten;
+                return bytesWritten + 1;
             }
 
             throw new WireFormattingException("Unable to get array segment from memory.");


### PR DESCRIPTION
## Proposed Changes

Simplifying write of string values. GetBytes returns the number of bytes written, so there is no need to precalculate the length.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Question: There is a bug in the code (before this and also after this) that if you write a string resulting in more than 255 bytes, the length variable (byte) will be cut off and the resulting deserialized value will be different from the source. Shall I open an issue for this?
