### PR TITLE
Be more defensive when closing SocketFrameHandler

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
+++ b/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
@@ -210,7 +210,7 @@ namespace RabbitMQ.Client.Impl
                     try
                     {
                         _channelWriter.Complete();
-                        _writerTask.GetAwaiter().GetResult();
+                        _writerTask?.GetAwaiter().GetResult();
                     }
                     catch(Exception)
                     {


### PR DESCRIPTION
Suggested by @danielsvalefelt in #974. We don't have much context but this makes the change "reviewable" compared to a suggestion comment.

@bollhals @stebet do you see any downsides to doing this? There isn't anything a `SocketFrameHandler` can do to recover when it's being closed, so being more defensive makes sense to me.