### PR TITLE
add two test applications

### DIFF
--- a/RabbitMQDotNetClient.sln
+++ b/RabbitMQDotNetClient.sln
@@ -12,7 +12,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RabbitMQ.Client", "projects
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Unit", "projects\Unit\Unit.csproj", "{B8FAC024-CC03-4067-9FFC-02846FB8AE48}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmarks", "projects\Benchmarks\Benchmarks.csproj", "{38D72C9A-68E9-4653-B0CE-C7BA9FFD91D0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmarks", "projects\Benchmarks\Benchmarks.csproj", "{38D72C9A-68E9-4653-B0CE-C7BA9FFD91D0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MassPublish", "projects\TestApplications\MassPublish\MassPublish.csproj", "{0E3C4FBE-9976-40A3-9F57-DC0D9B7A39A6}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TestApplications", "TestApplications", "{D21B282C-49E6-4A30-887B-9626D94B8D69}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CreateChannel", "projects\TestApplications\CreateChannel\CreateChannel.csproj", "{4A589408-F3A3-40E1-A6DF-F5E620F7CA31}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -32,9 +38,21 @@ Global
 		{38D72C9A-68E9-4653-B0CE-C7BA9FFD91D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{38D72C9A-68E9-4653-B0CE-C7BA9FFD91D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{38D72C9A-68E9-4653-B0CE-C7BA9FFD91D0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0E3C4FBE-9976-40A3-9F57-DC0D9B7A39A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0E3C4FBE-9976-40A3-9F57-DC0D9B7A39A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0E3C4FBE-9976-40A3-9F57-DC0D9B7A39A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0E3C4FBE-9976-40A3-9F57-DC0D9B7A39A6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4A589408-F3A3-40E1-A6DF-F5E620F7CA31}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4A589408-F3A3-40E1-A6DF-F5E620F7CA31}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4A589408-F3A3-40E1-A6DF-F5E620F7CA31}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4A589408-F3A3-40E1-A6DF-F5E620F7CA31}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{0E3C4FBE-9976-40A3-9F57-DC0D9B7A39A6} = {D21B282C-49E6-4A30-887B-9626D94B8D69}
+		{4A589408-F3A3-40E1-A6DF-F5E620F7CA31} = {D21B282C-49E6-4A30-887B-9626D94B8D69}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3C6A0C44-FA63-4101-BBF9-2598641167D1}

--- a/projects/TestApplications/CreateChannel/CreateChannel.csproj
+++ b/projects/TestApplications/CreateChannel/CreateChannel.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\RabbitMQ.Client\RabbitMQ.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/projects/TestApplications/CreateChannel/Program.cs
+++ b/projects/TestApplications/CreateChannel/Program.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+
+namespace CreateChannel
+{
+    public static class Program
+    {
+        private const int Repeats = 100;
+        private const int ChannelsToOpen = 50;
+
+        private static int channelsOpened;
+        private static AutoResetEvent doneEvent;
+
+        public static void Main()
+        {
+            ThreadPool.SetMinThreads(16 * Environment.ProcessorCount, 16 * Environment.ProcessorCount);
+
+            doneEvent = new AutoResetEvent(false);
+
+            var connectionFactory = new ConnectionFactory { DispatchConsumersAsync = true };
+            var connection = connectionFactory.CreateConnection();
+
+            var watch = Stopwatch.StartNew();
+            _ = Task.Run(() =>
+            {
+                var channels = new IModel[ChannelsToOpen];
+                for (int i = 0; i < Repeats; i++)
+                {
+                    for (int j = 0; j < channels.Length; j++)
+                    {
+                        channels[j] = connection.CreateModel();
+                        channelsOpened++;
+                    }
+
+                    for (int j = 0; j < channels.Length; j++)
+                    {
+                        channels[j].Dispose();
+                    }
+                }
+
+                doneEvent.Set();
+            });
+
+            Console.WriteLine($"{Repeats} times opening {ChannelsToOpen} channels on a connection. => Total channel open/close: {Repeats * ChannelsToOpen}");
+            Console.WriteLine();
+            Console.WriteLine("Opened");
+            while (!doneEvent.WaitOne(500))
+            {
+                Console.WriteLine($"{channelsOpened,5}");
+            }
+            watch.Stop();
+            Console.WriteLine($"{channelsOpened,5}");
+            Console.WriteLine();
+            Console.WriteLine($"Took {watch.Elapsed.TotalMilliseconds} ms");
+
+            connection.Dispose();
+            Console.ReadLine();
+        }
+    }
+}

--- a/projects/TestApplications/MassPublish/MassPublish.csproj
+++ b/projects/TestApplications/MassPublish/MassPublish.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\RabbitMQ.Client\RabbitMQ.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/projects/TestApplications/MassPublish/Program.cs
+++ b/projects/TestApplications/MassPublish/Program.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+
+namespace MassPublish
+{
+    public static class Program
+    {
+        private const int BatchesToSend = 100;
+        private const int ItemsPerBatch = 500;
+
+        private static int messagesSent;
+        private static int messagesReceived;
+        private static AutoResetEvent doneEvent;
+
+        public static void Main()
+        {
+            ThreadPool.SetMinThreads(16 * Environment.ProcessorCount, 16 * Environment.ProcessorCount);
+
+            doneEvent = new AutoResetEvent(false);
+
+            var connectionFactory = new ConnectionFactory { DispatchConsumersAsync = true };
+            var connection = connectionFactory.CreateConnection();
+            var publisher = connection.CreateModel();
+            var subscriber = connection.CreateModel();
+
+            publisher.ConfirmSelect();
+            publisher.ExchangeDeclare("test", ExchangeType.Topic, true, false);
+
+            subscriber.QueueDeclare("testqueue", false, false, true);
+            var asyncListener = new AsyncEventingBasicConsumer(subscriber);
+            asyncListener.Received += AsyncListener_Received;
+            subscriber.QueueBind("testqueue", "test", "myawesome.routing.key");
+            subscriber.BasicConsume("testqueue", true, "testconsumer", asyncListener);
+
+            byte[] payload = new byte[512];
+            var watch = Stopwatch.StartNew();
+            _ = Task.Run(async () =>
+            {
+                while (messagesSent < BatchesToSend * ItemsPerBatch)
+                {
+                    var batch = publisher.CreateBasicPublishBatch();
+                    for (int i = 0; i < ItemsPerBatch; i++)
+                    {
+                        var properties = publisher.CreateBasicProperties();
+                        properties.AppId = "testapp";
+                        properties.CorrelationId = Guid.NewGuid().ToString();
+                        batch.Add("test", "myawesome.routing.key", false, properties, payload);
+                    }
+                    batch.Publish();
+                    messagesSent += ItemsPerBatch;
+                    await publisher.WaitForConfirmsOrDieAsync().ConfigureAwait(false);
+                }
+            });
+
+            Console.WriteLine($"Sending {BatchesToSend} batches for {ItemsPerBatch} items per batch. => Total messages: {BatchesToSend * ItemsPerBatch}");
+            Console.WriteLine();
+            Console.WriteLine(" Sent | Received");
+            while (!doneEvent.WaitOne(500))
+            {
+                Console.WriteLine($"{messagesSent,5} | {messagesReceived,5}");
+            }
+            watch.Stop();
+            Console.WriteLine($"{messagesSent,5} | {messagesReceived,5}");
+            Console.WriteLine();
+            Console.WriteLine($"Took {watch.Elapsed.TotalMilliseconds} ms");
+
+            publisher.Dispose();
+            subscriber.Dispose();
+            connection.Dispose();
+            Console.ReadLine();
+        }
+
+        private static Task AsyncListener_Received(object sender, BasicDeliverEventArgs @event)
+        {
+            if (Interlocked.Increment(ref messagesReceived) == BatchesToSend * ItemsPerBatch)
+            {
+                doneEvent.Set();
+            }
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes

adds two test applications to execute when you want to profile (performance or memory) some changes.
I think it would be good to have them in git so everyone has access and we're talking about the same thing.

Apps added:
- Message batch publish / receive (originated from @stebet)
- Open / Close Channels

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
