### PR TITLE
Expose events ConsumerTagChangeAfterRecovery and QueueNameChangeAfterRecovery

### DIFF
--- a/projects/RabbitMQ.Client/client/api/IAutorecoveringConnection.cs
+++ b/projects/RabbitMQ.Client/client/api/IAutorecoveringConnection.cs
@@ -46,5 +46,8 @@ namespace RabbitMQ.Client
     {
         event EventHandler<EventArgs> RecoverySucceeded;
         event EventHandler<ConnectionRecoveryErrorEventArgs> ConnectionRecoveryError;
+
+        event EventHandler<ConsumerTagChangedAfterRecoveryEventArgs> ConsumerTagChangeAfterRecovery;
+        event EventHandler<QueueNameChangedAfterRecoveryEventArgs> QueueNameChangeAfterRecovery;
     }
 }


### PR DESCRIPTION
## Proposed Changes

After the merge #490 the events ConsumerTagChangeAfterRecovery and QueueNameChangeAfterRecovery became inaccessible. I propose to declare those events in the interface IAutorecoveringConnection.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
