### PR TITLE
change from Memory to ReadOnlyMemory

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -924,7 +924,7 @@ namespace RabbitMQ.Client.Framing.Impl
             return string.Format("Connection({0},{1})", _id, Endpoint);
         }
 
-        public void Write(Memory<byte> memory)
+        public void Write(ReadOnlyMemory<byte> memory)
         {
             _frameHandler.Write(memory);
         }

--- a/projects/RabbitMQ.Client/client/impl/IFrameHandler.cs
+++ b/projects/RabbitMQ.Client/client/impl/IFrameHandler.cs
@@ -61,6 +61,6 @@ namespace RabbitMQ.Client.Impl
 
         void SendHeader();
 
-        void Write(Memory<byte> memory);
+        void Write(ReadOnlyMemory<byte> memory);
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
+++ b/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
@@ -70,8 +70,8 @@ namespace RabbitMQ.Client.Impl
         private readonly ITcpClient _socket;
         private readonly Stream _reader;
         private readonly Stream _writer;
-        private readonly ChannelWriter<Memory<byte>> _channelWriter;
-        private readonly ChannelReader<Memory<byte>> _channelReader;
+        private readonly ChannelWriter<ReadOnlyMemory<byte>> _channelWriter;
+        private readonly ChannelReader<ReadOnlyMemory<byte>> _channelReader;
         private readonly Task _writerTask;
         private readonly object _semaphore = new object();
         private readonly byte[] _frameHeaderBuffer;
@@ -83,7 +83,7 @@ namespace RabbitMQ.Client.Impl
         {
             Endpoint = endpoint;
             _frameHeaderBuffer = new byte[6];
-            var channel = Channel.CreateUnbounded<Memory<byte>>(
+            var channel = Channel.CreateUnbounded<ReadOnlyMemory<byte>>(
                 new UnboundedChannelOptions
                 {
                     AllowSynchronousContinuations = false,
@@ -260,7 +260,7 @@ namespace RabbitMQ.Client.Impl
             _writer.Flush();
         }
 
-        public void Write(Memory<byte> memory)
+        public void Write(ReadOnlyMemory<byte> memory)
         {
             _channelWriter.TryWrite(memory);
         }


### PR DESCRIPTION
## Proposed Changes

Aligns the type to the usage (None of them actually should modify the memory, as we're sending it, hence it should be read only.) Also the usage of  
`MemoryMarshal.TryGetArray<T>(ReadOnlyMemory<T>, ArraySegment<T>)`
requires a ReadOnlyMemory not Memory.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
