### PR TITLE
throw ArgumentOutOfRangeException when table key is too long (> 255)

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/WireFormatting.cs
+++ b/projects/RabbitMQ.Client/client/impl/WireFormatting.cs
@@ -432,8 +432,13 @@ namespace RabbitMQ.Client.Impl
             if (MemoryMarshal.TryGetArray(memory, out ArraySegment<byte> segment))
             {
                 int bytesWritten = Encoding.UTF8.GetBytes(val, 0, val.Length, segment.Array, segment.Offset + 1);
-                memory.Span[0] = (byte)bytesWritten;
-                return bytesWritten + 1;
+                if (bytesWritten <= byte.MaxValue)
+                {
+                    memory.Span[0] = (byte)bytesWritten;
+                   return bytesWritten + 1;
+                }
+
+                throw new ArgumentOutOfRangeException(nameof(val), val, "Value exceeds the maximum allowed length of 255 bytes.");
             }
 
             throw new WireFormattingException("Unable to get array segment from memory.");

--- a/projects/Unit/TestFieldTableFormatting.cs
+++ b/projects/Unit/TestFieldTableFormatting.cs
@@ -38,6 +38,7 @@
 //  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
+using System;
 using System.Collections;
 using System.Text;
 
@@ -125,6 +126,20 @@ namespace RabbitMQ.Client.Unit
                     (byte)'x', // type
                     0,0,0,2,0xaa,0x55 // value
                 });
+        }
+
+        [Test]
+        public void TestTableEncoding_LongKey()
+        {
+            const int TooLarge = 256;
+            Hashtable t = new Hashtable
+            {
+                [new string('A', TooLarge)] = null
+            };
+            int bytesNeeded = WireFormatting.GetTableByteCount(t);
+            byte[] bytes = new byte[bytesNeeded];
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => WireFormatting.WriteTable(bytes, t));
         }
 
         [Test]


### PR DESCRIPTION
## Proposed Changes

As brought up in #845, there was a bug that if a key of a dictionary was longer than 255, it wrote the overflowed byte value and the full byte array. The reader on the other side though was only reading the number of bytes (the overflowed one) and then the followed reads were then off.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
