### PR TITLE
Move BinaryTableValue to public section

### DIFF
--- a/projects/RabbitMQ.Client/client/api/BinaryTableValue.cs
+++ b/projects/RabbitMQ.Client/client/api/BinaryTableValue.cs
@@ -1,4 +1,4 @@
-// This source code is dual-licensed under the Apache License, version
+﻿// This source code is dual-licensed under the Apache License, version
 // 2.0, and the Mozilla Public License, version 1.1.
 //
 // The APL v2.0:
@@ -38,7 +38,7 @@
 //  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
-namespace RabbitMQ.Client.Impl
+namespace RabbitMQ.Client
 {
     /// <summary>Wrapper for a byte[]. May appear as values read from
     ///and written to AMQP field tables.</summary>
@@ -67,7 +67,7 @@ namespace RabbitMQ.Client.Impl
     /// of this class must be used.
     /// </para>
     /// </remarks>
-    class BinaryTableValue
+    public class BinaryTableValue
     {
         /// <summary>
         /// Creates a new instance of the <see cref="BinaryTableValue"/> with null for its Bytes property.

--- a/projects/Unit/APIApproval.Approve.verified.txt
+++ b/projects/Unit/APIApproval.Approve.verified.txt
@@ -56,6 +56,12 @@ namespace RabbitMQ.Client
         public bool Redelivered { get; }
         public string RoutingKey { get; }
     }
+    public class BinaryTableValue
+    {
+        public BinaryTableValue() { }
+        public BinaryTableValue(byte[] bytes) { }
+        public byte[] Bytes { get; set; }
+    }
     public sealed class ConnectionFactory : RabbitMQ.Client.ConnectionFactoryBase, RabbitMQ.Client.IAsyncConnectionFactory, RabbitMQ.Client.IConnectionFactory
     {
         public const ushort DefaultChannelMax = 2047;


### PR DESCRIPTION
#879

## Proposed Changes

Move the BinaryTableValue class to the public section, because its returned by:
'result.BasicProperties.Headers.TryGetValue("key", out object value);'

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
