### PR TITLE
Ability to do concurrent dispatches both on the async as well as the sync consumer

### DIFF
--- a/projects/RabbitMQ.Client/client/api/ConnectionFactory.cs
+++ b/projects/RabbitMQ.Client/client/api/ConnectionFactory.cs
@@ -175,6 +175,16 @@ namespace RabbitMQ.Client
         /// </summary>
         public bool DispatchConsumersAsync { get; set; } = false;
 
+        /// <summary>
+        /// Set to a value greater than one to enable concurrent processing. For a concurrency greater than one <see cref="IBasicConsumer"/>
+        /// will be offloaded to the worker thread pool so it is important to choose the value for the concurrency wisely to avoid thread pool overloading.
+        /// <see cref="IAsyncBasicConsumer"/> can handle concurrency much more efficiently due to the non-blocking nature of the consumer.
+        /// Defaults to 1.
+        /// </summary>
+        /// <remarks>For concurrency greater than one this removes the guarantee that consumers handle messages in the order they receive them.
+        /// In addition to that consumers need to be thread/concurrency safe.</remarks>
+        public int ProcessingConcurrency { get; set; } = 1;
+
         /// <summary>The host to connect to.</summary>
         public string HostName { get; set; } = "localhost";
 

--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -110,13 +110,14 @@ namespace RabbitMQ.Client.Framing.Impl
             _factory = factory;
             _frameHandler = frameHandler;
 
+            int processingConcurrency = (factory as ConnectionFactory)?.ProcessingConcurrency ?? 1;
             if (factory is IAsyncConnectionFactory asyncConnectionFactory && asyncConnectionFactory.DispatchConsumersAsync)
             {
-                ConsumerWorkService = new AsyncConsumerWorkService();
+                ConsumerWorkService = new AsyncConsumerWorkService(processingConcurrency);
             }
             else
             {
-                ConsumerWorkService = new ConsumerWorkService();
+                ConsumerWorkService = new ConsumerWorkService(processingConcurrency);
             }
 
             _sessionManager = new SessionManager(this, 0);

--- a/projects/Unit/APIApproval.Approve.verified.txt
+++ b/projects/Unit/APIApproval.Approve.verified.txt
@@ -81,6 +81,7 @@ namespace RabbitMQ.Client
         public System.TimeSpan NetworkRecoveryInterval { get; set; }
         public string Password { get; set; }
         public int Port { get; set; }
+        public int ProcessingConcurrency { get; set; }
         public ushort RequestedChannelMax { get; set; }
         public System.TimeSpan RequestedConnectionTimeout { get; set; }
         public uint RequestedFrameMax { get; set; }

--- a/projects/Unit/TestAsyncConsumer.cs
+++ b/projects/Unit/TestAsyncConsumer.cs
@@ -39,6 +39,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -78,6 +79,59 @@ namespace RabbitMQ.Client.Unit
                 m.BasicPublish("", q.QueueName, bp, body);
                 bool waitResFalse = are.WaitOne(2000);
                 Assert.IsFalse(waitResFalse);
+            }
+        }
+
+        [Test]
+        public async Task TestBasicRoundtripConcurrent()
+        {
+            var cf = new ConnectionFactory{ DispatchConsumersAsync = true, ProcessingConcurrency = 2 };
+            using(IConnection c = cf.CreateConnection())
+            using(IModel m = c.CreateModel())
+            {
+                QueueDeclareOk q = m.QueueDeclare();
+                IBasicProperties bp = m.CreateBasicProperties();
+                const string publish1 = "async-hi-1";
+                var body = Encoding.UTF8.GetBytes(publish1);
+                m.BasicPublish("", q.QueueName, bp, body);
+                const string publish2 = "async-hi-2";
+                body = Encoding.UTF8.GetBytes(publish2);
+                m.BasicPublish("", q.QueueName, bp, body);
+
+                var consumer = new AsyncEventingBasicConsumer(m);
+
+                var publish1SyncSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var publish2SyncSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var maximumWaitTime = TimeSpan.FromSeconds(5);
+                var tokenSource = new CancellationTokenSource(maximumWaitTime);
+                tokenSource.Token.Register(() =>
+                {
+                    publish1SyncSource.TrySetResult(false);
+                    publish2SyncSource.TrySetResult(false);
+                });
+
+                consumer.Received += async (o, a) =>
+                {
+                    switch (Encoding.UTF8.GetString(a.Body.ToArray()))
+                    {
+                        case publish1:
+                            publish1SyncSource.TrySetResult(true);
+                            await publish2SyncSource.Task;
+                            break;
+                        case publish2:
+                            publish2SyncSource.TrySetResult(true);
+                            await publish1SyncSource.Task;
+                            break;
+                    }
+                };
+
+                m.BasicConsume(q.QueueName, true, consumer);
+                // ensure we get a delivery
+
+                await Task.WhenAll(publish1SyncSource.Task, publish2SyncSource.Task);
+
+                Assert.IsTrue(publish1SyncSource.Task.Result, $"Non concurrent dispatch lead to deadlock after {maximumWaitTime}");
+                Assert.IsTrue(publish2SyncSource.Task.Result, $"Non concurrent dispatch lead to deadlock after {maximumWaitTime}");
             }
         }
 

--- a/projects/Unit/TestConsumer.cs
+++ b/projects/Unit/TestConsumer.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using RabbitMQ.Client.Events;
+
+namespace RabbitMQ.Client.Unit
+{
+    [TestFixture]
+    public class TestConsumer
+    {
+        [Test]
+        public async Task TestBasicRoundtripConcurrent()
+        {
+            var cf = new ConnectionFactory{ ProcessingConcurrency = 2 };
+            using(IConnection c = cf.CreateConnection())
+            using(IModel m = c.CreateModel())
+            {
+                QueueDeclareOk q = m.QueueDeclare();
+                IBasicProperties bp = m.CreateBasicProperties();
+                const string publish1 = "sync-hi-1";
+                var body = Encoding.UTF8.GetBytes(publish1);
+                m.BasicPublish("", q.QueueName, bp, body);
+                const string publish2 = "sync-hi-2";
+                body = Encoding.UTF8.GetBytes(publish2);
+                m.BasicPublish("", q.QueueName, bp, body);
+
+                var consumer = new EventingBasicConsumer(m);
+
+                var publish1SyncSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var publish2SyncSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var maximumWaitTime = TimeSpan.FromSeconds(5);
+                var tokenSource = new CancellationTokenSource(maximumWaitTime);
+                tokenSource.Token.Register(() =>
+                {
+                    publish1SyncSource.TrySetResult(false);
+                    publish2SyncSource.TrySetResult(false);
+                });
+
+                consumer.Received += (o, a) =>
+                {
+                    switch (Encoding.UTF8.GetString(a.Body.ToArray()))
+                    {
+                        case publish1:
+                            publish1SyncSource.TrySetResult(true);
+                            publish2SyncSource.Task.GetAwaiter().GetResult();
+                            break;
+                        case publish2:
+                            publish2SyncSource.TrySetResult(true);
+                            publish1SyncSource.Task.GetAwaiter().GetResult();
+                            break;
+                    }
+                };
+
+                m.BasicConsume(q.QueueName, true, consumer);
+
+                await Task.WhenAll(publish1SyncSource.Task, publish2SyncSource.Task);
+
+                Assert.IsTrue(publish1SyncSource.Task.Result, $"Non concurrent dispatch lead to deadlock after {maximumWaitTime}");
+                Assert.IsTrue(publish2SyncSource.Task.Result, $"Non concurrent dispatch lead to deadlock after {maximumWaitTime}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes

An alternative to https://github.com/rabbitmq/rabbitmq-dotnet-client/pull/806

If the interface is not extended then this can be added in a non breaking way on the level of the connection factory and later could be propagated to the interfaces in v7. I currently named the property `ProcessingConcurrency` to convey the intent for both the sync and the async case

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
