### PR TITLE
use cached empty BasicProperties when null

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/BasicPublishBatch.cs
+++ b/projects/RabbitMQ.Client/client/impl/BasicPublishBatch.cs
@@ -57,7 +57,6 @@ namespace RabbitMQ.Client.Impl
 
         public void Add(string exchange, string routingKey, bool mandatory, IBasicProperties basicProperties, byte[] body)
         {
-            IBasicProperties bp = basicProperties ?? _model.CreateBasicProperties();
             var method = new BasicPublish
             {
                 _exchange = exchange,
@@ -65,7 +64,7 @@ namespace RabbitMQ.Client.Impl
                 _mandatory = mandatory
             };
 
-            _commands.Add(new Command(method, (ContentHeaderBase)bp, body, false));
+            _commands.Add(new Command(method, (ContentHeaderBase)(basicProperties ?? _model._emptyBasicProperties), body, false));
         }
 
         public void Publish()

--- a/projects/RabbitMQ.Client/client/impl/ModelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ModelBase.cs
@@ -58,6 +58,7 @@ namespace RabbitMQ.Client.Impl
         ///<summary>Only used to kick-start a connection open
         ///sequence. See <see cref="Connection.Open"/> </summary>
         public BlockingCell<ConnectionStartDetails> m_connectionStartCell = null;
+        internal readonly IBasicProperties _emptyBasicProperties;
 
         private readonly Dictionary<string, IBasicConsumer> _consumers = new Dictionary<string, IBasicConsumer>();
 
@@ -72,7 +73,6 @@ namespace RabbitMQ.Client.Impl
         private readonly object _confirmLock = new object();
         private readonly LinkedList<ulong> _pendingDeliveryTags = new LinkedList<ulong>();
         private readonly CountdownEvent _deliveryTagsCountdown = new CountdownEvent(0);
-
         private EventHandler<ShutdownEventArgs> _modelShutdown;
 
         private bool _onlyAcksReceived = true;
@@ -93,6 +93,7 @@ namespace RabbitMQ.Client.Impl
                 ConsumerDispatcher = new ConcurrentConsumerDispatcher(this, workService);
             }
 
+            _emptyBasicProperties = CreateBasicProperties();
             Initialise(session);
         }
 
@@ -1111,7 +1112,7 @@ namespace RabbitMQ.Client.Impl
 
             if (basicProperties == null)
             {
-                basicProperties = CreateBasicProperties();
+                basicProperties = _emptyBasicProperties;
             }
 
             if (NextPublishSeqNo > 0)


### PR DESCRIPTION
## Proposed Changes

Instead of creating a new BasicProperties when the passed one is null, a cached empty one is used. This avoids creating a new instance every time.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

edited as I accidentally posted it too early
