### PR TITLE
7.0 - implement WaitForConfirmsAsync

### DIFF
--- a/projects/RabbitMQ.Client/client/api/IModel.cs
+++ b/projects/RabbitMQ.Client/client/api/IModel.cs
@@ -31,7 +31,8 @@
 
 using System;
 using System.Collections.Generic;
-
+using System.Threading;
+using System.Threading.Tasks;
 using RabbitMQ.Client.Events;
 
 namespace RabbitMQ.Client
@@ -470,68 +471,29 @@ namespace RabbitMQ.Client
         /// </summary>
         void TxSelect();
 
-        /// <summary>Wait until all published messages have been confirmed.
-        /// </summary>
-        /// <remarks>
-        /// Waits until all messages published since the last call have
-        /// been either ack'd or nack'd by the broker.  Returns whether
-        /// all the messages were ack'd (and none were nack'd). Note,
-        /// throws an exception when called on a non-Confirm channel.
-        /// </remarks>
-        bool WaitForConfirms();
-
         /// <summary>
         /// Wait until all published messages have been confirmed.
         /// </summary>
         /// <returns>True if no nacks were received within the timeout, otherwise false.</returns>
-        /// <param name="timeout">How long to wait (at most) before returning
-        ///whether or not any nacks were returned.
-        /// </param>
+        /// <param name="token">The cancellation token.</param>
         /// <remarks>
         /// Waits until all messages published since the last call have
         /// been either ack'd or nack'd by the broker.  Returns whether
         /// all the messages were ack'd (and none were nack'd). Note,
         /// throws an exception when called on a non-Confirm channel.
         /// </remarks>
-        bool WaitForConfirms(TimeSpan timeout);
+        Task<bool> WaitForConfirmsAsync(CancellationToken token = default);
 
         /// <summary>
         /// Wait until all published messages have been confirmed.
         /// </summary>
-        /// <returns>True if no nacks were received within the timeout, otherwise false.</returns>
-        /// <param name="timeout">How long to wait (at most) before returning
-        /// whether or not any nacks were returned.
-        /// </param>
-        /// <param name="timedOut">True if the method returned because
-        /// the timeout elapsed, not because all messages were ack'd or at least one nack'd.
-        /// </param>
-        /// <remarks>
-        /// Waits until all messages published since the last call have
-        /// been either ack'd or nack'd by the broker.  Returns whether
-        /// all the messages were ack'd (and none were nack'd). Note,
-        /// throws an exception when called on a non-Confirm channel.
-        /// </remarks>
-        bool WaitForConfirms(TimeSpan timeout, out bool timedOut);
-
-        /// <summary>
-        /// Wait until all published messages have been confirmed.
-        /// </summary>
-        /// <remarks>
-        /// Waits until all messages published since the last call have
-        /// been ack'd by the broker.  If a nack is received, throws an
-        /// OperationInterrupedException exception immediately.
-        /// </remarks>
-        void WaitForConfirmsOrDie();
-
-        /// <summary>
-        /// Wait until all published messages have been confirmed.
-        /// </summary>
+        /// <param name="token">The cancellation token.</param>
         /// <remarks>
         /// Waits until all messages published since the last call have
         /// been ack'd by the broker.  If a nack is received or the timeout
         /// elapses, throws an OperationInterrupedException exception immediately.
         /// </remarks>
-        void WaitForConfirmsOrDie(TimeSpan timeout);
+        Task WaitForConfirmsOrDieAsync(CancellationToken token = default);
 
         /// <summary>
         /// Amount of time protocol  operations (e.g. <code>queue.declare</code>) are allowed to take before

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
@@ -32,8 +32,8 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Xml.Schema;
-
+using System.Threading;
+using System.Threading.Tasks;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Framing.Impl;
 
@@ -1023,15 +1023,9 @@ namespace RabbitMQ.Client.Impl
             _usesTransactions = true;
         }
 
-        public bool WaitForConfirms(TimeSpan timeout, out bool timedOut) => Delegate.WaitForConfirms(timeout, out timedOut);
+        public Task<bool> WaitForConfirmsAsync(CancellationToken token = default) => Delegate.WaitForConfirmsAsync(token);
 
-        public bool WaitForConfirms(TimeSpan timeout) => Delegate.WaitForConfirms(timeout);
-
-        public bool WaitForConfirms() => Delegate.WaitForConfirms();
-
-        public void WaitForConfirmsOrDie() => Delegate.WaitForConfirmsOrDie();
-
-        public void WaitForConfirmsOrDie(TimeSpan timeout) => Delegate.WaitForConfirmsOrDie(timeout);
+        public Task WaitForConfirmsOrDieAsync(CancellationToken token = default) => Delegate.WaitForConfirmsOrDieAsync(token);
 
         private void RecoverBasicAckHandlers()
         {

--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -105,7 +105,7 @@ namespace RabbitMQ.Client.Framing.Impl
             _connectionBlockedWrapper = new EventingWrapper<ConnectionBlockedEventArgs>("OnConnectionBlocked", onException);
             _connectionUnblockedWrapper = new EventingWrapper<EventArgs>("OnConnectionUnblocked", onException);
 
-                _sessionManager = new SessionManager(this, 0);
+            _sessionManager = new SessionManager(this, 0);
             _session0 = new MainSession(this) { Handler = NotifyReceivedCloseOk };
             _model0 = (ModelBase)Protocol.CreateModel(_session0);
 
@@ -426,15 +426,6 @@ namespace RabbitMQ.Client.Framing.Impl
             _model0.FinishClose();
         }
 
-        /// <remarks>
-        /// We need to close the socket, otherwise attempting to unload the domain
-        /// could cause a CannotUnloadAppDomainException
-        /// </remarks>
-        public void HandleDomainUnload(object sender, EventArgs ea)
-        {
-            Abort(Constants.InternalError, "Domain Unload");
-        }
-
         public void HandleMainLoopException(ShutdownEventArgs reason)
         {
             if (!SetCloseReason(reason))
@@ -750,7 +741,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public void StartMainLoop()
         {
-            _mainLoopTask = Task.Run((Action)MainLoop);
+            _mainLoopTask = Task.Factory.StartNew(MainLoop, TaskCreationOptions.LongRunning);
         }
 
         public void HeartbeatReadTimerCallback(object state)

--- a/projects/Unit/Fixtures.cs
+++ b/projects/Unit/Fixtures.cs
@@ -221,7 +221,8 @@ namespace RabbitMQ.Client.Unit
 
         internal bool WaitForConfirms(IModel m)
         {
-            return m.WaitForConfirms(TimeSpan.FromSeconds(4));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(4));
+            return m.WaitForConfirmsAsync(cts.Token).GetAwaiter().GetResult();
         }
 
         //

--- a/projects/Unit/TestBasicPublishBatch.cs
+++ b/projects/Unit/TestBasicPublishBatch.cs
@@ -30,7 +30,8 @@
 //---------------------------------------------------------------------------
 
 using System;
-
+using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace RabbitMQ.Client.Unit
@@ -38,7 +39,7 @@ namespace RabbitMQ.Client.Unit
     internal class TestBasicPublishBatch : IntegrationFixture
     {
         [Test]
-        public void TestBasicPublishBatchSend()
+        public async Task TestBasicPublishBatchSend()
         {
             _model.ConfirmSelect();
             _model.QueueDeclare(queue: "test-message-batch-a", durable: false);
@@ -47,7 +48,8 @@ namespace RabbitMQ.Client.Unit
             batch.Add("", "test-message-batch-a", false, null, new ReadOnlyMemory<byte>());
             batch.Add("", "test-message-batch-b", false, null, new ReadOnlyMemory<byte>());
             batch.Publish();
-            _model.WaitForConfirmsOrDie(TimeSpan.FromSeconds(15));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            await _model.WaitForConfirmsOrDieAsync(cts.Token).ConfigureAwait(false);
             BasicGetResult resultA = _model.BasicGet("test-message-batch-a", true);
             Assert.NotNull(resultA);
             BasicGetResult resultB = _model.BasicGet("test-message-batch-b", true);
@@ -55,7 +57,7 @@ namespace RabbitMQ.Client.Unit
         }
 
         [Test]
-        public void TestBasicPublishBatchSendWithSizeHint()
+        public async Task TestBasicPublishBatchSendWithSizeHint()
         {
             _model.ConfirmSelect();
             _model.QueueDeclare(queue: "test-message-batch-a", durable: false);
@@ -65,7 +67,8 @@ namespace RabbitMQ.Client.Unit
             batch.Add("", "test-message-batch-a", false, null, bodyAsMemory);
             batch.Add("", "test-message-batch-b", false, null, bodyAsMemory);
             batch.Publish();
-            _model.WaitForConfirmsOrDie(TimeSpan.FromSeconds(15));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            await _model.WaitForConfirmsOrDieAsync(cts.Token).ConfigureAwait(false);
             BasicGetResult resultA = _model.BasicGet("test-message-batch-a", true);
             Assert.NotNull(resultA);
             BasicGetResult resultB = _model.BasicGet("test-message-batch-b", true);
@@ -73,7 +76,7 @@ namespace RabbitMQ.Client.Unit
         }
 
         [Test]
-        public void TestBasicPublishBatchSendWithWrongSizeHint()
+        public async Task TestBasicPublishBatchSendWithWrongSizeHint()
         {
             _model.ConfirmSelect();
             _model.QueueDeclare(queue: "test-message-batch-a", durable: false);
@@ -83,7 +86,8 @@ namespace RabbitMQ.Client.Unit
             batch.Add("", "test-message-batch-a", false, null, bodyAsMemory);
             batch.Add("", "test-message-batch-b", false, null, bodyAsMemory);
             batch.Publish();
-            _model.WaitForConfirmsOrDie(TimeSpan.FromSeconds(15));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            await _model.WaitForConfirmsOrDieAsync(cts.Token).ConfigureAwait(false);
             BasicGetResult resultA = _model.BasicGet("test-message-batch-a", true);
             Assert.NotNull(resultA);
             BasicGetResult resultB = _model.BasicGet("test-message-batch-b", true);

--- a/projects/Unit/TestExtensions.cs
+++ b/projects/Unit/TestExtensions.cs
@@ -30,7 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
-
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace RabbitMQ.Client.Unit
@@ -39,24 +39,24 @@ namespace RabbitMQ.Client.Unit
     public class TestExtensions : IntegrationFixture
     {
         [Test]
-        public void TestConfirmBarrier()
+        public async Task TestConfirmBarrier()
         {
             _model.ConfirmSelect();
             for (int i = 0; i < 10; i++)
             {
                 _model.BasicPublish("", string.Empty, null, new byte[] {});
             }
-            Assert.That(_model.WaitForConfirms(), Is.True);
+            Assert.True(await _model.WaitForConfirmsAsync().ConfigureAwait(false));
         }
 
         [Test]
         public void TestConfirmBeforeWait()
         {
-            Assert.Throws(typeof (InvalidOperationException), () => _model.WaitForConfirms());
+            Assert.Throws(typeof (InvalidOperationException), () => _model.WaitForConfirmsAsync());
         }
 
         [Test]
-        public void TestExchangeBinding()
+        public async Task TestExchangeBinding()
         {
             _model.ConfirmSelect();
 
@@ -69,12 +69,12 @@ namespace RabbitMQ.Client.Unit
             _model.QueueBind(queue, "dest", string.Empty);
 
             _model.BasicPublish("src", string.Empty, null, new byte[] {});
-            _model.WaitForConfirms();
+            await _model.WaitForConfirmsAsync().ConfigureAwait(false);
             Assert.IsNotNull(_model.BasicGet(queue, true));
 
             _model.ExchangeUnbind("dest", "src", string.Empty);
             _model.BasicPublish("src", string.Empty, null, new byte[] {});
-            _model.WaitForConfirms();
+            await _model.WaitForConfirmsAsync().ConfigureAwait(false);
             Assert.IsNull(_model.BasicGet(queue, true));
 
             _model.ExchangeDelete("src");

--- a/projects/Unit/TestMessageCount.cs
+++ b/projects/Unit/TestMessageCount.cs
@@ -29,8 +29,7 @@
 //  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
-using System;
-
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace RabbitMQ.Client.Unit
@@ -38,7 +37,7 @@ namespace RabbitMQ.Client.Unit
     internal class TestMessageCount : IntegrationFixture
     {
         [Test]
-        public void TestMessageCountMethod()
+        public async Task TestMessageCountMethod()
         {
             _model.ConfirmSelect();
             string q = GenerateQueueName();
@@ -46,7 +45,7 @@ namespace RabbitMQ.Client.Unit
             Assert.AreEqual(0, _model.MessageCount(q));
 
             _model.BasicPublish(exchange: "", routingKey: q, basicProperties: null, body: _encoding.GetBytes("msg"));
-            _model.WaitForConfirms(TimeSpan.FromSeconds(2));
+            await _model.WaitForConfirmsAsync().ConfigureAwait(false);
             Assert.AreEqual(1, _model.MessageCount(q));
         }
     }


### PR DESCRIPTION
## Proposed Changes

implements a async WaitForConfirms => does not block a thread anymore while waiting.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #959 )
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

This change partially fixes #959. Partially due to it only fixes the wait part and not the channel open part.
(Meaning as long as not all thread pool threads are blocked in opening channels, the publish works as expected. This can be achieved by either precreating channels or pooling the channels or making sure not all threads are started at the same time, so all create a channel at the same time (I'd argue this is already given by real world scenarios))