### PR TITLE
Speeding up shortstr/longstr (de)serialization.

### DIFF
--- a/projects/RabbitMQ.Client/client/framing/BasicCancel.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicCancel.cs
@@ -70,7 +70,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 1 + 1; // bytes for length of _consumerTag, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_consumerTag); // _consumerTag in bytes
+            bufferSize += WireFormatting.GetByteCount(_consumerTag); // _consumerTag in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/BasicCancelOk.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicCancelOk.cs
@@ -66,7 +66,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 1; // bytes for length of _consumerTag
-            bufferSize += Encoding.UTF8.GetByteCount(_consumerTag); // _consumerTag in bytes
+            bufferSize += WireFormatting.GetByteCount(_consumerTag); // _consumerTag in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/BasicConsume.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicConsume.cs
@@ -90,8 +90,8 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1 + 1; // bytes for _reserved1, length of _queue, length of _consumerTag, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_queue); // _queue in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_consumerTag); // _consumerTag in bytes
+            bufferSize += WireFormatting.GetByteCount(_queue); // _queue in bytes
+            bufferSize += WireFormatting.GetByteCount(_consumerTag); // _consumerTag in bytes
             bufferSize += WireFormatting.GetTableByteCount(_arguments); // _arguments in bytes
             return bufferSize;
         }

--- a/projects/RabbitMQ.Client/client/framing/BasicConsumeOk.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicConsumeOk.cs
@@ -66,7 +66,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 1; // bytes for length of _consumerTag
-            bufferSize += Encoding.UTF8.GetByteCount(_consumerTag); // _consumerTag in bytes
+            bufferSize += WireFormatting.GetByteCount(_consumerTag); // _consumerTag in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/BasicDeliver.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicDeliver.cs
@@ -83,9 +83,9 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 1 + 8 + 1 + 1 + 1; // bytes for length of _consumerTag, _deliveryTag, bit fields, length of _exchange, length of _routingKey
-            bufferSize += Encoding.UTF8.GetByteCount(_consumerTag); // _consumerTag in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_exchange); // _exchange in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_routingKey); // _routingKey in bytes
+            bufferSize += WireFormatting.GetByteCount(_consumerTag); // _consumerTag in bytes
+            bufferSize += WireFormatting.GetByteCount(_exchange); // _exchange in bytes
+            bufferSize += WireFormatting.GetByteCount(_routingKey); // _routingKey in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/BasicGet.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicGet.cs
@@ -74,7 +74,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1; // bytes for _reserved1, length of _queue, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_queue); // _queue in bytes
+            bufferSize += WireFormatting.GetByteCount(_queue); // _queue in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/BasicGetEmpty.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicGetEmpty.cs
@@ -66,7 +66,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 1; // bytes for length of _reserved1
-            bufferSize += Encoding.UTF8.GetByteCount(_reserved1); // _reserved1 in bytes
+            bufferSize += WireFormatting.GetByteCount(_reserved1); // _reserved1 in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/BasicGetOk.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicGetOk.cs
@@ -82,8 +82,8 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 8 + 1 + 1 + 1 + 4; // bytes for _deliveryTag, bit fields, length of _exchange, length of _routingKey, _messageCount
-            bufferSize += Encoding.UTF8.GetByteCount(_exchange); // _exchange in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_routingKey); // _routingKey in bytes
+            bufferSize += WireFormatting.GetByteCount(_exchange); // _exchange in bytes
+            bufferSize += WireFormatting.GetByteCount(_routingKey); // _routingKey in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/BasicProperties.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicProperties.cs
@@ -260,20 +260,20 @@ namespace RabbitMQ.Client.Framing
         public override int GetRequiredPayloadBufferSize()
         {
             int bufferSize = 2; // number of presence fields (14) in 2 bytes blocks
-            if (IsContentTypePresent()) { bufferSize += 1 + Encoding.UTF8.GetByteCount(_contentType); } // _contentType in bytes
-            if (IsContentEncodingPresent()) { bufferSize += 1 + Encoding.UTF8.GetByteCount(_contentEncoding); } // _contentEncoding in bytes
+            if (IsContentTypePresent()) { bufferSize += 1 + WireFormatting.GetByteCount(_contentType); } // _contentType in bytes
+            if (IsContentEncodingPresent()) { bufferSize += 1 + WireFormatting.GetByteCount(_contentEncoding); } // _contentEncoding in bytes
             if (IsHeadersPresent()) { bufferSize += WireFormatting.GetTableByteCount(_headers); } // _headers in bytes
             if (IsDeliveryModePresent()) { bufferSize++; } // _deliveryMode in bytes
             if (IsPriorityPresent()) { bufferSize++; } // _priority in bytes
-            if (IsCorrelationIdPresent()) { bufferSize += 1 + Encoding.UTF8.GetByteCount(_correlationId); } // _correlationId in bytes
-            if (IsReplyToPresent()) { bufferSize += 1 + Encoding.UTF8.GetByteCount(_replyTo); } // _replyTo in bytes
-            if (IsExpirationPresent()) { bufferSize += 1 + Encoding.UTF8.GetByteCount(_expiration); } // _expiration in bytes
-            if (IsMessageIdPresent()) { bufferSize += 1 + Encoding.UTF8.GetByteCount(_messageId); } // _messageId in bytes
+            if (IsCorrelationIdPresent()) { bufferSize += 1 + WireFormatting.GetByteCount(_correlationId); } // _correlationId in bytes
+            if (IsReplyToPresent()) { bufferSize += 1 + WireFormatting.GetByteCount(_replyTo); } // _replyTo in bytes
+            if (IsExpirationPresent()) { bufferSize += 1 + WireFormatting.GetByteCount(_expiration); } // _expiration in bytes
+            if (IsMessageIdPresent()) { bufferSize += 1 + WireFormatting.GetByteCount(_messageId); } // _messageId in bytes
             if (IsTimestampPresent()) { bufferSize += 8; } // _timestamp in bytes
-            if (IsTypePresent()) { bufferSize += 1 + Encoding.UTF8.GetByteCount(_type); } // _type in bytes
-            if (IsUserIdPresent()) { bufferSize += 1 + Encoding.UTF8.GetByteCount(_userId); } // _userId in bytes
-            if (IsAppIdPresent()) { bufferSize += 1 + Encoding.UTF8.GetByteCount(_appId); } // _appId in bytes
-            if (IsClusterIdPresent()) { bufferSize += 1 + Encoding.UTF8.GetByteCount(_clusterId); } // _clusterId in bytes
+            if (IsTypePresent()) { bufferSize += 1 + WireFormatting.GetByteCount(_type); } // _type in bytes
+            if (IsUserIdPresent()) { bufferSize += 1 + WireFormatting.GetByteCount(_userId); } // _userId in bytes
+            if (IsAppIdPresent()) { bufferSize += 1 + WireFormatting.GetByteCount(_appId); } // _appId in bytes
+            if (IsClusterIdPresent()) { bufferSize += 1 + WireFormatting.GetByteCount(_clusterId); } // _clusterId in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/BasicPublish.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicPublish.cs
@@ -80,8 +80,8 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1 + 1; // bytes for _reserved1, length of _exchange, length of _routingKey, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_exchange); // _exchange in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_routingKey); // _routingKey in bytes
+            bufferSize += WireFormatting.GetByteCount(_exchange); // _exchange in bytes
+            bufferSize += WireFormatting.GetByteCount(_routingKey); // _routingKey in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/BasicReturn.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicReturn.cs
@@ -78,9 +78,9 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1 + 1; // bytes for _replyCode, length of _replyText, length of _exchange, length of _routingKey
-            bufferSize += Encoding.UTF8.GetByteCount(_replyText); // _replyText in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_exchange); // _exchange in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_routingKey); // _routingKey in bytes
+            bufferSize += WireFormatting.GetByteCount(_replyText); // _replyText in bytes
+            bufferSize += WireFormatting.GetByteCount(_exchange); // _exchange in bytes
+            bufferSize += WireFormatting.GetByteCount(_routingKey); // _routingKey in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/ChannelClose.cs
+++ b/projects/RabbitMQ.Client/client/framing/ChannelClose.cs
@@ -78,7 +78,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 2 + 2; // bytes for _replyCode, length of _replyText, _classId, _methodId
-            bufferSize += Encoding.UTF8.GetByteCount(_replyText); // _replyText in bytes
+            bufferSize += WireFormatting.GetByteCount(_replyText); // _replyText in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/ChannelOpen.cs
+++ b/projects/RabbitMQ.Client/client/framing/ChannelOpen.cs
@@ -66,7 +66,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 1; // bytes for length of _reserved1
-            bufferSize += Encoding.UTF8.GetByteCount(_reserved1); // _reserved1 in bytes
+            bufferSize += WireFormatting.GetByteCount(_reserved1); // _reserved1 in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/ConnectionBlocked.cs
+++ b/projects/RabbitMQ.Client/client/framing/ConnectionBlocked.cs
@@ -66,7 +66,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 1; // bytes for length of _reason
-            bufferSize += Encoding.UTF8.GetByteCount(_reason); // _reason in bytes
+            bufferSize += WireFormatting.GetByteCount(_reason); // _reason in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/ConnectionClose.cs
+++ b/projects/RabbitMQ.Client/client/framing/ConnectionClose.cs
@@ -78,7 +78,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 2 + 2; // bytes for _replyCode, length of _replyText, _classId, _methodId
-            bufferSize += Encoding.UTF8.GetByteCount(_replyText); // _replyText in bytes
+            bufferSize += WireFormatting.GetByteCount(_replyText); // _replyText in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/ConnectionOpen.cs
+++ b/projects/RabbitMQ.Client/client/framing/ConnectionOpen.cs
@@ -74,8 +74,8 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 1 + 1 + 1; // bytes for length of _virtualHost, length of _reserved1, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_virtualHost); // _virtualHost in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_reserved1); // _reserved1 in bytes
+            bufferSize += WireFormatting.GetByteCount(_virtualHost); // _virtualHost in bytes
+            bufferSize += WireFormatting.GetByteCount(_reserved1); // _reserved1 in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/ConnectionOpenOk.cs
+++ b/projects/RabbitMQ.Client/client/framing/ConnectionOpenOk.cs
@@ -66,7 +66,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 1; // bytes for length of _reserved1
-            bufferSize += Encoding.UTF8.GetByteCount(_reserved1); // _reserved1 in bytes
+            bufferSize += WireFormatting.GetByteCount(_reserved1); // _reserved1 in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/ConnectionStartOk.cs
+++ b/projects/RabbitMQ.Client/client/framing/ConnectionStartOk.cs
@@ -81,9 +81,9 @@ namespace RabbitMQ.Client.Framing.Impl
         {
             int bufferSize = 1 + 4 +1; // bytes for length of _mechanism, length of _response, length of _locale
             bufferSize += WireFormatting.GetTableByteCount(_clientProperties); // _clientProperties in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_mechanism); // _mechanism in bytes
+            bufferSize += WireFormatting.GetByteCount(_mechanism); // _mechanism in bytes
             bufferSize += _response.Length; // _response in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_locale); // _locale in bytes
+            bufferSize += WireFormatting.GetByteCount(_locale); // _locale in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/ConnectionUpdateSecret.cs
+++ b/projects/RabbitMQ.Client/client/framing/ConnectionUpdateSecret.cs
@@ -71,7 +71,7 @@ namespace RabbitMQ.Client.Framing.Impl
         {
             int bufferSize = 4 + 1; // bytes for length of _newSecret, length of _reason
             bufferSize += _newSecret.Length; // _newSecret in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_reason); // _reason in bytes
+            bufferSize += WireFormatting.GetByteCount(_reason); // _reason in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/ExchangeBind.cs
+++ b/projects/RabbitMQ.Client/client/framing/ExchangeBind.cs
@@ -88,9 +88,9 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1 + 1 + 1; // bytes for _reserved1, length of _destination, length of _source, length of _routingKey, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_destination); // _destination in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_source); // _source in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_routingKey); // _routingKey in bytes
+            bufferSize += WireFormatting.GetByteCount(_destination); // _destination in bytes
+            bufferSize += WireFormatting.GetByteCount(_source); // _source in bytes
+            bufferSize += WireFormatting.GetByteCount(_routingKey); // _routingKey in bytes
             bufferSize += WireFormatting.GetTableByteCount(_arguments); // _arguments in bytes
             return bufferSize;
         }

--- a/projects/RabbitMQ.Client/client/framing/ExchangeDeclare.cs
+++ b/projects/RabbitMQ.Client/client/framing/ExchangeDeclare.cs
@@ -92,8 +92,8 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1 + 1; // bytes for _reserved1, length of _exchange, length of _type, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_exchange); // _exchange in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_type); // _type in bytes
+            bufferSize += WireFormatting.GetByteCount(_exchange); // _exchange in bytes
+            bufferSize += WireFormatting.GetByteCount(_type); // _type in bytes
             bufferSize += WireFormatting.GetTableByteCount(_arguments); // _arguments in bytes
             return bufferSize;
         }

--- a/projects/RabbitMQ.Client/client/framing/ExchangeDelete.cs
+++ b/projects/RabbitMQ.Client/client/framing/ExchangeDelete.cs
@@ -76,7 +76,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1; // bytes for _reserved1, length of _exchange, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_exchange); // _exchange in bytes
+            bufferSize += WireFormatting.GetByteCount(_exchange); // _exchange in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/ExchangeUnbind.cs
+++ b/projects/RabbitMQ.Client/client/framing/ExchangeUnbind.cs
@@ -88,9 +88,9 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1 + 1 + 1; // bytes for _reserved1, length of _destination, length of _source, length of _routingKey, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_destination); // _destination in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_source); // _source in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_routingKey); // _routingKey in bytes
+            bufferSize += WireFormatting.GetByteCount(_destination); // _destination in bytes
+            bufferSize += WireFormatting.GetByteCount(_source); // _source in bytes
+            bufferSize += WireFormatting.GetByteCount(_routingKey); // _routingKey in bytes
             bufferSize += WireFormatting.GetTableByteCount(_arguments); // _arguments in bytes
             return bufferSize;
         }

--- a/projects/RabbitMQ.Client/client/framing/QueueBind.cs
+++ b/projects/RabbitMQ.Client/client/framing/QueueBind.cs
@@ -88,9 +88,9 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1 + 1 + 1; // bytes for _reserved1, length of _queue, length of _exchange, length of _routingKey, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_queue); // _queue in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_exchange); // _exchange in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_routingKey); // _routingKey in bytes
+            bufferSize += WireFormatting.GetByteCount(_queue); // _queue in bytes
+            bufferSize += WireFormatting.GetByteCount(_exchange); // _exchange in bytes
+            bufferSize += WireFormatting.GetByteCount(_routingKey); // _routingKey in bytes
             bufferSize += WireFormatting.GetTableByteCount(_arguments); // _arguments in bytes
             return bufferSize;
         }

--- a/projects/RabbitMQ.Client/client/framing/QueueDeclare.cs
+++ b/projects/RabbitMQ.Client/client/framing/QueueDeclare.cs
@@ -88,7 +88,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1; // bytes for _reserved1, length of _queue, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_queue); // _queue in bytes
+            bufferSize += WireFormatting.GetByteCount(_queue); // _queue in bytes
             bufferSize += WireFormatting.GetTableByteCount(_arguments); // _arguments in bytes
             return bufferSize;
         }

--- a/projects/RabbitMQ.Client/client/framing/QueueDeclareOk.cs
+++ b/projects/RabbitMQ.Client/client/framing/QueueDeclareOk.cs
@@ -74,7 +74,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 1 + 4 + 4; // bytes for length of _queue, _messageCount, _consumerCount
-            bufferSize += Encoding.UTF8.GetByteCount(_queue); // _queue in bytes
+            bufferSize += WireFormatting.GetByteCount(_queue); // _queue in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/QueueDelete.cs
+++ b/projects/RabbitMQ.Client/client/framing/QueueDelete.cs
@@ -78,7 +78,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1; // bytes for _reserved1, length of _queue, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_queue); // _queue in bytes
+            bufferSize += WireFormatting.GetByteCount(_queue); // _queue in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/QueuePurge.cs
+++ b/projects/RabbitMQ.Client/client/framing/QueuePurge.cs
@@ -74,7 +74,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1; // bytes for _reserved1, length of _queue, bit fields
-            bufferSize += Encoding.UTF8.GetByteCount(_queue); // _queue in bytes
+            bufferSize += WireFormatting.GetByteCount(_queue); // _queue in bytes
             return bufferSize;
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/QueueUnbind.cs
+++ b/projects/RabbitMQ.Client/client/framing/QueueUnbind.cs
@@ -84,9 +84,9 @@ namespace RabbitMQ.Client.Framing.Impl
         public override int GetRequiredBufferSize()
         {
             int bufferSize = 2 + 1 + 1 + 1; // bytes for _reserved1, length of _queue, length of _exchange, length of _routingKey
-            bufferSize += Encoding.UTF8.GetByteCount(_queue); // _queue in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_exchange); // _exchange in bytes
-            bufferSize += Encoding.UTF8.GetByteCount(_routingKey); // _routingKey in bytes
+            bufferSize += WireFormatting.GetByteCount(_queue); // _queue in bytes
+            bufferSize += WireFormatting.GetByteCount(_exchange); // _exchange in bytes
+            bufferSize += WireFormatting.GetByteCount(_routingKey); // _routingKey in bytes
             bufferSize += WireFormatting.GetTableByteCount(_arguments); // _arguments in bytes
             return bufferSize;
         }

--- a/projects/RabbitMQ.Client/client/impl/WireFormatting.cs
+++ b/projects/RabbitMQ.Client/client/impl/WireFormatting.cs
@@ -770,7 +770,6 @@ namespace RabbitMQ.Client.Impl
 #else
         public static int WriteLongstr(Span<byte> span, string val)
         {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static int GetBytes(Span<byte> span, string val)
             {
                 unsafe

--- a/projects/RabbitMQ.Client/client/impl/WireFormatting.cs
+++ b/projects/RabbitMQ.Client/client/impl/WireFormatting.cs
@@ -34,6 +34,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
+
 using RabbitMQ.Client.Exceptions;
 using RabbitMQ.Util;
 
@@ -41,6 +42,8 @@ namespace RabbitMQ.Client.Impl
 {
     internal static class WireFormatting
     {
+        private static UTF8Encoding UTF8 = new UTF8Encoding();
+
         public static decimal ReadDecimal(ReadOnlySpan<byte> span)
         {
             byte scale = span[0];
@@ -150,7 +153,7 @@ namespace RabbitMQ.Client.Impl
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe int ReadShortstr(ReadOnlySpan<byte> span, out string value)
+        public static int ReadShortstr(ReadOnlySpan<byte> span, out string value)
         {
             int byteCount = span[0];
             if (byteCount == 0)
@@ -162,11 +165,19 @@ namespace RabbitMQ.Client.Impl
             // equals span.Length >= byteCount + 1
             if (span.Length > byteCount)
             {
-                fixed (byte* bytes = &span.Slice(1).GetPinnableReference())
+#if NETCOREAPP
+                value = UTF8.GetString(span.Slice(1, byteCount));
+#else
+                unsafe
                 {
-                    value = Encoding.UTF8.GetString(bytes, byteCount);
-                    return 1 + byteCount;
+                    fixed (byte* bytes = span.Slice(1))
+                    {
+                        value = UTF8.GetString(bytes, byteCount);
+                    }
                 }
+
+#endif
+                return 1 + byteCount;
             }
 
             value = string.Empty;
@@ -229,16 +240,16 @@ namespace RabbitMQ.Client.Impl
             out bool val11, out bool val12, out bool val13, out bool val14)
         {
             byte bits = span[0];
-            val1  = (bits & 0b1000_0000) != 0;
-            val2  = (bits & 0b0100_0000) != 0;
-            val3  = (bits & 0b0010_0000) != 0;
-            val4  = (bits & 0b0001_0000) != 0;
-            val5  = (bits & 0b0000_1000) != 0;
-            val6  = (bits & 0b0000_0100) != 0;
-            val7  = (bits & 0b0000_0010) != 0;
-            val8  = (bits & 0b0000_0001) != 0;
+            val1 = (bits & 0b1000_0000) != 0;
+            val2 = (bits & 0b0100_0000) != 0;
+            val3 = (bits & 0b0010_0000) != 0;
+            val4 = (bits & 0b0001_0000) != 0;
+            val5 = (bits & 0b0000_1000) != 0;
+            val6 = (bits & 0b0000_0100) != 0;
+            val7 = (bits & 0b0000_0010) != 0;
+            val8 = (bits & 0b0000_0001) != 0;
             bits = span[1];
-            val9  = (bits & 0b1000_0000) != 0;
+            val9 = (bits & 0b1000_0000) != 0;
             val10 = (bits & 0b0100_0000) != 0;
             val11 = (bits & 0b0010_0000) != 0;
             val12 = (bits & 0b0001_0000) != 0;
@@ -341,6 +352,13 @@ namespace RabbitMQ.Client.Impl
 
             return byteCount;
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#if NETCOREAPP
+        public static int GetByteCount(ReadOnlySpan<char> val) => val.IsEmpty ? 0 : UTF8.GetByteCount(val);
+#else
+        public static int GetByteCount(string val) => string.IsNullOrEmpty(val) ? 0 : UTF8.GetByteCount(val);
+#endif
 
         public static int WriteDecimal(Span<byte> span, decimal value)
         {
@@ -468,7 +486,7 @@ namespace RabbitMQ.Client.Impl
                 case long _:
                     return 9;
                 case string val:
-                    return 5 + Encoding.UTF8.GetByteCount(val);
+                    return 5 + GetByteCount(val);
                 case byte[] val:
                     return 5 + val.Length;
                 case IDictionary val:
@@ -499,7 +517,7 @@ namespace RabbitMQ.Client.Impl
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int WriteBits(Span<byte> span, bool val)
         {
-            span[0] = val ? (byte) 1 : (byte) 0;
+            span[0] = (byte)(val ? 1 : 0);
             return 1;
         }
 
@@ -700,39 +718,75 @@ namespace RabbitMQ.Client.Impl
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe int WriteShortstr(Span<byte> span, string val)
+        public static int WriteShortstr(Span<byte> span, string val)
         {
-            int maxLength = span.Length - 1;
-            if (maxLength > byte.MaxValue)
+            int bytesWritten = 0;
+            if (!string.IsNullOrEmpty(val))
             {
-                maxLength = byte.MaxValue;
-            }
-            fixed (char* chars = val)
-            fixed (byte* bytes = &span.Slice(1).GetPinnableReference())
-            {
+                int maxLength = span.Length - 1;
+                if (maxLength > byte.MaxValue)
+                {
+                    maxLength = byte.MaxValue;
+                }
+#if NETCOREAPP
                 try
                 {
-                    int bytesWritten = Encoding.UTF8.GetBytes(chars, val.Length, bytes, maxLength);
-                    span[0] = (byte)bytesWritten;
-                    return bytesWritten + 1;
+                    bytesWritten = UTF8.GetBytes(val, span.Slice(1, maxLength));
                 }
                 catch (ArgumentException)
                 {
                     return ThrowArgumentOutOfRangeException(val, maxLength);
                 }
+#else
+                unsafe
+                {
+                    fixed (char* chars = val)
+                    {
+                        try
+                        {
+                            fixed (byte* bytes = span.Slice(1))
+                            {
+                                bytesWritten = UTF8.GetBytes(chars, val.Length, bytes, maxLength);
+                            }
+                        }
+                        catch (ArgumentException)
+                        {
+                            return ThrowArgumentOutOfRangeException(val, maxLength);
+                        }
+                    }
+                }
+#endif
             }
+
+            span[0] = (byte)bytesWritten;
+            return bytesWritten + 1;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe int WriteLongstr(Span<byte> span, string val)
+#if NETCOREAPP
+        public static int WriteLongstr(Span<byte> span, ReadOnlySpan<char> val)
         {
-            fixed (char* chars = val)
-            fixed (byte* bytes = &span.Slice(4).GetPinnableReference())
+            int bytesWritten = val.IsEmpty ? 0 : UTF8.GetBytes(val, span.Slice(4));
+#else
+        public static int WriteLongstr(Span<byte> span, string val)
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            static int GetBytes(Span<byte> span, string val)
             {
-                int bytesWritten = Encoding.UTF8.GetBytes(chars, val.Length, bytes, span.Length);
-                NetworkOrderSerializer.WriteUInt32(span, (uint)bytesWritten);
-                return bytesWritten + 4;
+                unsafe
+                {
+                    fixed (char* chars = val)
+                    fixed (byte* bytes = span)
+                    {
+                        return UTF8.GetBytes(chars, val.Length, bytes, span.Length);
+                    }
+                }
             }
+
+            int bytesWritten = string.IsNullOrEmpty(val) ? 0 : GetBytes(span.Slice(4), val);
+#endif
+            NetworkOrderSerializer.WriteUInt32(span, (uint)bytesWritten);
+            return bytesWritten + 4;
         }
 
         public static int WriteTable(Span<byte> span, IDictionary val)
@@ -798,7 +852,7 @@ namespace RabbitMQ.Client.Impl
 
             foreach (DictionaryEntry entry in val)
             {
-                byteCount += Encoding.UTF8.GetByteCount(entry.Key.ToString()) + 1;
+                byteCount += GetByteCount(entry.Key.ToString()) + 1;
                 byteCount += GetFieldValueByteCount(entry.Value);
             }
 
@@ -817,7 +871,7 @@ namespace RabbitMQ.Client.Impl
             {
                 foreach (KeyValuePair<string, object> entry in dict)
                 {
-                    byteCount += Encoding.UTF8.GetByteCount(entry.Key) + 1;
+                    byteCount += GetByteCount(entry.Key) + 1;
                     byteCount += GetFieldValueByteCount(entry.Value);
                 }
             }
@@ -825,7 +879,7 @@ namespace RabbitMQ.Client.Impl
             {
                 foreach (KeyValuePair<string, object> entry in val)
                 {
-                    byteCount += Encoding.UTF8.GetByteCount(entry.Key) + 1;
+                    byteCount += GetByteCount(entry.Key) + 1;
                     byteCount += GetFieldValueByteCount(entry.Value);
                 }
             }


### PR DESCRIPTION
## Proposed Changes

Code cleanups and optimizations for shortstr/longstr (de)serialization.

This provides a pretty hefty improvement to almost all messages sent and some improvements to most messages read as well.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [X] Cosmetic change (whitespace, formatting, etc)
- [X] Optimizations

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Benchmark results

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.20270
Intel Core i7-10700 CPU 2.90GHz, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=5.0.101
  [Host]        : .NET Core 3.1.10 (CoreCLR 4.700.20.51601, CoreFX 4.700.20.51901), X64 RyuJIT
  .NET 4.8      : .NET Framework 4.8 (4.8.4261.0), X64 RyuJIT
  .NET Core 3.1 : .NET Core 3.1.10 (CoreCLR 4.700.20.51601, CoreFX 4.700.20.51901), X64 RyuJIT
```

|                 Method |    Pre/Post |       Runtime |         Mean |      Error |     StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated | Code Size |
|----------------------- |------------ |-------------- |-------------:|-----------:|-----------:|-------:|-------:|------:|----------:|----------:|
|         ArrayReadEmpty |         Pre |      .NET 4.8 |    22.820 ns |  0.4441 ns |  0.4361 ns | 0.0063 |      - |     - |      40 B |     672 B |
|         ArrayReadEmpty |        Post |      .NET 4.8 |    21.905 ns |  0.0683 ns |  0.0639 ns | 0.0063 |      - |     - |      40 B |     672 B |
|     ArrayReadPopulated |         Pre |      .NET 4.8 |   137.263 ns |  0.2047 ns |  0.1710 ns | 0.0343 |      - |     - |     217 B |     672 B |
|     ArrayReadPopulated |        Post |      .NET 4.8 |   131.391 ns |  0.3584 ns |  0.3353 ns | 0.0343 |      - |     - |     217 B |     672 B |
|        ArrayWriteEmpty |         Pre |      .NET 4.8 |    20.649 ns |  0.0291 ns |  0.0227 ns |      - |      - |     - |         - |     795 B |
|        ArrayWriteEmpty |        Post |      .NET 4.8 |    21.355 ns |  0.0494 ns |  0.0438 ns |      - |      - |     - |         - |     816 B |
|    ArrayWritePopulated |         Pre |      .NET 4.8 |   142.924 ns |  0.8935 ns |  0.7461 ns | 0.0062 |      - |     - |      40 B |     795 B |
|    ArrayWritePopulated |        Post |      .NET 4.8 |   140.215 ns |  0.2400 ns |  0.2128 ns | 0.0062 |      - |     - |      40 B |     816 B |
|         TableReadEmpty |         Pre |      .NET 4.8 |    19.544 ns |  0.0570 ns |  0.0505 ns |      - |      - |     - |         - |     999 B |
|         TableReadEmpty |        Post |      .NET 4.8 |    19.186 ns |  0.0727 ns |  0.0607 ns |      - |      - |     - |         - |    1008 B |
|     TableReadPopulated |         Pre |      .NET 4.8 |   863.653 ns |  2.5798 ns |  2.2870 ns | 0.2222 | 0.0010 |     - |    1404 B |    1002 B |
|     TableReadPopulated |        Post |      .NET 4.8 |   797.831 ns |  2.0380 ns |  1.9064 ns | 0.2222 | 0.0010 |     - |    1404 B |    1008 B |
|        TableWriteEmpty |         Pre |      .NET 4.8 |    21.676 ns |  0.2943 ns |  0.2458 ns |      - |      - |     - |         - |    1505 B |
|        TableWriteEmpty |        Post |      .NET 4.8 |    21.620 ns |  0.0779 ns |  0.0651 ns |      - |      - |     - |         - |    1546 B |
|    TableWritePopulated |         Pre |      .NET 4.8 |   666.625 ns |  3.1778 ns |  2.6536 ns | 0.0257 |      - |     - |     168 B |    1505 B |
|    TableWritePopulated |        Post |      .NET 4.8 |   653.420 ns |  1.8345 ns |  1.6262 ns | 0.0257 |      - |     - |     168 B |    1546 B |
|       LongstrReadEmpty |         Pre |      .NET 4.8 |    18.582 ns |  0.1331 ns |  0.1180 ns |      - |      - |     - |         - |     668 B |
|       LongstrReadEmpty |        Post |      .NET 4.8 |    18.510 ns |  0.0741 ns |  0.0693 ns |      - |      - |     - |         - |     665 B |
|   LongstrReadPopulated |         Pre |      .NET 4.8 |   319.274 ns |  2.2690 ns |  2.0114 ns | 0.6561 |      - |     - |    4134 B |     668 B |
|   LongstrReadPopulated |        Post |      .NET 4.8 |   274.551 ns |  1.9830 ns |  1.8549 ns | 0.6561 |      - |     - |    4134 B |     665 B |
|      LongstrWriteEmpty |         Pre |      .NET 4.8 |    26.209 ns |  0.0735 ns |  0.0651 ns |      - |      - |     - |         - |     846 B |
|      LongstrWriteEmpty |        Post |      .NET 4.8 |    12.155 ns |  0.0385 ns |  0.0341 ns |      - |      - |     - |         - |     733 B |
|  LongstrWritePopulated |         Pre |      .NET 4.8 | 1,730.893 ns |  6.9724 ns |  6.5220 ns |      - |      - |     - |         - |     840 B |
|  LongstrWritePopulated |        Post |      .NET 4.8 | 1,696.238 ns |  9.0216 ns |  8.4388 ns |      - |      - |     - |         - |     727 B |
|      ShortstrReadEmpty |         Pre |      .NET 4.8 |     9.773 ns |  0.0826 ns |  0.0732 ns |      - |      - |     - |         - |     830 B |
|      ShortstrReadEmpty |        Post |      .NET 4.8 |     9.929 ns |  0.0419 ns |  0.0350 ns |      - |      - |     - |         - |     714 B |
|  ShortstrReadPopulated |         Pre |      .NET 4.8 |   178.406 ns |  0.6001 ns |  0.5613 ns | 0.0854 |      - |     - |     538 B |     866 B |
|  ShortstrReadPopulated |        Post |      .NET 4.8 |   168.054 ns |  0.5726 ns |  0.5356 ns | 0.0854 |      - |     - |     538 B |     750 B |
|     ShortstrWriteEmpty |         Pre |      .NET 4.8 |    27.042 ns |  0.1473 ns |  0.1306 ns |      - |      - |     - |         - |     719 B |
|     ShortstrWriteEmpty |        Post |      .NET 4.8 |    18.302 ns |  0.0738 ns |  0.0616 ns |      - |      - |     - |         - |     834 B |
| ShortstrWritePopulated |         Pre |      .NET 4.8 |   144.082 ns |  0.8153 ns |  0.7626 ns |      - |      - |     - |         - |     715 B |
| ShortstrWritePopulated |        Post |      .NET 4.8 |   143.466 ns |  0.6751 ns |  0.6315 ns |      - |      - |     - |         - |     830 B |
|         ArrayReadEmpty |         Pre | .NET Core 3.1 |    12.401 ns |  0.0976 ns |  0.0865 ns | 0.0038 |      - |     - |      32 B |     408 B |
|         ArrayReadEmpty |        Post | .NET Core 3.1 |    11.759 ns |  0.0510 ns |  0.0477 ns | 0.0038 |      - |     - |      32 B |     408 B |
|     ArrayReadPopulated |         Pre | .NET Core 3.1 |    96.808 ns |  0.3429 ns |  0.3208 ns | 0.0248 |      - |     - |     208 B |     408 B |
|     ArrayReadPopulated |        Post | .NET Core 3.1 |    87.208 ns |  0.3289 ns |  0.3077 ns | 0.0248 |      - |     - |     208 B |     408 B |
|        ArrayWriteEmpty |         Pre | .NET Core 3.1 |     4.587 ns |  0.0215 ns |  0.0201 ns |      - |      - |     - |         - |     413 B |
|        ArrayWriteEmpty |        Post | .NET Core 3.1 |     4.958 ns |  0.1162 ns |  0.1193 ns |      - |      - |     - |         - |     413 B |
|    ArrayWritePopulated |         Pre | .NET Core 3.1 |    82.959 ns |  0.4525 ns |  0.4233 ns | 0.0048 |      - |     - |      40 B |     413 B |
|    ArrayWritePopulated |        Post | .NET Core 3.1 |    79.865 ns |  0.2570 ns |  0.2404 ns | 0.0048 |      - |     - |      40 B |     413 B |
|         TableReadEmpty |         Pre | .NET Core 3.1 |     9.277 ns |  0.0173 ns |  0.0135 ns |      - |      - |     - |         - |     645 B |
|         TableReadEmpty |        Post | .NET Core 3.1 |     9.221 ns |  0.0464 ns |  0.0434 ns |      - |      - |     - |         - |     634 B |
|     TableReadPopulated |         Pre | .NET Core 3.1 |   752.980 ns |  3.8807 ns |  3.2406 ns | 0.1612 |      - |     - |    1352 B |     648 B |
|     TableReadPopulated |        Post | .NET Core 3.1 |   688.693 ns |  3.0056 ns |  2.8114 ns | 0.1612 |      - |     - |    1352 B |     634 B |
|        TableWriteEmpty |         Pre | .NET Core 3.1 |    11.404 ns |  0.0356 ns |  0.0333 ns |      - |      - |     - |         - |    1041 B |
|        TableWriteEmpty |        Post | .NET Core 3.1 |    11.040 ns |  0.2385 ns |  0.2114 ns |      - |      - |     - |         - |    1041 B |
|    TableWritePopulated |         Pre | .NET Core 3.1 |   422.034 ns |  1.4816 ns |  1.1567 ns | 0.0200 |      - |     - |     168 B |    1041 B |
|    TableWritePopulated |        Post | .NET Core 3.1 |   415.224 ns |  1.2110 ns |  1.1327 ns | 0.0200 |      - |     - |     168 B |    1041 B |
|       LongstrReadEmpty |         Pre | .NET Core 3.1 |     3.173 ns |  0.0597 ns |  0.0529 ns |      - |      - |     - |         - |     315 B |
|       LongstrReadEmpty |        Post | .NET Core 3.1 |     3.119 ns |  0.0249 ns |  0.0208 ns |      - |      - |     - |         - |     312 B |
|   LongstrReadPopulated |         Pre | .NET Core 3.1 |   222.098 ns |  4.3371 ns |  4.9946 ns | 0.4923 |      - |     - |    4120 B |     315 B |
|   LongstrReadPopulated |        Post | .NET Core 3.1 |   181.609 ns |  3.6231 ns |  4.1724 ns | 0.4923 |      - |     - |    4120 B |     312 B |
|      LongstrWriteEmpty |         Pre | .NET Core 3.1 |     9.726 ns |  0.0399 ns |  0.0354 ns |      - |      - |     - |         - |     516 B |
|      LongstrWriteEmpty |        Post | .NET Core 3.1 |     8.018 ns |  0.0635 ns |  0.0563 ns |      - |      - |     - |         - |     281 B |
|  LongstrWritePopulated |         Pre | .NET Core 3.1 |   219.733 ns |  0.7856 ns |  0.6964 ns |      - |      - |     - |         - |     512 B |
|  LongstrWritePopulated |        Post | .NET Core 3.1 |   223.276 ns |  0.3555 ns |  0.3326 ns |      - |      - |     - |         - |     277 B |
|      ShortstrReadEmpty |         Pre | .NET Core 3.1 |     1.524 ns |  0.0073 ns |  0.0061 ns |      - |      - |     - |         - |     248 B |
|      ShortstrReadEmpty |        Post | .NET Core 3.1 |     1.501 ns |  0.0098 ns |  0.0082 ns |      - |      - |     - |         - |     244 B |
|  ShortstrReadPopulated |         Pre | .NET Core 3.1 |    57.677 ns |  1.1032 ns |  1.1329 ns | 0.0641 |      - |     - |     536 B |     508 B |
|  ShortstrReadPopulated |        Post | .NET Core 3.1 |    52.808 ns |  0.7226 ns |  0.6759 ns | 0.0641 |      - |     - |     536 B |     299 B |
|     ShortstrWriteEmpty |         Pre | .NET Core 3.1 |    11.495 ns |  0.0496 ns |  0.0414 ns |      - |      - |     - |         - |     392 B |
|     ShortstrWriteEmpty |        Post | .NET Core 3.1 |     3.718 ns |  0.0194 ns |  0.0151 ns |      - |      - |     - |         - |     468 B |
| ShortstrWritePopulated |         Pre | .NET Core 3.1 |    25.018 ns |  0.4949 ns |  0.5083 ns |      - |      - |     - |         - |     388 B |
| ShortstrWritePopulated |        Post | .NET Core 3.1 |    24.920 ns |  0.0683 ns |  0.0605 ns |      - |      - |     - |         - |     464 B |

|               Method |    Pre/Post |       Runtime |       Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated | Code Size |
|--------------------- |------------ |-------------- |-----------:|----------:|----------:|-------:|------:|------:|----------:|----------:|
|         BasicAckRead |         Pre |      .NET 4.8 |  22.512 ns | 0.1782 ns | 0.1488 ns | 0.0051 |     - |     - |      32 B |     676 B |
|         BasicAckRead |        Post |      .NET 4.8 |  22.403 ns | 0.0297 ns | 0.0264 ns | 0.0051 |     - |     - |      32 B |     676 B |
|        BasicAckWrite |         Pre |      .NET 4.8 |  21.315 ns | 0.0615 ns | 0.0545 ns |      - |     - |     - |         - |     689 B |
|        BasicAckWrite |        Post |      .NET 4.8 |  21.317 ns | 0.0742 ns | 0.0694 ns |      - |     - |     - |         - |     689 B |
|     BasicDeliverRead |         Pre |      .NET 4.8 |  32.278 ns | 0.4230 ns | 0.3532 ns | 0.0089 |     - |     - |      56 B |    1475 B |
|     BasicDeliverRead |        Post |      .NET 4.8 |  30.830 ns | 0.4390 ns | 0.3890 ns | 0.0089 |     - |     - |      56 B |    1505 B |
|    BasicDeliverWrite |         Pre |      .NET 4.8 |  79.532 ns | 0.2814 ns | 0.2495 ns |      - |     - |     - |         - |     873 B |
|    BasicDeliverWrite |        Post |      .NET 4.8 |  48.970 ns | 0.1490 ns | 0.1390 ns |      - |     - |     - |         - |     903 B |
|  BasicPropertiesRead |         Pre |      .NET 4.8 | 108.924 ns | 0.4782 ns | 0.3994 ns | 0.0318 |     - |     - |     201 B |    6603 B |
|  BasicPropertiesRead |        Post |      .NET 4.8 | 101.670 ns | 0.2830 ns | 0.2650 ns | 0.0318 |     - |     - |     201 B |    6750 B |
| BasicPropertiesWrite |         Pre |      .NET 4.8 |  76.225 ns | 1.1911 ns | 1.1698 ns |      - |     - |     - |         - |    1991 B |
| BasicPropertiesWrite |        Post |      .NET 4.8 |  76.380 ns | 0.2660 ns | 0.2480 ns |      - |     - |     - |         - |    2013 B |
|     ChannelCloseRead |         Pre |      .NET 4.8 |  27.916 ns | 0.2079 ns | 0.1843 ns | 0.0051 |     - |     - |      32 B |    1049 B |
|     ChannelCloseRead |        Post |      .NET 4.8 |  27.363 ns | 0.2029 ns | 0.1694 ns | 0.0051 |     - |     - |      32 B |    1058 B |
|    ChannelCloseWrite |         Pre |      .NET 4.8 |  40.392 ns | 0.3391 ns | 0.3172 ns |      - |     - |     - |         - |     816 B |
|    ChannelCloseWrite |        Post |      .NET 4.8 |  32.318 ns | 0.0920 ns | 0.0861 ns |      - |     - |     - |         - |     858 B |
|         BasicAckRead |         Pre | .NET Core 3.1 |   4.796 ns | 0.1006 ns | 0.0941 ns | 0.0038 |     - |     - |      32 B |     260 B |
|         BasicAckRead |        Post | .NET Core 3.1 |   4.022 ns | 0.0231 ns | 0.0216 ns | 0.0038 |     - |     - |      32 B |     260 B |
|        BasicAckWrite |         Pre | .NET Core 3.1 |   3.324 ns | 0.0173 ns | 0.0144 ns |      - |     - |     - |         - |     256 B |
|        BasicAckWrite |        Post | .NET Core 3.1 |   3.269 ns | 0.0310 ns | 0.0290 ns |      - |     - |     - |         - |     256 B |
|     BasicDeliverRead |         Pre | .NET Core 3.1 |  13.006 ns | 0.1830 ns | 0.1712 ns | 0.0067 |     - |     - |      56 B |     935 B |
|     BasicDeliverRead |        Post | .NET Core 3.1 |  11.510 ns | 0.0540 ns | 0.0500 ns | 0.0067 |     - |     - |      56 B |     960 B |
|    BasicDeliverWrite |         Pre | .NET Core 3.1 |  36.468 ns | 0.2432 ns | 0.2156 ns |      - |     - |     - |         - |     438 B |
|    BasicDeliverWrite |        Post | .NET Core 3.1 |  13.130 ns | 0.0350 ns | 0.0330 ns |      - |     - |     - |         - |     438 B |
|  BasicPropertiesRead |         Pre | .NET Core 3.1 |  70.037 ns | 1.2143 ns | 1.0140 ns | 0.0229 |     - |     - |     192 B |    3461 B |
|  BasicPropertiesRead |        Post | .NET Core 3.1 |  55.300 ns | 0.1370 ns | 0.1290 ns | 0.0229 |     - |     - |     192 B |    3085 B |
| BasicPropertiesWrite |         Pre | .NET Core 3.1 |  34.849 ns | 0.3061 ns | 0.2713 ns |      - |     - |     - |         - |    1433 B |
| BasicPropertiesWrite |        Post | .NET Core 3.1 |  36.190 ns | 0.1010 ns | 0.0940 ns |      - |     - |     - |         - |    1433 B |
|     ChannelCloseRead |         Pre | .NET Core 3.1 |   8.378 ns | 0.0411 ns | 0.0364 ns | 0.0038 |     - |     - |      32 B |     582 B |
|     ChannelCloseRead |        Post | .NET Core 3.1 |   7.723 ns | 0.0335 ns | 0.0313 ns | 0.0038 |     - |     - |      32 B |     608 B |
|    ChannelCloseWrite |         Pre | .NET Core 3.1 |  15.743 ns | 0.2899 ns | 0.4249 ns |      - |     - |     - |         - |     392 B |
|    ChannelCloseWrite |        Post | .NET Core 3.1 |   6.979 ns | 0.0272 ns | 0.0254 ns |      - |     - |     - |         - |     392 B |
