### PR TITLE
More descriptive exception in WriteShortstr

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/WireFormatting.cs
+++ b/projects/RabbitMQ.Client/client/impl/WireFormatting.cs
@@ -435,9 +435,17 @@ namespace RabbitMQ.Client.Impl
             fixed (char* chars = val)
             fixed (byte* bytes = &span.Slice(1).GetPinnableReference())
             {
-                int bytesWritten = Encoding.UTF8.GetBytes(chars, val.Length, bytes, maxLength);
-                span[0] = (byte)bytesWritten;
-                return bytesWritten + 1;
+                try
+                {
+                    int bytesWritten = Encoding.UTF8.GetBytes(chars, val.Length, bytes, maxLength);
+                    span[0] = (byte)bytesWritten;
+                    return bytesWritten + 1;
+                }
+                catch (ArgumentException)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(val), val, $"Value exceeds the maximum allowed length of {maxLength} bytes.");
+                }
+                
             }
         }
 

--- a/projects/Unit/TestFieldTableFormatting.cs
+++ b/projects/Unit/TestFieldTableFormatting.cs
@@ -139,7 +139,7 @@ namespace RabbitMQ.Client.Unit
             int bytesNeeded = WireFormatting.GetTableByteCount(t);
             byte[] bytes = new byte[bytesNeeded];
 
-            Assert.Throws<ArgumentException>(() => WireFormatting.WriteTable(bytes, t));
+            Assert.Throws<ArgumentOutOfRangeException>(() => WireFormatting.WriteTable(bytes, t));
         }
 
         [Test]


### PR DESCRIPTION
##  Proposed Changes

This change wraps the `ArgumentException` throw by `Encoding.UTF8.GetBytes` when there is not enough space in the output buffer provided. `ArgumentException` doesn't give any indication on the string value passed to the `WriteShortstr` which makes it hard for the user to figure out what is the root cause of the problem eg. that the name passed to the `DeclareQueue` method is too long.

Currently, the exception message is:

> The output byte buffer is too small to contain the encoded data, encoding 'Unicode (UTF-8)' fallback 
> 'System.Text.EncoderReplacementFallback'. Parameter name: bytes

With the change the exception message is:

> System.ArgumentOutOfRangeException : Value exceeds the maximum allowed length of 255 bytes. Parameter name: val Actual value was **value**

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #907 )
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have ~added~ changed tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories