### PR TITLE
Make sure OnCallbackException is executed for AsyncConsumers

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/AsyncConsumerWorkService.cs
+++ b/projects/RabbitMQ.Client/client/impl/AsyncConsumerWorkService.cs
@@ -90,10 +90,7 @@ namespace RabbitMQ.Client.Impl
                         try
                         {
                             Task task = work.Execute();
-                            if (!task.IsCompleted)
-                            {
-                                await task.ConfigureAwait(false);
-                            }
+                            await task.ConfigureAwait(false);
                         }
                         catch (Exception e)
                         {
@@ -126,7 +123,7 @@ namespace RabbitMQ.Client.Impl
                         while (_channel.Reader.TryRead(out Work work))
                         {
                             // Do a quick synchronous check before we resort to async/await with the state-machine overhead.
-                            if(!_limiter.Wait(0))
+                            if (!_limiter.Wait(0))
                             {
                                 await _limiter.WaitAsync(cancellationToken).ConfigureAwait(false);
                             }
@@ -146,10 +143,7 @@ namespace RabbitMQ.Client.Impl
                 try
                 {
                     Task task = work.Execute();
-                    if (!task.IsCompleted)
-                    {
-                        await task.ConfigureAwait(false);
-                    }
+                    await task.ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {

--- a/projects/RabbitMQ.Client/client/impl/AsyncConsumerWorkService.cs
+++ b/projects/RabbitMQ.Client/client/impl/AsyncConsumerWorkService.cs
@@ -90,7 +90,16 @@ namespace RabbitMQ.Client.Impl
                         try
                         {
                             Task task = work.Execute();
-                            await task.ConfigureAwait(false);
+                            if (!task.IsCompleted)
+                            {
+                                await task.ConfigureAwait(false);
+                            }
+
+                            // Without await, the exception will disappear
+                            if(task.Exception != null)
+                            {
+                                throw task.Exception.InnerException;
+                            }
                         }
                         catch (Exception e)
                         {
@@ -143,7 +152,16 @@ namespace RabbitMQ.Client.Impl
                 try
                 {
                     Task task = work.Execute();
-                    await task.ConfigureAwait(false);
+                    if (!task.IsCompleted)
+                    {
+                        await task.ConfigureAwait(false);
+                    }
+
+                    // Without await, the exception will disappear
+                    if (task.Exception != null)
+                    {
+                        throw task.Exception.InnerException;
+                    }
                 }
                 catch (Exception e)
                 {

--- a/projects/RabbitMQ.Client/client/impl/AsyncConsumerWorkService.cs
+++ b/projects/RabbitMQ.Client/client/impl/AsyncConsumerWorkService.cs
@@ -94,11 +94,10 @@ namespace RabbitMQ.Client.Impl
                             {
                                 await task.ConfigureAwait(false);
                             }
-
-                            // Without await, the exception will disappear
-                            if(task.Exception != null)
+                            else
                             {
-                                throw task.Exception.InnerException;
+                                // to materialize exceptions if any
+                                task.GetAwaiter().GetResult();
                             }
                         }
                         catch (Exception e)
@@ -156,11 +155,10 @@ namespace RabbitMQ.Client.Impl
                     {
                         await task.ConfigureAwait(false);
                     }
-
-                    // Without await, the exception will disappear
-                    if (task.Exception != null)
+                    else
                     {
-                        throw task.Exception.InnerException;
+                        // to materialize exceptions if any
+                        task.GetAwaiter().GetResult();
                     }
                 }
                 catch (Exception e)

--- a/projects/Unit/TestAsyncConsumerExceptions.cs
+++ b/projects/Unit/TestAsyncConsumerExceptions.cs
@@ -114,7 +114,7 @@ namespace RabbitMQ.Client.Unit
             {
             }
 
-            public override async Task HandleBasicDeliver(string consumerTag,
+            public override Task HandleBasicDeliver(string consumerTag,
                 ulong deliveryTag,
                 bool redelivered,
                 string exchange,
@@ -122,8 +122,7 @@ namespace RabbitMQ.Client.Unit
                 IBasicProperties properties,
                 ReadOnlyMemory<byte> body)
             {
-                await Task.Delay(0);
-                throw new Exception("oops");
+                return Task.FromException(new Exception("oops"));
             }
         }
 
@@ -133,10 +132,9 @@ namespace RabbitMQ.Client.Unit
             {
             }
 
-            public override async Task HandleBasicCancel(string consumerTag)
+            public override Task HandleBasicCancel(string consumerTag)
             {
-                await Task.Delay(0);
-                throw new Exception("oops");
+                return Task.FromException(new Exception("oops"));
             }
         }
 
@@ -146,10 +144,9 @@ namespace RabbitMQ.Client.Unit
             {
             }
 
-            public override async Task HandleModelShutdown(object model, ShutdownEventArgs reason)
+            public override Task HandleModelShutdown(object model, ShutdownEventArgs reason)
             {
-                await Task.Delay(0);
-                throw new Exception("oops");
+                return Task.FromException(new Exception("oops"));
             }
         }
 
@@ -159,10 +156,9 @@ namespace RabbitMQ.Client.Unit
             {
             }
 
-            public override async Task HandleBasicConsumeOk(string consumerTag)
+            public override Task HandleBasicConsumeOk(string consumerTag)
             {
-                await Task.Delay(0);
-                throw new Exception("oops");
+                return Task.FromException(new Exception("oops"));
             }
         }
 
@@ -172,10 +168,9 @@ namespace RabbitMQ.Client.Unit
             {
             }
 
-            public override async Task HandleBasicCancelOk(string consumerTag)
+            public override Task HandleBasicCancelOk(string consumerTag)
             {
-                await Task.Delay(0);
-                throw new Exception("oops");
+                return Task.FromException(new Exception("oops"));
             }
         }
     }

--- a/projects/Unit/TestAsyncConsumerExceptions.cs
+++ b/projects/Unit/TestAsyncConsumerExceptions.cs
@@ -40,72 +40,6 @@ namespace RabbitMQ.Client.Unit
     [TestFixture]
     public class TestAsyncConsumerExceptions : IntegrationFixture
     {
-        private class ConsumerFailingOnDelivery : AsyncEventingBasicConsumer
-        {
-            public ConsumerFailingOnDelivery(IModel model) : base(model)
-            {
-            }
-
-            public override Task HandleBasicDeliver(string consumerTag,
-                ulong deliveryTag,
-                bool redelivered,
-                string exchange,
-                string routingKey,
-                IBasicProperties properties,
-                ReadOnlyMemory<byte> body)
-            {
-                throw new Exception("oops");
-            }
-        }
-
-        private class ConsumerFailingOnCancel : AsyncEventingBasicConsumer
-        {
-            public ConsumerFailingOnCancel(IModel model) : base(model)
-            {
-            }
-
-            public override Task HandleBasicCancel(string consumerTag)
-            {
-                throw new Exception("oops");
-            }
-        }
-
-        private class ConsumerFailingOnShutdown : AsyncEventingBasicConsumer
-        {
-            public ConsumerFailingOnShutdown(IModel model) : base(model)
-            {
-            }
-
-            public override Task HandleModelShutdown(object model, ShutdownEventArgs reason)
-            {
-                throw new Exception("oops");
-            }
-        }
-
-        private class ConsumerFailingOnConsumeOk : AsyncEventingBasicConsumer
-        {
-            public ConsumerFailingOnConsumeOk(IModel model) : base(model)
-            {
-            }
-
-            public override Task HandleBasicConsumeOk(string consumerTag)
-            {
-                throw new Exception("oops");
-            }
-        }
-
-        private class ConsumerFailingOnCancelOk : AsyncEventingBasicConsumer
-        {
-            public ConsumerFailingOnCancelOk(IModel model) : base(model)
-            {
-            }
-
-            public override Task HandleBasicCancelOk(string consumerTag)
-            {
-                throw new Exception("oops");
-            }
-        }
-
         protected void TestExceptionHandlingWith(IBasicConsumer consumer,
             Action<IModel, string, IBasicConsumer, string> action)
         {
@@ -125,6 +59,18 @@ namespace RabbitMQ.Client.Unit
             WaitOn(o);
 
             Assert.IsTrue(notified);
+        }
+
+        [SetUp]
+        public override void Init()
+        {
+            _connFactory = new ConnectionFactory
+            {
+                DispatchConsumersAsync = true
+            };
+
+            _conn = _connFactory.CreateConnection();
+            _model = _conn.CreateModel();
         }
 
         [Test]
@@ -160,6 +106,77 @@ namespace RabbitMQ.Client.Unit
         {
             IBasicConsumer consumer = new ConsumerFailingOnDelivery(_model);
             TestExceptionHandlingWith(consumer, (m, q, c, ct) => m.BasicPublish("", q, null, _encoding.GetBytes("msg")));
+        }
+
+        private class ConsumerFailingOnDelivery : AsyncEventingBasicConsumer
+        {
+            public ConsumerFailingOnDelivery(IModel model) : base(model)
+            {
+            }
+
+            public override async Task HandleBasicDeliver(string consumerTag,
+                ulong deliveryTag,
+                bool redelivered,
+                string exchange,
+                string routingKey,
+                IBasicProperties properties,
+                ReadOnlyMemory<byte> body)
+            {
+                await Task.Delay(0);
+                throw new Exception("oops");
+            }
+        }
+
+        private class ConsumerFailingOnCancel : AsyncEventingBasicConsumer
+        {
+            public ConsumerFailingOnCancel(IModel model) : base(model)
+            {
+            }
+
+            public override async Task HandleBasicCancel(string consumerTag)
+            {
+                await Task.Delay(0);
+                throw new Exception("oops");
+            }
+        }
+
+        private class ConsumerFailingOnShutdown : AsyncEventingBasicConsumer
+        {
+            public ConsumerFailingOnShutdown(IModel model) : base(model)
+            {
+            }
+
+            public override async Task HandleModelShutdown(object model, ShutdownEventArgs reason)
+            {
+                await Task.Delay(0);
+                throw new Exception("oops");
+            }
+        }
+
+        private class ConsumerFailingOnConsumeOk : AsyncEventingBasicConsumer
+        {
+            public ConsumerFailingOnConsumeOk(IModel model) : base(model)
+            {
+            }
+
+            public override async Task HandleBasicConsumeOk(string consumerTag)
+            {
+                await Task.Delay(0);
+                throw new Exception("oops");
+            }
+        }
+
+        private class ConsumerFailingOnCancelOk : AsyncEventingBasicConsumer
+        {
+            public ConsumerFailingOnCancelOk(IModel model) : base(model)
+            {
+            }
+
+            public override async Task HandleBasicCancelOk(string consumerTag)
+            {
+                await Task.Delay(0);
+                throw new Exception("oops");
+            }
         }
     }
 }

--- a/projects/Unit/TestAsyncConsumerExceptions.cs
+++ b/projects/Unit/TestAsyncConsumerExceptions.cs
@@ -46,7 +46,7 @@ namespace RabbitMQ.Client.Unit
             {
             }
 
-            public override async Task HandleBasicDeliver(string consumerTag,
+            public override Task HandleBasicDeliver(string consumerTag,
                 ulong deliveryTag,
                 bool redelivered,
                 string exchange,
@@ -64,7 +64,7 @@ namespace RabbitMQ.Client.Unit
             {
             }
 
-            public override async Task HandleBasicCancel(string consumerTag)
+            public override Task HandleBasicCancel(string consumerTag)
             {
                 throw new Exception("oops");
             }
@@ -76,7 +76,7 @@ namespace RabbitMQ.Client.Unit
             {
             }
 
-            public override async Task HandleModelShutdown(object model, ShutdownEventArgs reason)
+            public override Task HandleModelShutdown(object model, ShutdownEventArgs reason)
             {
                 throw new Exception("oops");
             }
@@ -88,7 +88,7 @@ namespace RabbitMQ.Client.Unit
             {
             }
 
-            public override async Task HandleBasicConsumeOk(string consumerTag)
+            public override Task HandleBasicConsumeOk(string consumerTag)
             {
                 throw new Exception("oops");
             }
@@ -100,7 +100,7 @@ namespace RabbitMQ.Client.Unit
             {
             }
 
-            public override async Task HandleBasicCancelOk(string consumerTag)
+            public override Task HandleBasicCancelOk(string consumerTag)
             {
                 throw new Exception("oops");
             }

--- a/projects/Unit/TestAsyncConsumerExceptions.cs
+++ b/projects/Unit/TestAsyncConsumerExceptions.cs
@@ -1,0 +1,165 @@
+﻿// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2020 VMware, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       https://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v2.0:
+//
+//---------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
+//---------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using RabbitMQ.Client.Events;
+
+namespace RabbitMQ.Client.Unit
+{
+    [TestFixture]
+    public class TestAsyncConsumerExceptions : IntegrationFixture
+    {
+        private class ConsumerFailingOnDelivery : AsyncEventingBasicConsumer
+        {
+            public ConsumerFailingOnDelivery(IModel model) : base(model)
+            {
+            }
+
+            public override async Task HandleBasicDeliver(string consumerTag,
+                ulong deliveryTag,
+                bool redelivered,
+                string exchange,
+                string routingKey,
+                IBasicProperties properties,
+                ReadOnlyMemory<byte> body)
+            {
+                throw new Exception("oops");
+            }
+        }
+
+        private class ConsumerFailingOnCancel : AsyncEventingBasicConsumer
+        {
+            public ConsumerFailingOnCancel(IModel model) : base(model)
+            {
+            }
+
+            public override async Task HandleBasicCancel(string consumerTag)
+            {
+                throw new Exception("oops");
+            }
+        }
+
+        private class ConsumerFailingOnShutdown : AsyncEventingBasicConsumer
+        {
+            public ConsumerFailingOnShutdown(IModel model) : base(model)
+            {
+            }
+
+            public override async Task HandleModelShutdown(object model, ShutdownEventArgs reason)
+            {
+                throw new Exception("oops");
+            }
+        }
+
+        private class ConsumerFailingOnConsumeOk : AsyncEventingBasicConsumer
+        {
+            public ConsumerFailingOnConsumeOk(IModel model) : base(model)
+            {
+            }
+
+            public override async Task HandleBasicConsumeOk(string consumerTag)
+            {
+                throw new Exception("oops");
+            }
+        }
+
+        private class ConsumerFailingOnCancelOk : AsyncEventingBasicConsumer
+        {
+            public ConsumerFailingOnCancelOk(IModel model) : base(model)
+            {
+            }
+
+            public override async Task HandleBasicCancelOk(string consumerTag)
+            {
+                throw new Exception("oops");
+            }
+        }
+
+        protected void TestExceptionHandlingWith(IBasicConsumer consumer,
+            Action<IModel, string, IBasicConsumer, string> action)
+        {
+            object o = new object();
+            bool notified = false;
+            string q = _model.QueueDeclare();
+
+
+            _model.CallbackException += (m, evt) =>
+            {
+                notified = true;
+                Monitor.PulseAll(o);
+            };
+
+            string tag = _model.BasicConsume(q, true, consumer);
+            action(_model, q, consumer, tag);
+            WaitOn(o);
+
+            Assert.IsTrue(notified);
+        }
+
+        [Test]
+        public void TestCancelNotificationExceptionHandling()
+        {
+            IBasicConsumer consumer = new ConsumerFailingOnCancel(_model);
+            TestExceptionHandlingWith(consumer, (m, q, c, ct) => m.QueueDelete(q));
+        }
+
+        [Test]
+        public void TestConsumerCancelOkExceptionHandling()
+        {
+            IBasicConsumer consumer = new ConsumerFailingOnCancelOk(_model);
+            TestExceptionHandlingWith(consumer, (m, q, c, ct) => m.BasicCancel(ct));
+        }
+
+        [Test]
+        public void TestConsumerConsumeOkExceptionHandling()
+        {
+            IBasicConsumer consumer = new ConsumerFailingOnConsumeOk(_model);
+            TestExceptionHandlingWith(consumer, (m, q, c, ct) => { });
+        }
+
+        [Test]
+        public void TestConsumerShutdownExceptionHandling()
+        {
+            IBasicConsumer consumer = new ConsumerFailingOnShutdown(_model);
+            TestExceptionHandlingWith(consumer, (m, q, c, ct) => m.Close());
+        }
+
+        [Test]
+        public void TestDeliveryExceptionHandling()
+        {
+            IBasicConsumer consumer = new ConsumerFailingOnDelivery(_model);
+            TestExceptionHandlingWith(consumer, (m, q, c, ct) => m.BasicPublish("", q, null, _encoding.GetBytes("msg")));
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes

Always call to await when executing a task in AsyncConsumerWorkService. Previously, the wait called only if the job hasn't done yet. It lead to missing exception and missed the invoke of OnCallbackException event.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #944 )
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
