### PR TITLE
add size hint variable for PublishBatch creation

### DIFF
--- a/projects/RabbitMQ.Client/client/api/IModel.cs
+++ b/projects/RabbitMQ.Client/client/api/IModel.cs
@@ -292,6 +292,12 @@ namespace RabbitMQ.Client
         IBasicPublishBatch CreateBasicPublishBatch();
 
         /// <summary>
+        ///  Creates a BasicPublishBatch instance
+        /// </summary>
+        [AmqpMethodDoNotImplement(null)]
+        IBasicPublishBatch CreateBasicPublishBatch(int sizeHint);
+
+        /// <summary>
         /// Construct a completely empty content header for use with the Basic content class.
         /// </summary>
         [AmqpContentHeaderFactory("basic")]

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
@@ -1960,5 +1960,15 @@ namespace RabbitMQ.Client.Impl
 
             return ((IFullModel)_delegate).CreateBasicPublishBatch();
         }
+
+        public IBasicPublishBatch CreateBasicPublishBatch(int sizeHint)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(GetType().FullName);
+            }
+
+            return ((IFullModel)_delegate).CreateBasicPublishBatch(sizeHint);
+        }
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/BasicPublishBatch.cs
+++ b/projects/RabbitMQ.Client/client/impl/BasicPublishBatch.cs
@@ -38,21 +38,27 @@
 //  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
-using System;
-using System.Buffers;
 using System.Collections.Generic;
 
 using RabbitMQ.Client.Framing.Impl;
 
 namespace RabbitMQ.Client.Impl
 {
-    class BasicPublishBatch : IBasicPublishBatch
+    internal sealed class BasicPublishBatch : IBasicPublishBatch
     {
-        private readonly List<Command> _commands = new List<Command>();
+        private readonly List<Command> _commands;
         private readonly ModelBase _model;
+
         internal BasicPublishBatch (ModelBase model)
         {
             _model = model;
+            _commands = new List<Command>();
+        }
+
+        internal BasicPublishBatch (ModelBase model, int sizeHint)
+        {
+            _model = model;
+            _commands = new List<Command>(sizeHint);
         }
 
         public void Add(string exchange, string routingKey, bool mandatory, IBasicProperties basicProperties, byte[] body)

--- a/projects/RabbitMQ.Client/client/impl/ModelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ModelBase.cs
@@ -1202,6 +1202,11 @@ namespace RabbitMQ.Client.Impl
             return new BasicPublishBatch(this);
         }
 
+        public IBasicPublishBatch CreateBasicPublishBatch(int sizeHint)
+        {
+            return new BasicPublishBatch(this, sizeHint);
+        }
+
 
         public void ExchangeBind(string destination,
             string source,

--- a/projects/Unit/TestBasicPublishBatch.cs
+++ b/projects/Unit/TestBasicPublishBatch.cs
@@ -62,5 +62,39 @@ namespace RabbitMQ.Client.Unit
             BasicGetResult resultB = Model.BasicGet("test-message-batch-b", true);
             Assert.NotNull(resultB);
         }
+
+        [Test]
+        public void TestBasicPublishBatchSendWithSizeHint()
+        {
+            Model.ConfirmSelect();
+            Model.QueueDeclare(queue: "test-message-batch-a", durable: false);
+            Model.QueueDeclare(queue: "test-message-batch-b", durable: false);
+            IBasicPublishBatch batch = Model.CreateBasicPublishBatch(2);
+            batch.Add("", "test-message-batch-a", false, null, new byte [] {});
+            batch.Add("", "test-message-batch-b", false, null, new byte [] {});
+            batch.Publish();
+            Model.WaitForConfirmsOrDie(TimeSpan.FromSeconds(15));
+            BasicGetResult resultA = Model.BasicGet("test-message-batch-a", true);
+            Assert.NotNull(resultA);
+            BasicGetResult resultB = Model.BasicGet("test-message-batch-b", true);
+            Assert.NotNull(resultB);
+        }
+
+        [Test]
+        public void TestBasicPublishBatchSendWithWrongSizeHint()
+        {
+            Model.ConfirmSelect();
+            Model.QueueDeclare(queue: "test-message-batch-a", durable: false);
+            Model.QueueDeclare(queue: "test-message-batch-b", durable: false);
+            IBasicPublishBatch batch = Model.CreateBasicPublishBatch(1);
+            batch.Add("", "test-message-batch-a", false, null, new byte [] {});
+            batch.Add("", "test-message-batch-b", false, null, new byte [] {});
+            batch.Publish();
+            Model.WaitForConfirmsOrDie(TimeSpan.FromSeconds(15));
+            BasicGetResult resultA = Model.BasicGet("test-message-batch-a", true);
+            Assert.NotNull(resultA);
+            BasicGetResult resultB = Model.BasicGet("test-message-batch-b", true);
+            Assert.NotNull(resultB);
+        }
     }
 }


### PR DESCRIPTION
## Proposed Changes

add a new method with a size hint for the creation of the list to hold the commands. This can reduce the allocations due to the storage of the commands by half. 

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

This only adds a new overloaded method to the public IModel interface. 