### PR TITLE
Remove unsafe, please

### DIFF
--- a/projects/RabbitMQ.Client/RabbitMQ.Client.csproj
+++ b/projects/RabbitMQ.Client/RabbitMQ.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyTitle>RabbitMQ Client Library for .NET</AssemblyTitle>

--- a/projects/RabbitMQ.Client/RabbitMQ.Client.csproj
+++ b/projects/RabbitMQ.Client/RabbitMQ.Client.csproj
@@ -26,7 +26,6 @@
     <MinVerVerbosity>minimal</MinVerVerbosity>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageOutputPath>..\..\packages</PackageOutputPath>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CodeAnalysisRuleSet>RabbitMQ.ruleset</CodeAnalysisRuleSet>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/projects/RabbitMQ.Client/util/NetworkOrderDeserializer.cs
+++ b/projects/RabbitMQ.Client/util/NetworkOrderDeserializer.cs
@@ -33,8 +33,7 @@ namespace RabbitMQ.Util
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static float ReadSingle(ReadOnlySpan<byte> span)
         {
-            uint num = BinaryPrimitives.ReadUInt32BigEndian(span);
-            return Unsafe.As<uint, float>(ref num);
+            return BinaryPrimitives.ReadSingleBigEndian(span);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/projects/RabbitMQ.Client/util/NetworkOrderDeserializer.cs
+++ b/projects/RabbitMQ.Client/util/NetworkOrderDeserializer.cs
@@ -33,7 +33,7 @@ namespace RabbitMQ.Util
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static float ReadSingle(ReadOnlySpan<byte> span)
         {
-            return BinaryPrimitives.ReadSingleBigEndian(span);
+            return BitConverter.Int32BitsToSingle(ReadInt32(span));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/projects/RabbitMQ.Client/util/NetworkOrderSerializer.cs
+++ b/projects/RabbitMQ.Client/util/NetworkOrderSerializer.cs
@@ -33,8 +33,7 @@ namespace RabbitMQ.Util
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void WriteSingle(Span<byte> span, float val)
         {
-            int tempVal = Unsafe.As<float, int>(ref val);
-            BinaryPrimitives.WriteInt32BigEndian(span, tempVal);
+            BinaryPrimitives.WriteSingleBigEndian(span, val);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/projects/RabbitMQ.Client/util/NetworkOrderSerializer.cs
+++ b/projects/RabbitMQ.Client/util/NetworkOrderSerializer.cs
@@ -33,7 +33,7 @@ namespace RabbitMQ.Util
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void WriteSingle(Span<byte> span, float val)
         {
-            BinaryPrimitives.WriteSingleBigEndian(span, val);
+            BinaryPrimitives.WriteInt32BigEndian(span, BitConverter.SingleToInt32Bits(val));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/projects/Unit/Unit.csproj
+++ b/projects/Unit/Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <AssemblyOriginatorKeyFile>../rabbit.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
## Proposed Changes

Memory safety is the main reason of moving from native code to JVM or CLR,
so I think we must fully unleash memory safety when working in C#, just easily
by not using `unsafe` and disallowing unsafe code in the library.
Performance difference would be very trivial, tried a sample (`ReadShortstr`)
on the .NET benchmark and the performance difference were about 
100 milliseconds when repeating the operation 10000000 times.
So I don't think it deserves using `unsafe`, the unsafe code seems sane but
at least removing unsafe now would make it easier to audit any further unsafe
code that maybe added.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [x] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Consider leaving it as an issue and removing the PR if the PR itself is not appropriate

Please note, it seems don't work on old versions of .NET Framework, so either we
should remove support from old versions (like what happens in this PR), or, use
the unsafe only when addressing old frameworks, by adding some precompiler
directives.  I don't think keeping the unsafe just for compatibility for old versions
would be good idea, maybe keep an old version for who needs something old?