### PR TITLE
Fix RabbitMQ version parsing

### DIFF
--- a/projects/Unit/TestUpdateSecret.cs
+++ b/projects/Unit/TestUpdateSecret.cs
@@ -69,6 +69,13 @@ namespace RabbitMQ.Client.Unit
             if (properties.TryGetValue("version", out object versionVal))
             {
                 string versionStr = Encoding.UTF8.GetString((byte[])versionVal);
+
+                int dashIdx = versionStr.IndexOf('-');
+                if (dashIdx > 0)
+                {
+                    versionStr = versionStr.Remove(dashIdx);
+                }
+
                 if (Version.TryParse(versionStr, out Version version))
                 {
                     return version >= new Version(3, 8);


### PR DESCRIPTION
Turns out that Version.TryParse does not handle semver, and the following version will not be parsed:

3.8.5-alpha.8

This change removes all characters following the dash and the dash itself.

https://ci.rabbitmq.com/teams/main/pipelines/dotnet/jobs/test/builds/343