### PR TITLE
Minor WireFormatting code cleanups and optimizations.

### DIFF
--- a/projects/RabbitMQ.Client/client/framing/BasicCancel.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicCancel.cs
@@ -70,7 +70,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 1 + 1; // bytes for length of _consumerTag, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_consumerTag); // _consumerTag in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_consumerTag); // _consumerTag in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/BasicCancelOk.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicCancelOk.cs
@@ -66,7 +66,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 1; // bytes for length of _consumerTag
-            bufferSize += Encoding.UTF8.GetByteCount(_consumerTag); // _consumerTag in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_consumerTag); // _consumerTag in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/BasicConsume.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicConsume.cs
@@ -90,8 +90,8 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1 + 1; // bytes for _reserved1, length of _queue, length of _consumerTag, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_queue); // _queue in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_consumerTag); // _consumerTag in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_queue); // _queue in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_consumerTag); // _consumerTag in bytes
             bufferSize += WireFormatting.GetTableByteCount(_arguments); // _arguments in bytes
             return bufferSize;
         }

--- a/projects/RabbitMQ.Client/client/framing/BasicConsumeOk.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicConsumeOk.cs
@@ -66,7 +66,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 1; // bytes for length of _consumerTag
-            bufferSize += Encoding.UTF8.GetByteCount(_consumerTag); // _consumerTag in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_consumerTag); // _consumerTag in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/BasicDeliver.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicDeliver.cs
@@ -83,9 +83,9 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 1 + 8 + 1 + 1 + 1; // bytes for length of _consumerTag, _deliveryTag, bit fields, length of _exchange, length of _routingKey
-            bufferSize += Encoding.UTF8.GetByteCount(_consumerTag); // _consumerTag in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_exchange); // _exchange in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_routingKey); // _routingKey in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_consumerTag); // _consumerTag in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_exchange); // _exchange in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_routingKey); // _routingKey in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/BasicGet.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicGet.cs
@@ -74,7 +74,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1; // bytes for _reserved1, length of _queue, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_queue); // _queue in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_queue); // _queue in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/BasicGetEmpty.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicGetEmpty.cs
@@ -66,7 +66,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 1; // bytes for length of _reserved1
-            bufferSize += Encoding.UTF8.GetByteCount(_reserved1); // _reserved1 in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_reserved1); // _reserved1 in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/BasicGetOk.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicGetOk.cs
@@ -82,8 +82,8 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 8 + 1 + 1 + 1 + 4; // bytes for _deliveryTag, bit fields, length of _exchange, length of _routingKey, _messageCount
-            bufferSize += Encoding.UTF8.GetByteCount(_exchange); // _exchange in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_routingKey); // _routingKey in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_exchange); // _exchange in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_routingKey); // _routingKey in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/BasicProperties.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicProperties.cs
@@ -260,20 +260,20 @@ namespace RabbitMQ.Client.Framing
         public override int GetRequiredPayloadBufferSize()
         {
             int bufferSize = 2; // number of presence fields (14) in 2 bytes blocks
-            if (IsContentTypePresent()) { bufferSize += 1 + Encoding.UTF8.GetByteCount(_contentType); } // _contentType in bytes
-            if (IsContentEncodingPresent()) { bufferSize += 1 + Encoding.UTF8.GetByteCount(_contentEncoding); } // _contentEncoding in bytes
+            if (IsContentTypePresent()) { bufferSize += 1 + WireFormatting.GetUTF8ByteCount(_contentType); } // _contentType in bytes
+            if (IsContentEncodingPresent()) { bufferSize += 1 + WireFormatting.GetUTF8ByteCount(_contentEncoding); } // _contentEncoding in bytes
             if (IsHeadersPresent()) { bufferSize += WireFormatting.GetTableByteCount(_headers); } // _headers in bytes
             if (IsDeliveryModePresent()) { bufferSize++; } // _deliveryMode in bytes
             if (IsPriorityPresent()) { bufferSize++; } // _priority in bytes
-            if (IsCorrelationIdPresent()) { bufferSize += 1 + Encoding.UTF8.GetByteCount(_correlationId); } // _correlationId in bytes
-            if (IsReplyToPresent()) { bufferSize += 1 + Encoding.UTF8.GetByteCount(_replyTo); } // _replyTo in bytes
-            if (IsExpirationPresent()) { bufferSize += 1 + Encoding.UTF8.GetByteCount(_expiration); } // _expiration in bytes
-            if (IsMessageIdPresent()) { bufferSize += 1 + Encoding.UTF8.GetByteCount(_messageId); } // _messageId in bytes
+            if (IsCorrelationIdPresent()) { bufferSize += 1 + WireFormatting.GetUTF8ByteCount(_correlationId); } // _correlationId in bytes
+            if (IsReplyToPresent()) { bufferSize += 1 + WireFormatting.GetUTF8ByteCount(_replyTo); } // _replyTo in bytes
+            if (IsExpirationPresent()) { bufferSize += 1 + WireFormatting.GetUTF8ByteCount(_expiration); } // _expiration in bytes
+            if (IsMessageIdPresent()) { bufferSize += 1 + WireFormatting.GetUTF8ByteCount(_messageId); } // _messageId in bytes
             if (IsTimestampPresent()) { bufferSize += 8; } // _timestamp in bytes
-            if (IsTypePresent()) { bufferSize += 1 + Encoding.UTF8.GetByteCount(_type); } // _type in bytes
-            if (IsUserIdPresent()) { bufferSize += 1 + Encoding.UTF8.GetByteCount(_userId); } // _userId in bytes
-            if (IsAppIdPresent()) { bufferSize += 1 + Encoding.UTF8.GetByteCount(_appId); } // _appId in bytes
-            if (IsClusterIdPresent()) { bufferSize += 1 + Encoding.UTF8.GetByteCount(_clusterId); } // _clusterId in bytes
+            if (IsTypePresent()) { bufferSize += 1 + WireFormatting.GetUTF8ByteCount(_type); } // _type in bytes
+            if (IsUserIdPresent()) { bufferSize += 1 + WireFormatting.GetUTF8ByteCount(_userId); } // _userId in bytes
+            if (IsAppIdPresent()) { bufferSize += 1 + WireFormatting.GetUTF8ByteCount(_appId); } // _appId in bytes
+            if (IsClusterIdPresent()) { bufferSize += 1 + WireFormatting.GetUTF8ByteCount(_clusterId); } // _clusterId in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/BasicPublish.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicPublish.cs
@@ -80,8 +80,8 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1 + 1; // bytes for _reserved1, length of _exchange, length of _routingKey, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_exchange); // _exchange in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_routingKey); // _routingKey in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_exchange); // _exchange in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_routingKey); // _routingKey in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/BasicReturn.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicReturn.cs
@@ -78,9 +78,9 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1 + 1; // bytes for _replyCode, length of _replyText, length of _exchange, length of _routingKey
-            bufferSize += Encoding.UTF8.GetByteCount(_replyText); // _replyText in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_exchange); // _exchange in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_routingKey); // _routingKey in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_replyText); // _replyText in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_exchange); // _exchange in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_routingKey); // _routingKey in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/ChannelClose.cs
+++ b/projects/RabbitMQ.Client/client/framing/ChannelClose.cs
@@ -78,7 +78,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 2 + 2; // bytes for _replyCode, length of _replyText, _classId, _methodId
-            bufferSize += Encoding.UTF8.GetByteCount(_replyText); // _replyText in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_replyText); // _replyText in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/ChannelOpen.cs
+++ b/projects/RabbitMQ.Client/client/framing/ChannelOpen.cs
@@ -66,7 +66,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 1; // bytes for length of _reserved1
-            bufferSize += Encoding.UTF8.GetByteCount(_reserved1); // _reserved1 in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_reserved1); // _reserved1 in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/ConnectionBlocked.cs
+++ b/projects/RabbitMQ.Client/client/framing/ConnectionBlocked.cs
@@ -66,7 +66,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 1; // bytes for length of _reason
-            bufferSize += Encoding.UTF8.GetByteCount(_reason); // _reason in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_reason); // _reason in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/ConnectionClose.cs
+++ b/projects/RabbitMQ.Client/client/framing/ConnectionClose.cs
@@ -78,7 +78,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 2 + 2; // bytes for _replyCode, length of _replyText, _classId, _methodId
-            bufferSize += Encoding.UTF8.GetByteCount(_replyText); // _replyText in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_replyText); // _replyText in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/ConnectionOpen.cs
+++ b/projects/RabbitMQ.Client/client/framing/ConnectionOpen.cs
@@ -74,8 +74,8 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 1 + 1 + 1; // bytes for length of _virtualHost, length of _reserved1, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_virtualHost); // _virtualHost in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_reserved1); // _reserved1 in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_virtualHost); // _virtualHost in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_reserved1); // _reserved1 in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/ConnectionOpenOk.cs
+++ b/projects/RabbitMQ.Client/client/framing/ConnectionOpenOk.cs
@@ -66,7 +66,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 1; // bytes for length of _reserved1
-            bufferSize += Encoding.UTF8.GetByteCount(_reserved1); // _reserved1 in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_reserved1); // _reserved1 in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/ConnectionStartOk.cs
+++ b/projects/RabbitMQ.Client/client/framing/ConnectionStartOk.cs
@@ -81,9 +81,9 @@ namespace RabbitMQ.Client.Framing.Impl
         {
             int bufferSize = 1 + 4 +1; // bytes for length of _mechanism, length of _response, length of _locale
             bufferSize += WireFormatting.GetTableByteCount(_clientProperties); // _clientProperties in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_mechanism); // _mechanism in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_mechanism); // _mechanism in bytes
             bufferSize += _response.Length; // _response in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_locale); // _locale in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_locale); // _locale in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/ConnectionUpdateSecret.cs
+++ b/projects/RabbitMQ.Client/client/framing/ConnectionUpdateSecret.cs
@@ -71,7 +71,7 @@ namespace RabbitMQ.Client.Framing.Impl
         {
             int bufferSize = 4 + 1; // bytes for length of _newSecret, length of _reason
             bufferSize += _newSecret.Length; // _newSecret in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_reason); // _reason in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_reason); // _reason in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/ExchangeBind.cs
+++ b/projects/RabbitMQ.Client/client/framing/ExchangeBind.cs
@@ -88,9 +88,9 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1 + 1 + 1; // bytes for _reserved1, length of _destination, length of _source, length of _routingKey, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_destination); // _destination in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_source); // _source in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_routingKey); // _routingKey in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_destination); // _destination in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_source); // _source in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_routingKey); // _routingKey in bytes
             bufferSize += WireFormatting.GetTableByteCount(_arguments); // _arguments in bytes
             return bufferSize;
         }

--- a/projects/RabbitMQ.Client/client/framing/ExchangeDeclare.cs
+++ b/projects/RabbitMQ.Client/client/framing/ExchangeDeclare.cs
@@ -92,8 +92,8 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1 + 1; // bytes for _reserved1, length of _exchange, length of _type, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_exchange); // _exchange in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_type); // _type in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_exchange); // _exchange in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_type); // _type in bytes
             bufferSize += WireFormatting.GetTableByteCount(_arguments); // _arguments in bytes
             return bufferSize;
         }

--- a/projects/RabbitMQ.Client/client/framing/ExchangeDelete.cs
+++ b/projects/RabbitMQ.Client/client/framing/ExchangeDelete.cs
@@ -76,7 +76,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1; // bytes for _reserved1, length of _exchange, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_exchange); // _exchange in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_exchange); // _exchange in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/ExchangeUnbind.cs
+++ b/projects/RabbitMQ.Client/client/framing/ExchangeUnbind.cs
@@ -88,9 +88,9 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1 + 1 + 1; // bytes for _reserved1, length of _destination, length of _source, length of _routingKey, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_destination); // _destination in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_source); // _source in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_routingKey); // _routingKey in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_destination); // _destination in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_source); // _source in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_routingKey); // _routingKey in bytes
             bufferSize += WireFormatting.GetTableByteCount(_arguments); // _arguments in bytes
             return bufferSize;
         }

--- a/projects/RabbitMQ.Client/client/framing/QueueBind.cs
+++ b/projects/RabbitMQ.Client/client/framing/QueueBind.cs
@@ -88,9 +88,9 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1 + 1 + 1; // bytes for _reserved1, length of _queue, length of _exchange, length of _routingKey, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_queue); // _queue in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_exchange); // _exchange in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_routingKey); // _routingKey in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_queue); // _queue in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_exchange); // _exchange in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_routingKey); // _routingKey in bytes
             bufferSize += WireFormatting.GetTableByteCount(_arguments); // _arguments in bytes
             return bufferSize;
         }

--- a/projects/RabbitMQ.Client/client/framing/QueueDeclare.cs
+++ b/projects/RabbitMQ.Client/client/framing/QueueDeclare.cs
@@ -88,7 +88,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1; // bytes for _reserved1, length of _queue, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_queue); // _queue in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_queue); // _queue in bytes
             bufferSize += WireFormatting.GetTableByteCount(_arguments); // _arguments in bytes
             return bufferSize;
         }

--- a/projects/RabbitMQ.Client/client/framing/QueueDeclareOk.cs
+++ b/projects/RabbitMQ.Client/client/framing/QueueDeclareOk.cs
@@ -74,7 +74,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 1 + 4 + 4; // bytes for length of _queue, _messageCount, _consumerCount
-            bufferSize += Encoding.UTF8.GetByteCount(_queue); // _queue in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_queue); // _queue in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/QueueDelete.cs
+++ b/projects/RabbitMQ.Client/client/framing/QueueDelete.cs
@@ -78,7 +78,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1; // bytes for _reserved1, length of _queue, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_queue); // _queue in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_queue); // _queue in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/QueuePurge.cs
+++ b/projects/RabbitMQ.Client/client/framing/QueuePurge.cs
@@ -74,7 +74,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1; // bytes for _reserved1, length of _queue, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_queue); // _queue in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_queue); // _queue in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/QueueUnbind.cs
+++ b/projects/RabbitMQ.Client/client/framing/QueueUnbind.cs
@@ -84,9 +84,9 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1 + 1; // bytes for _reserved1, length of _queue, length of _exchange, length of _routingKey
-            bufferSize += Encoding.UTF8.GetByteCount(_queue); // _queue in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_exchange); // _exchange in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_routingKey); // _routingKey in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_queue); // _queue in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_exchange); // _exchange in bytes
+            bufferSize += WireFormatting.GetUTF8ByteCount(_routingKey); // _routingKey in bytes
             bufferSize += WireFormatting.GetTableByteCount(_arguments); // _arguments in bytes
             return bufferSize;
         }


### PR DESCRIPTION
## Proposed Changes

Code cleanups to simplify/optimize code for WireFormatting.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

A simple change, performance benchmarks shows considerable improvements to serialization times for empty/null strings and objects. Getting rid of "unsafe" code for the `netcoreapp` target.

**Before:**
``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.20262
Intel Core i7-10700 CPU 2.90GHz, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=5.0.100
  [Host]   : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  ShortRun : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT

Job=ShortRun  IterationCount=3  LaunchCount=1  
WarmupCount=3  

```
|                                 Type |                Method |      Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------------------- |---------------------- |----------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
|         WireFormatting_Read_BasicAck |          ReadFromSpan |  3.905 ns | 0.4919 ns | 0.0270 ns |  1.00 |    0.00 | 0.0038 |     - |     - |      32 B |
|     WireFormatting_Read_BasicDeliver |          ReadFromSpan | 11.831 ns | 1.2428 ns | 0.0681 ns |  3.03 |    0.03 | 0.0067 |     - |     - |      56 B |
|  WireFormatting_Read_BasicProperties |          ReadFromSpan | 63.368 ns | 4.6002 ns | 0.2522 ns | 16.23 |    0.10 | 0.0229 |     - |     - |     192 B |
|     WireFormatting_Read_ChannelClose |          ReadFromSpan |  7.086 ns | 0.9426 ns | 0.0517 ns |  1.81 |    0.03 | 0.0038 |     - |     - |      32 B |
|        WireFormatting_Write_BasicAck |      WriteArgumentsTo |  1.899 ns | 0.0449 ns | 0.0025 ns |  0.49 |    0.00 |      - |     - |     - |         - |
|    WireFormatting_Write_BasicDeliver |      WriteArgumentsTo | 34.764 ns | 3.9156 ns | 0.2146 ns |  8.90 |    0.08 |      - |     - |     - |         - |
| WireFormatting_Write_BasicProperties | WritePropertiesToSpan | 32.445 ns | 0.2154 ns | 0.0118 ns |  8.31 |    0.06 |      - |     - |     - |         - |
|    WireFormatting_Write_ChannelClose |      WriteArgumentsTo | 13.923 ns | 1.5404 ns | 0.0844 ns |  3.57 |    0.03 |      - |     - |     - |         - |

**After:**
``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.20262
Intel Core i7-10700 CPU 2.90GHz, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=5.0.100
  [Host]   : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  ShortRun : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT

Job=ShortRun  IterationCount=3  LaunchCount=1  
WarmupCount=3  

```
|                                 Type |                Method |      Mean |      Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------------------- |---------------------- |----------:|-----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
|         WireFormatting_Read_BasicAck |          ReadFromSpan |  3.889 ns |  0.5254 ns | 0.0288 ns |  1.00 |    0.00 | 0.0038 |     - |     - |      32 B |
|     WireFormatting_Read_BasicDeliver |          ReadFromSpan | 11.002 ns |  0.4028 ns | 0.0221 ns |  2.83 |    0.02 | 0.0067 |     - |     - |      56 B |
|  WireFormatting_Read_BasicProperties |          ReadFromSpan | 58.720 ns | 11.1702 ns | 0.6123 ns | 15.10 |    0.24 | 0.0229 |     - |     - |     192 B |
|     WireFormatting_Read_ChannelClose |          ReadFromSpan |  6.678 ns |  0.1788 ns | 0.0098 ns |  1.72 |    0.02 | 0.0038 |     - |     - |      32 B |
|        WireFormatting_Write_BasicAck |      WriteArgumentsTo |  1.820 ns |  0.0432 ns | 0.0024 ns |  0.47 |    0.00 |      - |     - |     - |         - |
|    WireFormatting_Write_BasicDeliver |      WriteArgumentsTo |  4.797 ns |  0.3201 ns | 0.0175 ns |  1.23 |    0.00 |      - |     - |     - |         - |
| WireFormatting_Write_BasicProperties | WritePropertiesToSpan | 34.957 ns |  0.8850 ns | 0.0485 ns |  8.99 |    0.06 |      - |     - |     - |         - |
|    WireFormatting_Write_ChannelClose |      WriteArgumentsTo |  3.786 ns |  0.1707 ns | 0.0094 ns |  0.97 |    0.01 |      - |     - |     - |         - |

