### PR TITLE
WIP (Spike) Introduce bound default timeouts for connection closure

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.cs
@@ -196,6 +196,8 @@ namespace RabbitMQ.Client.Framing.Impl
             set => Delegate.KnownHosts = value;
         }
 
+        internal IFrameHandler FrameHandler => Delegate.FrameHandler;
+
         public int LocalPort => Delegate.LocalPort;
 
         public ProtocolBase Protocol => Delegate.Protocol;
@@ -248,8 +250,6 @@ namespace RabbitMQ.Client.Framing.Impl
 
             return false;
         }
-
-        public void Close(ShutdownEventArgs reason) => Delegate.Close(reason);
 
         public RecoveryAwareModel CreateNonRecoveringModel()
         {
@@ -514,6 +514,16 @@ namespace RabbitMQ.Client.Framing.Impl
             if (_delegate.IsOpen)
             {
                 _delegate.Close(reasonCode, reasonText);
+            }
+        }
+
+        public void Close(ShutdownEventArgs reason)
+        {
+            ThrowIfDisposed();
+            StopRecoveryLoop();
+            if (_delegate.IsOpen)
+            {
+                _delegate.Close(reason);
             }
         }
 

--- a/projects/RabbitMQ.Client/client/impl/IFrameHandler.cs
+++ b/projects/RabbitMQ.Client/client/impl/IFrameHandler.cs
@@ -62,5 +62,7 @@ namespace RabbitMQ.Client.Impl
         void SendHeader();
 
         void Write(ReadOnlyMemory<byte> memory);
+
+        bool IsOpen();
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
+++ b/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
@@ -201,6 +201,21 @@ namespace RabbitMQ.Client.Impl
             }
         }
 
+        public bool IsOpen()
+        {
+            if(_closed)
+            {
+                return false;
+            }
+
+            if(_socket == null)
+            {
+                return false;
+            }
+
+            return _socket.Connected;
+        }
+
         public void Close()
         {
             lock (_semaphore)


### PR DESCRIPTION
This demonstrates the approach. There are currently two TestConnectionShutdown failures.

See #938 for the background.
