### PR TITLE
simplify missed heartbeat recognition

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -86,9 +86,9 @@ namespace RabbitMQ.Client.Framing.Impl
 
         private TimeSpan _heartbeat = TimeSpan.Zero;
         private TimeSpan _heartbeatTimeSpan = TimeSpan.FromSeconds(0);
-        private int _missedHeartbeats = 0;
+        private int _missedHeartbeats;
         private int _heartbeatCounter;
-        private int _lastHeartbeat;
+        private int _lastHeartbeatCounter;
 
         private Timer _heartbeatWriteTimer;
         private Timer _heartbeatReadTimer;
@@ -618,7 +618,12 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public void NotifyHeartbeatListener()
         {
-            _heartbeatCounter++;
+            // https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/checked-and-unchecked
+            // No worries if this overflows. What matters is that the value changes.
+            unchecked
+            {
+                _heartbeatCounter++;
+            }
         }
 
         public void NotifyReceivedCloseOk()
@@ -845,7 +850,7 @@ namespace RabbitMQ.Client.Framing.Impl
             {
                 if (!_closed)
                 {
-                    if (_lastHeartbeat == _heartbeatCounter)
+                    if (_lastHeartbeatCounter == _heartbeatCounter)
                     {
                         _missedHeartbeats++;
                     }
@@ -854,7 +859,7 @@ namespace RabbitMQ.Client.Framing.Impl
                         _missedHeartbeats = 0;
                     }
 
-                    _lastHeartbeat = _heartbeatCounter;
+                    _lastHeartbeatCounter = _heartbeatCounter;
 
                     // We check against 8 = 2 * 4 because we need to wait for at
                     // least two complete heartbeat setting intervals before


### PR DESCRIPTION
## Proposed Changes

The `NotifyHeartbeatListener()` was showing up on my analysis. Even though it is fairly small and quick, but it is called for every received frame.

I think this simplified implementation should be fast and as safe as before. 
Some comments to the implementation:
- AFAIK _heartbeatCounter is only updated by a single thread (MainLoop), so no additional thread safety needed.
- The reading do not need to be 100% exact as 1) as long as they're different it's good enough and 2) they're called so little, they won't suffer reading the wrong cached value and even if, nothing changes until 8 missed heartbeat anyway.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
