### PR TITLE
change AmqpVersion to struct

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/AmqpVersion.cs
+++ b/projects/RabbitMQ.Client/client/impl/AmqpVersion.cs
@@ -29,6 +29,8 @@
 //  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
+using System;
+
 namespace RabbitMQ.Client.Framing.Impl
 {
     /// <summary>Represents a version of the AMQP specification.</summary>
@@ -45,7 +47,7 @@ namespace RabbitMQ.Client.Framing.Impl
     /// special-cases 8-0, rewriting it at construction time to be 0-8 instead.
     /// </para>
     /// </remarks>
-    class AmqpVersion
+    internal readonly struct AmqpVersion : IEquatable<AmqpVersion>
     {
         /// <summary>
         /// Construct an <see cref="AmqpVersion"/> from major and minor version numbers.
@@ -70,27 +72,36 @@ namespace RabbitMQ.Client.Framing.Impl
         /// <summary>
         /// The AMQP specification major version number.
         /// </summary>
-        public int Major { get; private set; }
+        public int Major { get; }
 
         /// <summary>
         /// The AMQP specification minor version number.
         /// </summary>
-        public int Minor { get; private set; }
+        public int Minor { get; }
 
         /// <summary>
         /// Implement value-equality comparison.
         /// </summary>
         public override bool Equals(object other)
         {
-            return (other is AmqpVersion version) && (version.Major == Major) && (version.Minor == Minor);
+            return other is AmqpVersion version && Equals(version);
         }
+
+        public bool Equals(AmqpVersion other) => Major == other.Major && Minor == other.Minor;
+
+        public static bool operator ==(AmqpVersion left, AmqpVersion right) => left.Equals(right);
+
+        public static bool operator !=(AmqpVersion left, AmqpVersion right) => !left.Equals(right);
 
         /// <summary>
         /// Implement hashing as for value-equality.
         /// </summary>
         public override int GetHashCode()
         {
-            return 31*Major.GetHashCode() + Minor.GetHashCode();
+            unchecked
+            {
+                return (Major * 397) ^ Minor;
+            }
         }
 
         /// <summary>

--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -1060,16 +1060,12 @@ namespace RabbitMQ.Client.Framing.Impl
 
             ServerProperties = connectionStart.m_serverProperties;
 
-            var serverVersion = new AmqpVersion(connectionStart.m_versionMajor,
-                connectionStart.m_versionMinor);
+            var serverVersion = new AmqpVersion(connectionStart.m_versionMajor, connectionStart.m_versionMinor);
             if (!serverVersion.Equals(Protocol.Version))
             {
                 TerminateMainloop();
                 FinishClose();
-                throw new ProtocolVersionMismatchException(Protocol.MajorVersion,
-                    Protocol.MinorVersion,
-                    serverVersion.Major,
-                    serverVersion.Minor);
+                throw new ProtocolVersionMismatchException(Protocol.MajorVersion, Protocol.MinorVersion, serverVersion.Major, serverVersion.Minor);
             }
 
             ClientProperties = new Dictionary<string, object>(_factory.ClientProperties)


### PR DESCRIPTION
## Proposed Changes

Simple small change to change it to a struct. Avoids allocation.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [x] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

I've let resharper implement the equality members, which also changed the GetHashCode. But as the type is internal, this is not breaking.
