### PR TITLE
Fixing rethrown exceptions to properly preserve stackframes.

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -310,11 +310,11 @@ namespace RabbitMQ.Client.Framing.Impl
                     // Wait for CloseOk in the MainLoop
                     _session0.Transmit(ConnectionCloseWrapper(reason.ReplyCode, reason.ReplyText));
                 }
-                catch (AlreadyClosedException ace)
+                catch (AlreadyClosedException)
                 {
                     if (!abort)
                     {
-                        throw ace;
+                        throw;
                     }
                 }
 #pragma warning disable 0168
@@ -330,7 +330,7 @@ namespace RabbitMQ.Client.Framing.Impl
                     {
                         if (!abort)
                         {
-                            throw ioe;
+                            throw;
                         }
                         else
                         {

--- a/projects/RabbitMQ.Client/client/impl/Frame.cs
+++ b/projects/RabbitMQ.Client/client/impl/Frame.cs
@@ -42,6 +42,7 @@ using System;
 using System.Buffers;
 using System.IO;
 using System.Net.Sockets;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using RabbitMQ.Client.Exceptions;
 using RabbitMQ.Client.Framing;
@@ -228,7 +229,7 @@ namespace RabbitMQ.Client.Impl
 
         internal static InboundFrame ReadFrom(Stream reader)
         {
-            int type;
+            int type = default;
 
             try
             {
@@ -247,9 +248,10 @@ namespace RabbitMQ.Client.Impl
                     !(ioe.InnerException is SocketException) ||
                     ((SocketException)ioe.InnerException).SocketErrorCode != SocketError.TimedOut)
                 {
-                    throw ioe;
+                    throw;
                 }
-                throw ioe.InnerException;
+
+                ExceptionDispatchInfo.Capture(ioe.InnerException).Throw();
             }
 
             if (type == 'A')

--- a/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
+++ b/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
@@ -291,10 +291,10 @@ namespace RabbitMQ.Client.Impl
                 ConnectOrFail(socket, endpoint, timeout);
                 return socket;
             }
-            catch (ConnectFailureException e)
+            catch (ConnectFailureException)
             {
                 socket.Dispose();
-                throw e;
+                throw;
             }
         }
 

--- a/projects/Unit/Fixtures.cs
+++ b/projects/Unit/Fixtures.cs
@@ -499,7 +499,7 @@ namespace RabbitMQ.Client.Unit
             catch (Exception e)
             {
                 ReportExecFailure("rabbitmqctl", args, e.Message);
-                throw e;
+                throw;
             }
         }
 
@@ -556,7 +556,7 @@ namespace RabbitMQ.Client.Unit
             catch (Exception e)
             {
                 ReportExecFailure(cmd, args, e.Message);
-                throw e;
+                throw;
             }
         }
 


### PR DESCRIPTION
## Proposed Changes

This PR fixes those cases where exceptions were rethrown in a way that polluted the stackframes, making debugging/troubleshooting harder.

This is in line with the .NET guidelines on rethrowing exceptions:
https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2200?view=vs-2019
https://docs.microsoft.com/en-us/archive/msdn-magazine/2015/november/essential-net-csharp-exception-handling#throwing-existing-exceptions-without-replacing-stack-information

## Types of Changes

- [X] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
