### PR TITLE
7.0 - improve eventing

### DIFF
--- a/projects/Benchmarks/Eventing/Eventing.cs
+++ b/projects/Benchmarks/Eventing/Eventing.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using RabbitMQ.Benchmarks;
+using RabbitMQ.Client.Impl;
+
+namespace Benchmarks.Eventing
+{
+    [Config(typeof(Config))]
+    [BenchmarkCategory("Eventing")]
+    public class EventingBase
+    {
+        public static IEnumerable<object> CountSource()
+        {
+            yield return 1;
+            yield return 5;
+        }
+
+        protected readonly EventHandler<ulong> _action = (_, __) => { };
+        protected List<EventHandler<ulong>> _list;
+        private protected EventingWrapper<ulong> _wrapper;
+    }
+
+    public class Eventing_AddRemove : EventingBase
+    {
+        private event EventHandler<ulong> _event;
+
+        [Benchmark(Baseline = true)]
+        [ArgumentsSource(nameof(CountSource))]
+        public void Event(int count)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                _event += _action;
+            }
+
+            for (int i = 0; i < count; i++)
+            {
+                _event -= _action;
+            }
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(CountSource))]
+        public void Wrapper(int count)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                _wrapper.AddHandler(_action);
+            }
+
+            for (int i = 0; i < count; i++)
+            {
+                _wrapper.RemoveHandler(_action);
+            }
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(CountSource))]
+        public void List(int count)
+        {
+            _list = new List<EventHandler<ulong>>(1);
+            for (int i = 0; i < count; i++)
+            {
+                _list.Add(_action);
+            }
+
+            for (int i = 0; i < count; i++)
+            {
+                _list.Remove(_action);
+            }
+        }
+    }
+
+    public class Eventing_Invoke : EventingBase
+    {
+        private event EventHandler<ulong> _event;
+
+        public Eventing_Invoke()
+        {
+            _wrapper = new EventingWrapper<ulong>("ContextString", (ex, context) => OnUnhandledExceptionOccurred(ex, context));
+        }
+
+        [ParamsSource(nameof(CountSource))]
+        public int Length
+        {
+            set
+            {
+                _list = new List<EventHandler<ulong>>(value);
+                var action = new EventHandler<ulong>((exception, context) => { });
+                for (int i = 0; i < value; i++)
+                {
+                    _event += action;
+                    _wrapper.AddHandler(action);
+                    _list.Add(action);
+                }
+            }
+        }
+
+        [Benchmark(Baseline = true)]
+        public void SingleInvoke()
+        {
+            _event?.Invoke(this, 5UL);
+        }
+
+        [Benchmark]
+        public void GetInvocationList()
+        {
+            var handler = _event;
+            if (handler != null)
+            {
+                foreach (EventHandler<ulong> action in handler.GetInvocationList())
+                {
+                    try
+                    {
+                        action(this, 5UL);
+                    }
+                    catch (Exception e)
+                    {
+                        OnUnhandledExceptionOccurred(e, "ContextString");
+                    }
+                }
+            }
+        }
+
+        [Benchmark]
+        public void List()
+        {
+            var handler = _event;
+            if (handler != null)
+            {
+                foreach (EventHandler<ulong> action in _list)
+                {
+                    try
+                    {
+                        action(this, 5UL);
+                    }
+                    catch (Exception e)
+                    {
+                        OnUnhandledExceptionOccurred(e, "ContextString");
+                    }
+                }
+            }
+        }
+
+        [Benchmark]
+        public void Wrapper()
+        {
+            _wrapper.Invoke(this, 5UL);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void OnUnhandledExceptionOccurred(Exception exception, string context)
+        {
+        }
+    }
+}

--- a/projects/RabbitMQ.Client/client/events/AsyncEventHandler.cs
+++ b/projects/RabbitMQ.Client/client/events/AsyncEventHandler.cs
@@ -1,21 +1,6 @@
-using System;
 using System.Threading.Tasks;
 
 namespace RabbitMQ.Client.Events
 {
-    public delegate Task AsyncEventHandler<in TEvent>(object sender, TEvent @event) where TEvent : EventArgs;
-
-    internal static class AsyncEventHandlerExtensions
-    {
-        public static async Task InvokeAsync<TEvent>(this AsyncEventHandler<TEvent> eventHandler, object sender, TEvent @event) where TEvent : EventArgs
-        {
-            if (eventHandler != null)
-            {
-                foreach (AsyncEventHandler<TEvent> handlerInstance in eventHandler.GetInvocationList())
-                {
-                    await handlerInstance(sender, @event).ConfigureAwait(false);
-                }
-            }
-        }
-    }
+    public delegate Task AsyncEventHandler<in TEvent>(object sender, TEvent @event);
 }

--- a/projects/RabbitMQ.Client/client/events/AsyncEventingBasicConsumer.cs
+++ b/projects/RabbitMQ.Client/client/events/AsyncEventingBasicConsumer.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Threading.Tasks;
+using RabbitMQ.Client.Impl;
 
 namespace RabbitMQ.Client.Events
 {
     public class AsyncEventingBasicConsumer : AsyncDefaultBasicConsumer
     {
-        ///<summary>Constructor which sets the Model property to the
-        ///given value.</summary>
+        ///<summary>Constructor which sets the Model property to the given value.</summary>
         public AsyncEventingBasicConsumer(IModel model) : base(model)
         {
         }
@@ -19,43 +19,72 @@ namespace RabbitMQ.Client.Events
         /// Accessing the body at a later point is unsafe as its memory can
         /// be already released.
         /// </remarks>
-        public event AsyncEventHandler<BasicDeliverEventArgs> Received;
+        public event AsyncEventHandler<BasicDeliverEventArgs> Received
+        {
+            add => _receivedWrapper.AddHandler(value);
+            remove => _receivedWrapper.RemoveHandler(value);
+        }
+        private AsyncEventingWrapper<BasicDeliverEventArgs> _receivedWrapper;
 
         ///<summary>Fires when the server confirms successful consumer cancelation.</summary>
-        public event AsyncEventHandler<ConsumerEventArgs> Registered;
+        public event AsyncEventHandler<ConsumerEventArgs> Registered
+        {
+            add => _registeredWrapper.AddHandler(value);
+            remove => _registeredWrapper.RemoveHandler(value);
+        }
+        private AsyncEventingWrapper<ConsumerEventArgs> _registeredWrapper;
 
-        ///<summary>Fires on model (channel) shutdown, both client and server initiated.</summary>
-        public event AsyncEventHandler<ShutdownEventArgs> Shutdown;
+        ///<summary>Fires on channel shutdown, both client and server initiated.</summary>
+        public event AsyncEventHandler<ShutdownEventArgs> Shutdown
+        {
+            add => _shutdownWrapper.AddHandler(value);
+            remove => _shutdownWrapper.RemoveHandler(value);
+        }
+        private AsyncEventingWrapper<ShutdownEventArgs> _shutdownWrapper;
 
         ///<summary>Fires when the server confirms successful consumer cancelation.</summary>
-        public event AsyncEventHandler<ConsumerEventArgs> Unregistered;
+        public event AsyncEventHandler<ConsumerEventArgs> Unregistered
+        {
+            add => _unregisteredWrapper.AddHandler(value);
+            remove => _unregisteredWrapper.RemoveHandler(value);
+        }
+        private AsyncEventingWrapper<ConsumerEventArgs> _unregisteredWrapper;
 
         ///<summary>Fires when the server confirms successful consumer cancelation.</summary>
         public override async Task HandleBasicCancelOk(string consumerTag)
         {
             await base.HandleBasicCancelOk(consumerTag).ConfigureAwait(false);
-            await Unregistered.InvokeAsync(this, new ConsumerEventArgs(new[] { consumerTag })).ConfigureAwait(false);
+            if (!_unregisteredWrapper.IsEmpty)
+            {
+                await _unregisteredWrapper.InvokeAsync(this, new ConsumerEventArgs(new[] { consumerTag })).ConfigureAwait(false);
+            }
         }
 
         ///<summary>Fires when the server confirms successful consumer registration.</summary>
         public override async Task HandleBasicConsumeOk(string consumerTag)
         {
             await base.HandleBasicConsumeOk(consumerTag).ConfigureAwait(false);
-            await Registered.InvokeAsync(this, new ConsumerEventArgs(new[] { consumerTag })).ConfigureAwait(false);
+            if (!_registeredWrapper.IsEmpty)
+            {
+                await _registeredWrapper.InvokeAsync(this, new ConsumerEventArgs(new[] { consumerTag })).ConfigureAwait(false);
+            }
         }
 
         ///<summary>Fires the Received event.</summary>
         public override Task HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, IBasicProperties properties, ReadOnlyMemory<byte> body)
         {
             // No need to call base, it's empty.
-            return Received.InvokeAsync(this, new BasicDeliverEventArgs(consumerTag, deliveryTag, redelivered, exchange, routingKey, properties, body));
+            return _receivedWrapper.InvokeAsync(this, new BasicDeliverEventArgs(consumerTag, deliveryTag, redelivered, exchange, routingKey, properties, body));
         }
 
         ///<summary>Fires the Shutdown event.</summary>
         public override async Task HandleModelShutdown(object model, ShutdownEventArgs reason)
         {
             await base.HandleModelShutdown(model, reason).ConfigureAwait(false);
-            await Shutdown.InvokeAsync(this, reason).ConfigureAwait(false);
+            if (!_shutdownWrapper.IsEmpty)
+            {
+                await _shutdownWrapper.InvokeAsync(this, reason).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
@@ -200,7 +200,11 @@ namespace RabbitMQ.Client.Impl
             }
         }
 
-        public event EventHandler<EventArgs> Recovery;
+        public event EventHandler<EventArgs> Recovery
+        {
+            add { RecoveryAwareDelegate.Recovery += value; }
+            remove { RecoveryAwareDelegate.Recovery -= value; }
+        }
 
         public int ChannelNumber => Delegate.ChannelNumber;
 
@@ -228,7 +232,7 @@ namespace RabbitMQ.Client.Impl
             RecoveryAwareModel defunctModel = _delegate;
 
             _delegate = conn.CreateNonRecoveringModel();
-            _delegate.InheritOffsetFrom(defunctModel);
+            _delegate.TakeOver(defunctModel);
 
             RecoverModelShutdownHandlers();
             RecoverState();
@@ -1097,19 +1101,7 @@ namespace RabbitMQ.Client.Impl
         private void RunRecoveryEventHandlers()
         {
             ThrowIfDisposed();
-            foreach (EventHandler<EventArgs> reh in Recovery?.GetInvocationList() ?? Array.Empty<Delegate>())
-            {
-                try
-                {
-                    reh(this, EventArgs.Empty);
-                }
-                catch (Exception e)
-                {
-                    var args = new CallbackExceptionEventArgs(e);
-                    args.Detail["context"] = "OnModelRecovery";
-                    _delegate.OnCallbackException(args);
-                }
-            }
+            _delegate.RunRecoveryEventHandlers(this);
         }
 
         public IBasicPublishBatch CreateBasicPublishBatch() => Delegate.CreateBasicPublishBatch();

--- a/projects/RabbitMQ.Client/client/impl/CommandAssembler.cs
+++ b/projects/RabbitMQ.Client/client/impl/CommandAssembler.cs
@@ -120,6 +120,11 @@ namespace RabbitMQ.Client.Impl
             {
                 throw new UnexpectedFrameException(frame.Type);
             }
+            if (totalBodyBytes == 0)
+            {
+                // If the body size is 0, there is no body frame coming, so assign an empty array
+                _bodyBytes = Array.Empty<byte>();
+            }
 
             _remainingBodyBytes = (int) totalBodyBytes;
             UpdateContentBodyState();

--- a/projects/RabbitMQ.Client/client/impl/EventingWrapper.cs
+++ b/projects/RabbitMQ.Client/client/impl/EventingWrapper.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Threading.Tasks;
+using RabbitMQ.Client.Events;
+
+namespace RabbitMQ.Client.Impl
+{
+    #nullable enable
+    internal struct EventingWrapper<T>
+    {
+        private event EventHandler<T>? _event;
+        private Delegate[]? _handlers;
+        private string? _context;
+        private Action<Exception, string>? _onExceptionAction;
+
+        public bool IsEmpty => _event is null;
+
+        public EventingWrapper(string context, Action<Exception, string> onExceptionAction)
+        {
+            _event = null;
+            _handlers = null;
+            _context = context;
+            _onExceptionAction = onExceptionAction;
+        }
+
+        public void AddHandler(EventHandler<T>? handler)
+        {
+            _event += handler;
+            _handlers = null;
+        }
+
+        public void RemoveHandler(EventHandler<T>? handler)
+        {
+            _event -= handler;
+            _handlers = null;
+        }
+
+        public void ClearHandlers()
+        {
+            _event = null;
+            _handlers = null;
+        }
+
+        public void Invoke(object sender, T parameter)
+        {
+            var handlers = _handlers;
+            if (handlers is null)
+            {
+                handlers = _event?.GetInvocationList();
+                if (handlers is null)
+                {
+                    return;
+                }
+
+                _handlers = handlers;
+            }
+            foreach (EventHandler<T> action in handlers)
+            {
+                try
+                {
+                    action(sender, parameter);
+                }
+                catch (Exception exception)
+                {
+                    var onException = _onExceptionAction;
+                    if (onException != null)
+                    {
+                        onException(exception, _context!);
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+            }
+        }
+
+        public void Takeover(in EventingWrapper<T> other)
+        {
+            _event = other._event;
+            _handlers = other._handlers;
+            _context = other._context;
+            _onExceptionAction = other._onExceptionAction;
+        }
+    }
+
+    internal struct AsyncEventingWrapper<T>
+    {
+        private event AsyncEventHandler<T>? _event;
+        private Delegate[]? _handlers;
+
+        public bool IsEmpty => _event is null;
+
+        public void AddHandler(AsyncEventHandler<T>? handler)
+        {
+            _event += handler;
+            _handlers = null;
+        }
+
+        public void RemoveHandler(AsyncEventHandler<T>? handler)
+        {
+            _event -= handler;
+            _handlers = null;
+        }
+
+        public async Task InvokeAsync(object sender, T parameter)
+        {
+            var handlers = _handlers;
+            if (handlers is null)
+            {
+                handlers = _event?.GetInvocationList();
+                if (handlers is null)
+                {
+                    return;
+                }
+
+                _handlers = handlers;
+            }
+            foreach (AsyncEventHandler<T> action in handlers)
+            {
+                await action(sender, parameter).ConfigureAwait(false);
+            }
+        }
+
+        public void Takeover(in AsyncEventingWrapper<T> other)
+        {
+            _event = other._event;
+            _handlers = other._handlers;
+        }
+    }
+}

--- a/projects/RabbitMQ.Client/client/impl/RecoveryAwareModel.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecoveryAwareModel.cs
@@ -45,8 +45,10 @@ namespace RabbitMQ.Client.Impl
         public ulong ActiveDeliveryTagOffset { get; private set; }
         public ulong MaxSeenDeliveryTag { get; private set; }
 
-        public void InheritOffsetFrom(RecoveryAwareModel other)
+        internal void TakeOver(RecoveryAwareModel other)
         {
+            base.TakeOver(other);
+
             ActiveDeliveryTagOffset = other.ActiveDeliveryTagOffset + other.MaxSeenDeliveryTag;
             MaxSeenDeliveryTag = 0;
         }

--- a/projects/Unit/TestConnectionRecovery.cs
+++ b/projects/Unit/TestConnectionRecovery.cs
@@ -616,7 +616,7 @@ namespace RabbitMQ.Client.Unit
             CloseAndWaitForRecovery();
             Assert.IsTrue(_conn.IsOpen);
 
-            Assert.IsTrue(counter >= 1);
+            Assert.GreaterOrEqual(counter, 1);
         }
 
         [Test]
@@ -631,7 +631,7 @@ namespace RabbitMQ.Client.Unit
             CloseAndWaitForRecovery();
             Assert.IsTrue(_conn.IsOpen);
 
-            Assert.IsTrue(counter >= 3);
+            Assert.GreaterOrEqual(counter, 3);
         }
 
         [Test]
@@ -646,7 +646,7 @@ namespace RabbitMQ.Client.Unit
             CloseAndWaitForRecovery();
             Assert.IsTrue(_model.IsOpen);
 
-            Assert.IsTrue(counter >= 3);
+            Assert.GreaterOrEqual(counter, 3);
         }
 
         [Test]
@@ -716,7 +716,7 @@ namespace RabbitMQ.Client.Unit
             CloseAndWaitForRecovery();
             Assert.IsTrue(_conn.IsOpen);
 
-            Assert.IsTrue(counter >= 3);
+            Assert.GreaterOrEqual(counter, 3);
         }
 
         [Test]
@@ -736,7 +736,7 @@ namespace RabbitMQ.Client.Unit
             Wait(recoveryLatch, TimeSpan.FromSeconds(30));
             Assert.IsTrue(_conn.IsOpen);
 
-            Assert.IsTrue(counter >= 1);
+            Assert.GreaterOrEqual(counter, 1);
         }
 
         [Test]
@@ -752,7 +752,7 @@ namespace RabbitMQ.Client.Unit
             CloseAndWaitForRecovery();
             Assert.IsTrue(_model.IsOpen);
 
-            Assert.IsTrue(counter >= 3);
+            Assert.GreaterOrEqual(counter, 3);
         }
 
         [Test]


### PR DESCRIPTION
## Proposed Changes

Changes the eventing used in this lib to use the new EventingWrapper. The main benefit is that the delegates are cached after the first invocation.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [x] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Local output of new benchmarks

**Eventing_AddRemove:**
|  Method |        Job |       Runtime | count |      Mean |     Error |    StdDev |    Median | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated | Code Size |
|-------- |----------- |-------------- |------ |----------:|----------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|----------:|
|   Event | Job-TXURZZ |      .NET 4.8 |     1 |  38.31 ns |  0.107 ns |  0.100 ns |  38.31 ns |  1.00 |    0.00 |      - |     - |     - |         - |     258 B |
| Wrapper | Job-TXURZZ |      .NET 4.8 |     1 |  38.82 ns |  0.148 ns |  0.138 ns |  38.76 ns |  1.01 |    0.00 |      - |     - |     - |         - |    1391 B |
|    List | Job-TXURZZ |      .NET 4.8 |     1 |  40.95 ns |  0.191 ns |  0.179 ns |  40.95 ns |  1.07 |    0.01 | 0.0153 |     - |     - |      72 B |     713 B |
|         |            |               |       |           |           |           |           |       |         |        |       |       |           |           |
|   Event | Job-ECJYBK | .NET Core 3.1 |     1 |  28.59 ns |  0.172 ns |  0.160 ns |  28.65 ns |  1.00 |    0.00 |      - |     - |     - |         - |     259 B |
| Wrapper | Job-ECJYBK | .NET Core 3.1 |     1 |  27.60 ns |  0.087 ns |  0.081 ns |  27.56 ns |  0.97 |    0.01 |      - |     - |     - |         - |     394 B |
|    List | Job-ECJYBK | .NET Core 3.1 |     1 |  28.52 ns |  0.581 ns |  0.938 ns |  28.00 ns |  1.02 |    0.04 | 0.0136 |     - |     - |      64 B |     671 B |
|         |            |               |       |           |           |           |           |       |         |        |       |       |           |           |
|   Event | Job-TXURZZ |      .NET 4.8 |     5 | 589.66 ns |  5.712 ns |  5.343 ns | 589.28 ns |  1.00 |    0.00 | 0.1659 |     - |     - |     786 B |     258 B |
| Wrapper | Job-TXURZZ |      .NET 4.8 |     5 | 609.88 ns | 11.078 ns | 10.363 ns | 610.47 ns |  1.03 |    0.02 | 0.1659 |     - |     - |     786 B |    1391 B |
|    List | Job-TXURZZ |      .NET 4.8 |     5 | 261.28 ns |  1.068 ns |  0.999 ns | 261.12 ns |  0.44 |    0.00 | 0.0544 |     - |     - |     257 B |     713 B |
|         |            |               |       |           |           |           |           |       |         |        |       |       |           |           |
|   Event | Job-ECJYBK | .NET Core 3.1 |     5 | 546.30 ns |  2.606 ns |  2.176 ns | 547.02 ns |  1.00 |    0.00 | 0.1659 |     - |     - |     784 B |     259 B |
| Wrapper | Job-ECJYBK | .NET Core 3.1 |     5 | 516.55 ns |  3.137 ns |  2.934 ns | 515.22 ns |  0.95 |    0.01 | 0.1659 |     - |     - |     784 B |    1562 B |
|    List | Job-ECJYBK | .NET Core 3.1 |     5 | 212.80 ns |  0.572 ns |  0.535 ns | 212.80 ns |  0.39 |    0.00 | 0.0527 |     - |     - |     248 B |     669 B |

**Eventing_Invoke:**
|            Method |        Job |       Runtime | Length |      Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated | Code Size |
|------------------ |----------- |-------------- |------- |----------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|----------:|
|      SingleInvoke | Job-UDUQAG |      .NET 4.8 |      1 |  1.011 ns | 0.0028 ns | 0.0022 ns |  1.00 |    0.00 |      - |     - |     - |         - |      57 B |
| GetInvocationList | Job-UDUQAG |      .NET 4.8 |      1 | 14.499 ns | 0.1101 ns | 0.1029 ns | 14.32 |    0.11 | 0.0068 |     - |     - |      32 B |     501 B |
|              List | Job-UDUQAG |      .NET 4.8 |      1 | 13.284 ns | 0.0530 ns | 0.0496 ns | 13.15 |    0.05 |      - |     - |     - |         - |     325 B |
|           Wrapper | Job-UDUQAG |      .NET 4.8 |      1 |  3.716 ns | 0.0078 ns | 0.0065 ns |  3.68 |    0.01 |      - |     - |     - |         - |     322 B |
|                   |            |               |        |           |           |           |       |         |        |       |       |           |           |
|      SingleInvoke | Job-KHEQLR | .NET Core 3.1 |      1 |  1.207 ns | 0.0043 ns | 0.0036 ns |  1.00 |    0.00 |      - |     - |     - |         - |      37 B |
| GetInvocationList | Job-KHEQLR | .NET Core 3.1 |      1 | 15.319 ns | 0.1321 ns | 0.1235 ns | 12.71 |    0.11 | 0.0068 |     - |     - |      32 B |     488 B |
|              List | Job-KHEQLR | .NET Core 3.1 |      1 |  7.838 ns | 0.0236 ns | 0.0221 ns |  6.49 |    0.03 |      - |     - |     - |         - |     310 B |
|           Wrapper | Job-KHEQLR | .NET Core 3.1 |      1 |  3.611 ns | 0.0200 ns | 0.0187 ns |  2.99 |    0.02 |      - |     - |     - |         - |     308 B |
|                   |            |               |        |           |           |           |       |         |        |       |       |           |           |
|      SingleInvoke | Job-UDUQAG |      .NET 4.8 |      5 | 10.845 ns | 0.0726 ns | 0.0643 ns |  1.00 |    0.00 |      - |     - |     - |         - |      57 B |
| GetInvocationList | Job-UDUQAG |      .NET 4.8 |      5 | 64.140 ns | 0.2262 ns | 0.2116 ns |  5.91 |    0.04 | 0.0136 |     - |     - |      64 B |     501 B |
|              List | Job-UDUQAG |      .NET 4.8 |      5 | 32.994 ns | 0.1074 ns | 0.1005 ns |  3.04 |    0.02 |      - |     - |     - |         - |     325 B |
|           Wrapper | Job-UDUQAG |      .NET 4.8 |      5 | 12.765 ns | 0.0529 ns | 0.0495 ns |  1.18 |    0.01 |      - |     - |     - |         - |     322 B |
|                   |            |               |        |           |           |           |       |         |        |       |       |           |           |
|      SingleInvoke | Job-KHEQLR | .NET Core 3.1 |      5 | 15.334 ns | 0.0359 ns | 0.0319 ns |  1.00 |    0.00 |      - |     - |     - |         - |      37 B |
| GetInvocationList | Job-KHEQLR | .NET Core 3.1 |      5 | 66.992 ns | 0.3860 ns | 0.3611 ns |  4.37 |    0.03 | 0.0136 |     - |     - |      64 B |     488 B |
|              List | Job-KHEQLR | .NET Core 3.1 |      5 | 26.444 ns | 0.5399 ns | 0.7390 ns |  1.75 |    0.05 |      - |     - |     - |         - |     310 B |
|           Wrapper | Job-KHEQLR | .NET Core 3.1 |      5 | 11.851 ns | 0.0465 ns | 0.0412 ns |  0.77 |    0.00 |      - |     - |     - |         - |     308 B |