### PR TITLE
Reduce work allocations

### DIFF
--- a/projects/RabbitMQ.Client/client/events/AsyncEventingBasicConsumer.cs
+++ b/projects/RabbitMQ.Client/client/events/AsyncEventingBasicConsumer.cs
@@ -45,10 +45,10 @@ namespace RabbitMQ.Client.Events
         }
 
         ///<summary>Fires the Received event.</summary>
-        public override async Task HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, IBasicProperties properties, ReadOnlyMemory<byte> body)
+        public override Task HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, IBasicProperties properties, ReadOnlyMemory<byte> body)
         {
-            await base.HandleBasicDeliver(consumerTag, deliveryTag, redelivered, exchange, routingKey, properties, body).ConfigureAwait(false);
-            await Received.InvokeAsync(this, new BasicDeliverEventArgs(consumerTag, deliveryTag, redelivered, exchange, routingKey, properties, body)).ConfigureAwait(false);
+            // No need to call base, it's empty.
+            return Received.InvokeAsync(this, new BasicDeliverEventArgs(consumerTag, deliveryTag, redelivered, exchange, routingKey, properties, body));
         }
 
         ///<summary>Fires the Shutdown event.</summary>

--- a/projects/RabbitMQ.Client/client/impl/AsyncConsumerDispatcher.cs
+++ b/projects/RabbitMQ.Client/client/impl/AsyncConsumerDispatcher.cs
@@ -66,7 +66,7 @@ namespace RabbitMQ.Client.Impl
         public void HandleModelShutdown(IBasicConsumer consumer, ShutdownEventArgs reason)
         {
             // the only case where we ignore the shutdown flag.
-            Schedule(new ModelShutdown(consumer, reason));
+            Schedule(new ModelShutdown(consumer, reason, _model));
         }
 
         private void ScheduleUnlessShuttingDown<TWork>(TWork work)

--- a/projects/RabbitMQ.Client/client/impl/AsyncConsumerWorkService.cs
+++ b/projects/RabbitMQ.Client/client/impl/AsyncConsumerWorkService.cs
@@ -89,7 +89,7 @@ namespace RabbitMQ.Client.Impl
                     {
                         try
                         {
-                            Task task = work.Execute(_model);
+                            Task task = work.Execute();
                             if (!task.IsCompleted)
                             {
                                 await task.ConfigureAwait(false);
@@ -145,7 +145,7 @@ namespace RabbitMQ.Client.Impl
             {
                 try
                 {
-                    Task task = work.Execute(model);
+                    Task task = work.Execute();
                     if (!task.IsCompleted)
                     {
                         await task.ConfigureAwait(false);

--- a/projects/RabbitMQ.Client/client/impl/BasicCancel.cs
+++ b/projects/RabbitMQ.Client/client/impl/BasicCancel.cs
@@ -13,7 +13,7 @@ namespace RabbitMQ.Client.Impl
             _consumerTag = consumerTag;
         }
 
-        protected override Task Execute(IModel model, IAsyncBasicConsumer consumer)
+        protected override Task Execute(IAsyncBasicConsumer consumer)
         {
             return consumer.HandleBasicCancel(_consumerTag);
         }

--- a/projects/RabbitMQ.Client/client/impl/BasicCancel.cs
+++ b/projects/RabbitMQ.Client/client/impl/BasicCancel.cs
@@ -1,40 +1,21 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-
-using RabbitMQ.Client.Events;
+﻿using System.Threading.Tasks;
 
 namespace RabbitMQ.Client.Impl
 {
-    sealed class BasicCancel : Work
+    internal sealed class BasicCancel : Work
     {
-        readonly string _consumerTag;
+        private readonly string _consumerTag;
+
+        public override string Context => "HandleBasicCancel";
 
         public BasicCancel(IBasicConsumer consumer, string consumerTag) : base(consumer)
         {
             _consumerTag = consumerTag;
         }
 
-        protected override async Task Execute(IModel model, IAsyncBasicConsumer consumer)
+        protected override Task Execute(IModel model, IAsyncBasicConsumer consumer)
         {
-            try
-            {
-                await consumer.HandleBasicCancel(_consumerTag).ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                if (!(model is ModelBase modelBase))
-                {
-                    return;
-                }
-
-                var details = new Dictionary<string, object>
-                {
-                    {"consumer", consumer},
-                    {"context",  "HandleBasicCancel"}
-                };
-                modelBase.OnCallbackException(CallbackExceptionEventArgs.Build(e, details));
-            }
+            return consumer.HandleBasicCancel(_consumerTag);
         }
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/BasicCancelOk.cs
+++ b/projects/RabbitMQ.Client/client/impl/BasicCancelOk.cs
@@ -1,40 +1,21 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-
-using RabbitMQ.Client.Events;
+﻿using System.Threading.Tasks;
 
 namespace RabbitMQ.Client.Impl
 {
-    sealed class BasicCancelOk : Work
+    internal sealed class BasicCancelOk : Work
     {
-        readonly string _consumerTag;
+        private readonly string _consumerTag;
+
+        public override string Context => "HandleBasicCancelOk";
 
         public BasicCancelOk(IBasicConsumer consumer, string consumerTag) : base(consumer)
         {
             _consumerTag = consumerTag;
         }
 
-        protected override async Task Execute(IModel model, IAsyncBasicConsumer consumer)
+        protected override Task Execute(IModel model, IAsyncBasicConsumer consumer)
         {
-            try
-            {
-                await consumer.HandleBasicCancelOk(_consumerTag).ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                if (!(model is ModelBase modelBase))
-                {
-                    return;
-                }
-
-                var details = new Dictionary<string, object>()
-                {
-                    {"consumer", consumer},
-                    {"context",  "HandleBasicCancelOk"}
-                };
-                modelBase.OnCallbackException(CallbackExceptionEventArgs.Build(e, details));
-            }
+            return consumer.HandleBasicCancelOk(_consumerTag);
         }
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/BasicCancelOk.cs
+++ b/projects/RabbitMQ.Client/client/impl/BasicCancelOk.cs
@@ -13,7 +13,7 @@ namespace RabbitMQ.Client.Impl
             _consumerTag = consumerTag;
         }
 
-        protected override Task Execute(IModel model, IAsyncBasicConsumer consumer)
+        protected override Task Execute(IAsyncBasicConsumer consumer)
         {
             return consumer.HandleBasicCancelOk(_consumerTag);
         }

--- a/projects/RabbitMQ.Client/client/impl/BasicConsumeOk.cs
+++ b/projects/RabbitMQ.Client/client/impl/BasicConsumeOk.cs
@@ -1,40 +1,21 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-
-using RabbitMQ.Client.Events;
+﻿using System.Threading.Tasks;
 
 namespace RabbitMQ.Client.Impl
 {
-    sealed class BasicConsumeOk : Work
+    internal sealed class BasicConsumeOk : Work
     {
-        readonly string _consumerTag;
+        private readonly string _consumerTag;
+
+        public override string Context => "HandleBasicConsumeOk";
 
         public BasicConsumeOk(IBasicConsumer consumer, string consumerTag) : base(consumer)
         {
             _consumerTag = consumerTag;
         }
 
-        protected override async Task Execute(IModel model, IAsyncBasicConsumer consumer)
+        protected override Task Execute(IModel model, IAsyncBasicConsumer consumer)
         {
-            try
-            {
-                await consumer.HandleBasicConsumeOk(_consumerTag).ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                if (!(model is ModelBase modelBase))
-                {
-                    return;
-                }
-
-                var details = new Dictionary<string, object>()
-                {
-                    {"consumer", consumer},
-                    {"context",  "HandleBasicConsumeOk"}
-                };
-                modelBase.OnCallbackException(CallbackExceptionEventArgs.Build(e, details));
-            }
+            return consumer.HandleBasicConsumeOk(_consumerTag);
         }
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/BasicConsumeOk.cs
+++ b/projects/RabbitMQ.Client/client/impl/BasicConsumeOk.cs
@@ -13,7 +13,7 @@ namespace RabbitMQ.Client.Impl
             _consumerTag = consumerTag;
         }
 
-        protected override Task Execute(IModel model, IAsyncBasicConsumer consumer)
+        protected override Task Execute(IAsyncBasicConsumer consumer)
         {
             return consumer.HandleBasicConsumeOk(_consumerTag);
         }

--- a/projects/RabbitMQ.Client/client/impl/BasicDeliver.cs
+++ b/projects/RabbitMQ.Client/client/impl/BasicDeliver.cs
@@ -1,22 +1,21 @@
 ﻿using System;
 using System.Buffers;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
-using RabbitMQ.Client.Events;
-
 namespace RabbitMQ.Client.Impl
 {
-    sealed class BasicDeliver : Work
+    internal sealed class BasicDeliver : Work
     {
-        readonly string _consumerTag;
-        readonly ulong _deliveryTag;
-        readonly bool _redelivered;
-        readonly string _exchange;
-        readonly string _routingKey;
-        readonly IBasicProperties _basicProperties;
-        readonly ReadOnlyMemory<byte> _body;
+        private readonly string _consumerTag;
+        private readonly ulong _deliveryTag;
+        private readonly bool _redelivered;
+        private readonly string _exchange;
+        private readonly string _routingKey;
+        private readonly IBasicProperties _basicProperties;
+        private readonly ReadOnlyMemory<byte> _body;
+
+        public override string Context => "HandleBasicDeliver";
 
         public BasicDeliver(IBasicConsumer consumer,
             string consumerTag,
@@ -36,38 +35,22 @@ namespace RabbitMQ.Client.Impl
             _body = body;
         }
 
-        protected override async Task Execute(IModel model, IAsyncBasicConsumer consumer)
+        protected override Task Execute(IModel model, IAsyncBasicConsumer consumer)
         {
-            try
-            {
-                await consumer.HandleBasicDeliver(_consumerTag,
-                    _deliveryTag,
-                    _redelivered,
-                    _exchange,
-                    _routingKey,
-                    _basicProperties,
-                    _body).ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                if (!(model is ModelBase modelBase))
-                {
-                    return;
-                }
+             return consumer.HandleBasicDeliver(_consumerTag,
+                     _deliveryTag,
+                     _redelivered,
+                     _exchange,
+                     _routingKey,
+                     _basicProperties,
+                     _body);
+        }
 
-                var details = new Dictionary<string, object>()
-                {
-                    {"consumer", consumer},
-                    {"context",  "HandleBasicDeliver"}
-                };
-                modelBase.OnCallbackException(CallbackExceptionEventArgs.Build(e, details));
-            }
-            finally
+        public override void PostExecute()
+        {
+            if (MemoryMarshal.TryGetArray(_body, out ArraySegment<byte> segment))
             {
-                if (MemoryMarshal.TryGetArray(_body, out ArraySegment<byte> segment))
-                {
-                    ArrayPool<byte>.Shared.Return(segment.Array);
-                }
+                ArrayPool<byte>.Shared.Return(segment.Array);
             }
         }
     }

--- a/projects/RabbitMQ.Client/client/impl/BasicDeliver.cs
+++ b/projects/RabbitMQ.Client/client/impl/BasicDeliver.cs
@@ -35,7 +35,7 @@ namespace RabbitMQ.Client.Impl
             _body = body;
         }
 
-        protected override Task Execute(IModel model, IAsyncBasicConsumer consumer)
+        protected override Task Execute(IAsyncBasicConsumer consumer)
         {
              return consumer.HandleBasicDeliver(_consumerTag,
                      _deliveryTag,

--- a/projects/RabbitMQ.Client/client/impl/ModelShutdown.cs
+++ b/projects/RabbitMQ.Client/client/impl/ModelShutdown.cs
@@ -1,40 +1,21 @@
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
-
-using RabbitMQ.Client.Events;
 
 namespace RabbitMQ.Client.Impl
 {
-    sealed class ModelShutdown : Work
+    internal sealed class ModelShutdown : Work
     {
-        readonly ShutdownEventArgs _reason;
+        private readonly ShutdownEventArgs _reason;
+
+        public override string Context => "HandleModelShutdown";
 
         public ModelShutdown(IBasicConsumer consumer, ShutdownEventArgs reason) : base(consumer)
         {
             _reason = reason;
         }
 
-        protected override async Task Execute(IModel model, IAsyncBasicConsumer consumer)
+        protected override Task Execute(IModel model, IAsyncBasicConsumer consumer)
         {
-            try
-            {
-                await consumer.HandleModelShutdown(model, _reason).ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                if (!(model is ModelBase modelBase))
-                {
-                    return;
-                }
-
-                var details = new Dictionary<string, object>()
-                {
-                    { "consumer", consumer },
-                    { "context", "HandleModelShutdown" }
-                };
-                modelBase.OnCallbackException(CallbackExceptionEventArgs.Build(e, details));
-            }
+            return consumer.HandleModelShutdown(model, _reason);
         }
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/ModelShutdown.cs
+++ b/projects/RabbitMQ.Client/client/impl/ModelShutdown.cs
@@ -5,17 +5,19 @@ namespace RabbitMQ.Client.Impl
     internal sealed class ModelShutdown : Work
     {
         private readonly ShutdownEventArgs _reason;
+        private readonly IModel _model;
 
         public override string Context => "HandleModelShutdown";
 
-        public ModelShutdown(IBasicConsumer consumer, ShutdownEventArgs reason) : base(consumer)
+        public ModelShutdown(IBasicConsumer consumer, ShutdownEventArgs reason, IModel model) : base(consumer)
         {
             _reason = reason;
+            _model = model;
         }
 
-        protected override Task Execute(IModel model, IAsyncBasicConsumer consumer)
+        protected override Task Execute(IAsyncBasicConsumer consumer)
         {
-            return consumer.HandleModelShutdown(model, _reason);
+            return consumer.HandleModelShutdown(_model, _reason);
         }
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/Work.cs
+++ b/projects/RabbitMQ.Client/client/impl/Work.cs
@@ -4,18 +4,24 @@ namespace RabbitMQ.Client.Impl
 {
     internal abstract class Work
     {
-        readonly IAsyncBasicConsumer _asyncConsumer;
+        public IAsyncBasicConsumer Consumer { get; }
+
+        public abstract string Context { get; }
 
         protected Work(IBasicConsumer consumer)
         {
-            _asyncConsumer = (IAsyncBasicConsumer)consumer;
+            Consumer = (IAsyncBasicConsumer)consumer;
         }
 
         public Task Execute(IModel model)
         {
-            return Execute(model, _asyncConsumer);
+            return Execute(model, Consumer);
         }
 
         protected abstract Task Execute(IModel model, IAsyncBasicConsumer consumer);
+
+        public virtual void PostExecute()
+        {
+        }
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/Work.cs
+++ b/projects/RabbitMQ.Client/client/impl/Work.cs
@@ -13,12 +13,12 @@ namespace RabbitMQ.Client.Impl
             Consumer = (IAsyncBasicConsumer)consumer;
         }
 
-        public Task Execute(IModel model)
+        public Task Execute()
         {
-            return Execute(model, Consumer);
+            return Execute(Consumer);
         }
 
-        protected abstract Task Execute(IModel model, IAsyncBasicConsumer consumer);
+        protected abstract Task Execute(IAsyncBasicConsumer consumer);
 
         public virtual void PostExecute()
         {


### PR DESCRIPTION
## Proposed Changes

4506a70 does move the error handling from the work classes to the WorkService. This eliminates some async state machine allocations.

f1af6ac removes passing the IModel in the Work.Execute, as only the Shutdown required it, so it's now passed in the ctor of it.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Allocations before:
![image](https://user-images.githubusercontent.com/2437596/87164713-63fd9680-c2c9-11ea-99b0-eb2229d88339.png)

after:
![image](https://user-images.githubusercontent.com/2437596/87164579-3add0600-c2c9-11ea-953d-4d760be5b400.png)

Performance before:
![image](https://user-images.githubusercontent.com/2437596/87165157-0cabf600-c2ca-11ea-9ea0-89186bda96a0.png)

after:
![image](https://user-images.githubusercontent.com/2437596/87165185-17668b00-c2ca-11ea-923c-118c9b0bb9ad.png)
