### PR TITLE
Implement BasicPublishBatch with ReadOnlyMemory

### DIFF
--- a/projects/RabbitMQ.Client/client/api/IBasicPublishBatch.cs
+++ b/projects/RabbitMQ.Client/client/api/IBasicPublishBatch.cs
@@ -37,12 +37,14 @@
 //  The Initial Developer of the Original Code is Pivotal Software, Inc.
 //  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
+
 using System;
 
 namespace RabbitMQ.Client
 {
     public interface IBasicPublishBatch
     {
+        [Obsolete("Use Add(string exchange, string routingKey, bool mandatory, IBasicProperties properties, ReadOnlyMemory<byte> body) instead. Will be replaced in version 7.0", false)]
         void Add(string exchange, string routingKey, bool mandatory, IBasicProperties properties, byte[] body);
         void Publish();
     }

--- a/projects/Unit/APIApproval.Approve.verified.txt
+++ b/projects/Unit/APIApproval.Approve.verified.txt
@@ -56,6 +56,10 @@ namespace RabbitMQ.Client
         public bool Redelivered { get; }
         public string RoutingKey { get; }
     }
+    public static class BasicPublishBatchExtensions
+    {
+        public static void Add(this RabbitMQ.Client.IBasicPublishBatch batch, string exchange, string routingKey, bool mandatory, RabbitMQ.Client.IBasicProperties properties, System.ReadOnlyMemory<byte> body) { }
+    }
     public class BinaryTableValue
     {
         public BinaryTableValue() { }
@@ -291,6 +295,8 @@ namespace RabbitMQ.Client
     }
     public interface IBasicPublishBatch
     {
+        [System.Obsolete("Use Add(string exchange, string routingKey, bool mandatory, IBasicProperties prop" +
+            "erties, ReadOnlyMemory<byte> body) instead. Will be replaced in version 7.0", false)]
         void Add(string exchange, string routingKey, bool mandatory, RabbitMQ.Client.IBasicProperties properties, byte[] body);
         void Publish();
     }

--- a/projects/Unit/TestBasicPublishBatch.cs
+++ b/projects/Unit/TestBasicPublishBatch.cs
@@ -53,8 +53,8 @@ namespace RabbitMQ.Client.Unit
             Model.QueueDeclare(queue: "test-message-batch-a", durable: false);
             Model.QueueDeclare(queue: "test-message-batch-b", durable: false);
             IBasicPublishBatch batch = Model.CreateBasicPublishBatch();
-            batch.Add("", "test-message-batch-a", false, null, new byte [] {});
-            batch.Add("", "test-message-batch-b", false, null, new byte [] {});
+            batch.Add("", "test-message-batch-a", false, null, new ReadOnlyMemory<byte>());
+            batch.Add("", "test-message-batch-b", false, null, new ReadOnlyMemory<byte>());
             batch.Publish();
             Model.WaitForConfirmsOrDie(TimeSpan.FromSeconds(15));
             BasicGetResult resultA = Model.BasicGet("test-message-batch-a", true);


### PR DESCRIPTION
## Proposed Changes

Alternative to #816

It seems that `BasicPublishBatch` doesn't support yet `ReadOnlyMemory<byte>`. This is a proposal to add it in a non-breaking way, which could be added in `6.2`. Later the extension method can become the interface method in v7 because there the breaking change can be made.

wasn't sure if the extension method needs to be included in the ApiGen

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

