### PR TITLE
Adding BinaryPrimitives support for NETSTANDARD targets

### DIFF
--- a/projects/Apigen/apigen/Apigen.cs
+++ b/projects/Apigen/apigen/Apigen.cs
@@ -935,8 +935,8 @@ $@"namespace {ApiNamespaceBase}
         {
             EmitLine("    internal override Client.Impl.MethodBase DecodeMethodFrom(ReadOnlyMemory<byte> memory)");
             EmitLine("    {");
-            EmitLine("      ushort classId = Util.NetworkOrderDeserializer.ReadUInt16(memory);");
-            EmitLine("      ushort methodId = Util.NetworkOrderDeserializer.ReadUInt16(memory.Slice(2));");
+            EmitLine("      ushort classId = Util.NetworkOrderDeserializer.ReadUInt16(memory.Span);");
+            EmitLine("      ushort methodId = Util.NetworkOrderDeserializer.ReadUInt16(memory.Slice(2).Span);");
             EmitLine("      Client.Impl.MethodBase result = DecodeMethodFrom(classId, methodId);");
             EmitLine("      if(result != null)");
             EmitLine("      {");

--- a/projects/RabbitMQ.Client/client/impl/CommandAssembler.cs
+++ b/projects/RabbitMQ.Client/client/impl/CommandAssembler.cs
@@ -89,7 +89,7 @@ namespace RabbitMQ.Client.Impl
                     {
                         throw new UnexpectedFrameException(f.Type);
                     }
-                    m_header = m_protocol.DecodeContentHeaderFrom(NetworkOrderDeserializer.ReadUInt16(f.Payload));
+                    m_header = m_protocol.DecodeContentHeaderFrom(NetworkOrderDeserializer.ReadUInt16(f.Payload.Span));
                     ulong totalBodyBytes = m_header.ReadFrom(f.Payload.Slice(2));
                     if (totalBodyBytes > MaxArrayOfBytesSize)
                     {

--- a/projects/RabbitMQ.Client/client/impl/ContentHeaderBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ContentHeaderBase.cs
@@ -70,7 +70,7 @@ namespace RabbitMQ.Client.Impl
         internal ulong ReadFrom(ReadOnlyMemory<byte> memory)
         {
             // Skipping the first two bytes since they arent used (weight - not currently used)
-            ulong bodySize = NetworkOrderDeserializer.ReadUInt64(memory.Slice(2));
+            ulong bodySize = NetworkOrderDeserializer.ReadUInt64(memory.Slice(2).Span);
             ContentHeaderPropertyReader reader = new ContentHeaderPropertyReader(memory.Slice(10));
             ReadPropertiesFrom(ref reader);
             return bodySize;
@@ -83,8 +83,8 @@ namespace RabbitMQ.Client.Impl
 
         internal int WriteTo(Memory<byte> memory, ulong bodySize)
         {
-            NetworkOrderSerializer.WriteUInt16(memory, ZERO); // Weight - not used
-            NetworkOrderSerializer.WriteUInt64(memory.Slice(2), bodySize);
+            NetworkOrderSerializer.WriteUInt16(memory.Span, ZERO); // Weight - not used
+            NetworkOrderSerializer.WriteUInt64(memory.Slice(2).Span, bodySize);
 
             ContentHeaderPropertyWriter writer = new ContentHeaderPropertyWriter(memory.Slice(10));
             WritePropertiesTo(ref writer);

--- a/projects/RabbitMQ.Client/client/impl/ContentHeaderPropertyReader.cs
+++ b/projects/RabbitMQ.Client/client/impl/ContentHeaderPropertyReader.cs
@@ -84,21 +84,21 @@ namespace RabbitMQ.Client.Impl
             {
                 throw new MalformedFrameException("Attempted to read flag word when none advertised");
             }
-            m_flagWord = NetworkOrderDeserializer.ReadUInt16(_memory.Slice(_memoryOffset));
+            m_flagWord = NetworkOrderDeserializer.ReadUInt16(_memory.Slice(_memoryOffset).Span);
             _memoryOffset += 2;
             m_bitCount = 0;
         }
 
         public uint ReadLong()
         {
-            uint result = NetworkOrderDeserializer.ReadUInt32(_memory.Slice(_memoryOffset));
+            uint result = NetworkOrderDeserializer.ReadUInt32(_memory.Slice(_memoryOffset).Span);
             _memoryOffset += 4;
             return result;
         }
 
         public ulong ReadLonglong()
         {
-            ulong result = NetworkOrderDeserializer.ReadUInt64(_memory.Slice(_memoryOffset));
+            ulong result = NetworkOrderDeserializer.ReadUInt64(_memory.Slice(_memoryOffset).Span);
             _memoryOffset += 8;
             return result;
         }
@@ -130,7 +130,7 @@ namespace RabbitMQ.Client.Impl
 
         public ushort ReadShort()
         {
-            ushort result = NetworkOrderDeserializer.ReadUInt16(_memory.Slice(_memoryOffset));
+            ushort result = NetworkOrderDeserializer.ReadUInt16(_memory.Slice(_memoryOffset).Span);
             _memoryOffset += 2;
             return result;
         }

--- a/projects/RabbitMQ.Client/client/impl/ContentHeaderPropertyWriter.cs
+++ b/projects/RabbitMQ.Client/client/impl/ContentHeaderPropertyWriter.cs
@@ -127,7 +127,7 @@ namespace RabbitMQ.Client.Impl
 
         private void EmitFlagWord(bool continuationBit)
         {
-            NetworkOrderSerializer.WriteUInt16(Memory.Slice(Offset), (ushort)(continuationBit ? (_flagWord | 1) : _flagWord));
+            NetworkOrderSerializer.WriteUInt16(Memory.Slice(Offset).Span, (ushort)(continuationBit ? (_flagWord | 1) : _flagWord));
             Offset += 2;
             _flagWord = 0;
             _bitCount = 0;

--- a/projects/RabbitMQ.Client/client/impl/Frame.cs
+++ b/projects/RabbitMQ.Client/client/impl/Frame.cs
@@ -69,7 +69,7 @@ namespace RabbitMQ.Client.Impl
         internal override int WritePayload(Memory<byte> memory)
         {
             // write protocol class id (2 bytes)
-            NetworkOrderSerializer.WriteUInt16(memory, _header.ProtocolClassId);
+            NetworkOrderSerializer.WriteUInt16(memory.Span, _header.ProtocolClassId);
             // write header (X bytes)
             int bytesWritten = _header.WriteTo(memory.Slice(2), (ulong)_bodyLength);
             return 2 + bytesWritten;
@@ -114,8 +114,8 @@ namespace RabbitMQ.Client.Impl
 
         internal override int WritePayload(Memory<byte> memory)
         {
-            NetworkOrderSerializer.WriteUInt16(memory, _method.ProtocolClassId);
-            NetworkOrderSerializer.WriteUInt16(memory.Slice(2), _method.ProtocolMethodId);
+            NetworkOrderSerializer.WriteUInt16(memory.Span, _method.ProtocolClassId);
+            NetworkOrderSerializer.WriteUInt16(memory.Slice(2).Span, _method.ProtocolMethodId);
             var argWriter = new MethodArgumentWriter(memory.Slice(4));
             _method.WriteArgumentsTo(ref argWriter);
             argWriter.Flush();
@@ -150,9 +150,9 @@ namespace RabbitMQ.Client.Impl
         internal void WriteTo(Memory<byte> memory)
         {
             memory.Span[0] = (byte)Type;
-            NetworkOrderSerializer.WriteUInt16(memory.Slice(1), (ushort)Channel);
+            NetworkOrderSerializer.WriteUInt16(memory.Slice(1).Span, (ushort)Channel);
             int bytesWritten = WritePayload(memory.Slice(7));
-            NetworkOrderSerializer.WriteUInt32(memory.Slice(3), (uint)bytesWritten);
+            NetworkOrderSerializer.WriteUInt32(memory.Slice(3).Span, (uint)bytesWritten);
             memory.Span[bytesWritten + 7] = Constants.FrameEnd;
             ByteCount = bytesWritten + 8;
         }

--- a/projects/RabbitMQ.Client/client/impl/MethodArgumentReader.cs
+++ b/projects/RabbitMQ.Client/client/impl/MethodArgumentReader.cs
@@ -82,7 +82,7 @@ namespace RabbitMQ.Client.Impl
         public uint ReadLong()
         {
             ClearBits();
-            uint result = NetworkOrderDeserializer.ReadUInt32(_memory.Slice(_memoryOffset));
+            uint result = NetworkOrderDeserializer.ReadUInt32(_memory.Slice(_memoryOffset).Span);
             _memoryOffset += 4;
             return result;
         }
@@ -90,7 +90,7 @@ namespace RabbitMQ.Client.Impl
         public ulong ReadLonglong()
         {
             ClearBits();
-            ulong result = NetworkOrderDeserializer.ReadUInt64(_memory.Slice(_memoryOffset));
+            ulong result = NetworkOrderDeserializer.ReadUInt64(_memory.Slice(_memoryOffset).Span);
             _memoryOffset += 8;
             return result;
         }
@@ -112,7 +112,7 @@ namespace RabbitMQ.Client.Impl
         public ushort ReadShort()
         {
             ClearBits();
-            ushort result = NetworkOrderDeserializer.ReadUInt16(_memory.Slice(_memoryOffset));
+            ushort result = NetworkOrderDeserializer.ReadUInt16(_memory.Slice(_memoryOffset).Span);
             _memoryOffset += 2;
             return result;
         }

--- a/projects/RabbitMQ.Client/util/NetworkOrderDeserializer.cs
+++ b/projects/RabbitMQ.Client/util/NetworkOrderDeserializer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 
 namespace RabbitMQ.Util
@@ -6,111 +7,115 @@ namespace RabbitMQ.Util
     internal static class NetworkOrderDeserializer
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static double ReadDouble(ReadOnlyMemory<byte> memory) => ReadDouble(memory.Span);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static double ReadDouble(ReadOnlySpan<byte> span)
         {
+#if NETFRAMEWORK
             if (span.Length < 8)
             {
                 throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to decode Double from memory.");
             }
-
             ulong val = ReadUInt64(span);
+#elif NETSTANDARD
+            ulong val = BinaryPrimitives.ReadUInt64BigEndian(span);
+#endif
             return Unsafe.As<ulong, double>(ref val);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static short ReadInt16(ReadOnlyMemory<byte> memory) => ReadInt16(memory.Span);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static short ReadInt16(ReadOnlySpan<byte> span)
         {
+#if NETFRAMEWORK
             if (span.Length < 2)
             {
                 throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to decode Int16 from memory.");
             }
 
             return (short)ReadUInt16(span);
+#elif NETSTANDARD
+            return BinaryPrimitives.ReadInt16BigEndian(span);
+#endif
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int ReadInt32(ReadOnlyMemory<byte> memory) => ReadInt32(memory.Span);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int ReadInt32(ReadOnlySpan<byte> span)
         {
+#if NETFRAMEWORK
             if (span.Length < 4)
             {
                 throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to decode Int32 from memory.");
             }
 
             return (int)ReadUInt32(span);
+#elif NETSTANDARD
+            return BinaryPrimitives.ReadInt32BigEndian(span);
+#endif
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static long ReadInt64(ReadOnlyMemory<byte> memory) => ReadInt64(memory.Span);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static long ReadInt64(ReadOnlySpan<byte> span)
         {
+#if NETFRAMEWORK
             if (span.Length < 8)
             {
                 throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to decode Int64 from memory.");
             }
 
             return (long)ReadUInt64(span);
+#elif NETSTANDARD
+            return BinaryPrimitives.ReadInt64BigEndian(span);
+#endif
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static float ReadSingle(ReadOnlyMemory<byte> memory) => ReadSingle(memory.Span);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static float ReadSingle(ReadOnlySpan<byte> span)
         {
+#if NETFRAMEWORK
             if (span.Length < 4)
             {
                 throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to decode Single from memory.");
             }
 
             uint num = ReadUInt32(span);
+#elif NETSTANDARD
+            uint num = BinaryPrimitives.ReadUInt32BigEndian(span);
+#endif
             return Unsafe.As<uint, float>(ref num);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static ushort ReadUInt16(ReadOnlyMemory<byte> memory) => ReadUInt16(memory.Span);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static ushort ReadUInt16(ReadOnlySpan<byte> span)
         {
+#if NETFRAMEWORK
             if (span.Length < 2)
             {
                 throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to decode UInt16 from memory.");
             }
 
             return (ushort)((span[0] << 8) | span[1]);
+#elif NETSTANDARD
+            return BinaryPrimitives.ReadUInt16BigEndian(span);
+#endif
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static uint ReadUInt32(ReadOnlyMemory<byte> memory) => ReadUInt32(memory.Span);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static uint ReadUInt32(ReadOnlySpan<byte> span)
         {
+#if NETFRAMEWORK
             if (span.Length < 4)
             {
                 throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to decode UInt32 from memory.");
             }
 
             return (uint)((span[0] << 24) | (span[1] << 16) | (span[2] << 8) | span[3]);
+#elif NETSTANDARD
+            return BinaryPrimitives.ReadUInt32BigEndian(span);
+#endif
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static ulong ReadUInt64(ReadOnlyMemory<byte> memory) => ReadUInt64(memory.Span);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static ulong ReadUInt64(ReadOnlySpan<byte> span)
         {
+#if NETFRAMEWORK
             if (span.Length < 8)
             {
                 throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to decode UInt64 from memory.");
@@ -119,6 +124,9 @@ namespace RabbitMQ.Util
             uint num1 = (uint)((span[0] << 24) | (span[1] << 16) | (span[2] << 8) | span[3]);
             uint num2 = (uint)((span[4] << 24) | (span[5] << 16) | (span[6] << 8) | span[7]);
             return ((ulong)num1 << 32) | num2;
+#elif NETSTANDARD
+            return BinaryPrimitives.ReadUInt64BigEndian(span);
+#endif
         }
     }
 }

--- a/projects/RabbitMQ.Client/util/NetworkOrderSerializer.cs
+++ b/projects/RabbitMQ.Client/util/NetworkOrderSerializer.cs
@@ -8,141 +8,160 @@ namespace RabbitMQ.Util
     internal static class NetworkOrderSerializer
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void WriteDouble(Memory<byte> memory, double val)
+        internal static void WriteDouble(Span<byte> span, double val)
         {
-            if (memory.Length < 8)
+#if NETFRAMEWORK
+            if (span.Length < 8)
             {
-                throw new ArgumentOutOfRangeException(nameof(memory), "Insufficient length to write Double to memory.");
+                throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to write Double to memory.");
             }
 
             long tempVal = BitConverter.DoubleToInt64Bits(val);
-            SerializeInt64(memory.Span, tempVal);
+            span[0] = (byte)((tempVal >> 56) & 0xFF);
+            span[1] = (byte)((tempVal >> 48) & 0xFF);
+            span[2] = (byte)((tempVal >> 40) & 0xFF);
+            span[3] = (byte)((tempVal >> 32) & 0xFF);
+            span[4] = (byte)((tempVal >> 24) & 0xFF);
+            span[5] = (byte)((tempVal >> 16) & 0xFF);
+            span[6] = (byte)((tempVal >> 8) & 0xFF);
+            span[7] = (byte)(tempVal & 0xFF);
+#elif NETSTANDARD
+            long tempVal = BitConverter.DoubleToInt64Bits(val);
+            BinaryPrimitives.WriteInt64BigEndian(span, tempVal);
+#endif
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void WriteInt16(Memory<byte> memory, short val)
+        internal static void WriteInt16(Span<byte> span, short val)
         {
-            if (memory.Length < 2)
+#if NETFRAMEWORK
+            if (span.Length < 2)
             {
-                throw new ArgumentOutOfRangeException(nameof(memory), "Insufficient length to write Int16 to memory.");
+                throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to write Int16 to memory.");
             }
 
-            SerializeInt16(memory.Span, val);
+            span[0] = (byte)((val >> 8) & 0xFF);
+            span[1] = (byte)(val & 0xFF);
+#elif NETSTANDARD
+            BinaryPrimitives.WriteInt16BigEndian(span, val);
+#endif
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void WriteInt32(Memory<byte> memory, int val)
+        internal static void WriteInt32(Span<byte> span, int val)
         {
-            if (memory.Length < 4)
+#if NETFRAMEWORK
+            if (span.Length < 4)
             {
-                throw new ArgumentOutOfRangeException(nameof(memory), "Insufficient length to write Int32 to memory.");
+                throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to write Int32 to memory.");
             }
 
-            SerializeInt32(memory.Span, val);
+            span[0] = (byte)((val >> 24) & 0xFF);
+            span[1] = (byte)((val >> 16) & 0xFF);
+            span[2] = (byte)((val >> 8) & 0xFF);
+            span[3] = (byte)(val & 0xFF);
+#elif NETSTANDARD
+            BinaryPrimitives.WriteInt32BigEndian(span, val);
+#endif
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void WriteInt64(Memory<byte> memory, long val)
+        internal static void WriteInt64(Span<byte> span, long val)
         {
-            if (memory.Length < 8)
+#if NETFRAMEWORK
+            if (span.Length < 8)
             {
-                throw new ArgumentOutOfRangeException(nameof(memory), "Insufficient length to write Int64 to memory.");
+                throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to write Int64 to memory.");
             }
 
-            SerializeInt64(memory.Span, val);
-        }        
+            span[0] = (byte)((val >> 56) & 0xFF);
+            span[1] = (byte)((val >> 48) & 0xFF);
+            span[2] = (byte)((val >> 40) & 0xFF);
+            span[3] = (byte)((val >> 32) & 0xFF);
+            span[4] = (byte)((val >> 24) & 0xFF);
+            span[5] = (byte)((val >> 16) & 0xFF);
+            span[6] = (byte)((val >> 8) & 0xFF);
+            span[7] = (byte)(val & 0xFF);
+#elif NETSTANDARD
+            BinaryPrimitives.WriteInt64BigEndian(span, val);
+#endif
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void WriteSingle(Memory<byte> memory, float val)
+        internal static void WriteSingle(Span<byte> span, float val)
         {
-            if (memory.Length < 4)
+#if NETFRAMEWORK
+            if (span.Length < 4)
             {
-                throw new ArgumentOutOfRangeException(nameof(memory), "Insufficient length to write Single to memory.");
+                throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to write Single to memory.");
             }
 
             int tempVal = Unsafe.As<float, int>(ref val);
-            SerializeInt32(memory.Span, tempVal);
+            span[0] = (byte)((tempVal >> 24) & 0xFF);
+            span[1] = (byte)((tempVal >> 16) & 0xFF);
+            span[2] = (byte)((tempVal >> 8) & 0xFF);
+            span[3] = (byte)(tempVal & 0xFF);
+#elif NETSTANDARD
+            int tempVal = Unsafe.As<float, int>(ref val);
+            BinaryPrimitives.WriteInt32BigEndian(span, tempVal);
+#endif
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void WriteUInt16(Memory<byte> memory, ushort val)
+        internal static void WriteUInt16(Span<byte> span, ushort val)
         {
-            if (memory.Length < 2)
+#if NETFRAMEWORK
+            if (span.Length < 2)
             {
-                throw new ArgumentOutOfRangeException(nameof(memory), "Insufficient length to write UInt16 to memory.");
+                throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to write UInt16 to memory.");
             }
 
-            SerializeUInt16(memory.Span, val);
+            span[0] = (byte)((val >> 8) & 0xFF);
+            span[1] = (byte)(val & 0xFF);
+#elif NETSTANDARD
+            BinaryPrimitives.WriteUInt16BigEndian(span, val);
+#endif
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void WriteUInt32(Memory<byte> memory, uint val)
+        internal static void WriteUInt32(Span<byte> span, uint val)
         {
-            if (memory.Length < 4)
+#if NETFRAMEWORK
+            if (span.Length < 4)
             {
-                throw new ArgumentOutOfRangeException(nameof(memory), "Insufficient length to write UInt32 to memory.");
+                throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to write UInt32 to memory.");
             }
 
-            SerializeUInt32(memory.Span, val);
+            span[0] = (byte)((val >> 24) & 0xFF);
+            span[1] = (byte)((val >> 16) & 0xFF);
+            span[2] = (byte)((val >> 8) & 0xFF);
+            span[3] = (byte)(val & 0xFF);
+#elif NETSTANDARD
+            BinaryPrimitives.WriteUInt32BigEndian(span, val);
+#endif
         }
 
-        
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void WriteUInt64(Memory<byte> memory, ulong val)
+        internal static void WriteUInt64(Span<byte> span, ulong val)
         {
-            if (memory.Length < 8)
+            if (span.Length < 8)
             {
-                throw new ArgumentOutOfRangeException(nameof(memory), "Insufficient length to write UInt64 from memory.");
+                throw new ArgumentOutOfRangeException(nameof(span), "Insufficient length to write UInt64 from memory.");
             }
 
-            SerializeUInt64(memory.Span, val);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void SerializeInt16(Span<byte> memory, short val)
-        {
-            SerializeUInt16(memory, (ushort)val);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void SerializeUInt16(Span<byte> memory, ushort val)
-        {
-            memory[0] = (byte)((val >> 8) & 0xFF);
-            memory[1] = (byte)(val & 0xFF);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void SerializeInt32(Span<byte> memory, int val)
-        {
-            SerializeUInt32(memory, (uint)val);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void SerializeUInt32(Span<byte> memory, uint val)
-        {
-            memory[0] = (byte)((val >> 24) & 0xFF);
-            memory[1] = (byte)((val >> 16) & 0xFF);
-            memory[2] = (byte)((val >> 8) & 0xFF);
-            memory[3] = (byte)(val & 0xFF);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void SerializeInt64(Span<byte> memory, long val)
-        {
-            SerializeUInt64(memory, (ulong)val);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void SerializeUInt64(Span<byte> memory, ulong val)
-        {
-            memory[0] = (byte)((val >> 56) & 0xFF);
-            memory[1] = (byte)((val >> 48) & 0xFF);
-            memory[2] = (byte)((val >> 40) & 0xFF);
-            memory[3] = (byte)((val >> 32) & 0xFF);
-            memory[4] = (byte)((val >> 24) & 0xFF);
-            memory[5] = (byte)((val >> 16) & 0xFF);
-            memory[6] = (byte)((val >> 8) & 0xFF);
-            memory[7] = (byte)(val & 0xFF);
+#if NETFRAMEWORK
+            span[0] = (byte)((val >> 56) & 0xFF);
+            span[1] = (byte)((val >> 48) & 0xFF);
+            span[2] = (byte)((val >> 40) & 0xFF);
+            span[3] = (byte)((val >> 32) & 0xFF);
+            span[4] = (byte)((val >> 24) & 0xFF);
+            span[5] = (byte)((val >> 16) & 0xFF);
+            span[6] = (byte)((val >> 8) & 0xFF);
+            span[7] = (byte)(val & 0xFF);
+#elif NETSTANDARD
+            BinaryPrimitives.WriteUInt64BigEndian(span, val);
+#endif
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

This PR adds NETSTANDARD ifdefs for the binary serialization for more optimized code when targeting .NET Core applications. Thanks to @bollhals for the tip and the benchmarks showing greatly improved performance for those targets, which I had underestimated. See #801 for the discussion.

This does convolute the code a little bit (but not too much) and is mostly aimed at 6.X as these ifdefs can be removed for 7.0 later and we can just stick to the BinaryPrimitives method there.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
