### PR TITLE
Simplify recordings in AutorecoveringConnection

### DIFF
--- a/projects/RabbitMQ.Client/FrameworkExtension/DictionaryExtension.cs
+++ b/projects/RabbitMQ.Client/FrameworkExtension/DictionaryExtension.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace RabbitMQ
+{
+#nullable enable
+#if NETSTANDARD
+    internal static class DictionaryExtension
+    {
+        public static bool Remove<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, out TValue value)
+        {
+            return dictionary.TryGetValue(key, out value) && dictionary.Remove(key);
+        }
+    }
+#endif
+}

--- a/projects/RabbitMQ.Client/client/api/Protocols.cs
+++ b/projects/RabbitMQ.Client/client/api/Protocols.cs
@@ -39,17 +39,11 @@ namespace RabbitMQ.Client
         ///<summary>
         /// Protocol version 0-9-1 as modified by Pivotal.
         ///</summary>
-        public static IProtocol AMQP_0_9_1
-        {
-            get { return (IProtocol)new RabbitMQ.Client.Framing.Protocol(); }
-        }
+        public static IProtocol AMQP_0_9_1 { get; } = new Framing.Protocol();
 
         ///<summary>
         /// Retrieve the current default protocol variant (currently AMQP_0_9_1).
         ///</summary>
-        public static IProtocol DefaultProtocol
-        {
-            get { return AMQP_0_9_1; }
-        }
+        public static IProtocol DefaultProtocol => AMQP_0_9_1;
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recording.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recording.cs
@@ -1,0 +1,248 @@
+// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2020 VMware, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       https://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v2.0:
+//
+//---------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
+//---------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using RabbitMQ.Client.Impl;
+
+namespace RabbitMQ.Client.Framing.Impl
+{
+#nullable enable
+    internal sealed partial class AutorecoveringConnection
+    {
+        private readonly object _recordedEntitiesLock = new object();
+        private readonly Dictionary<string, RecordedExchange> _recordedExchanges = new Dictionary<string, RecordedExchange>();
+        private readonly Dictionary<string, RecordedQueue> _recordedQueues = new Dictionary<string, RecordedQueue>();
+        private readonly HashSet<RecordedBinding> _recordedBindings = new HashSet<RecordedBinding>();
+        private readonly Dictionary<string, RecordedConsumer> _recordedConsumers = new Dictionary<string, RecordedConsumer>();
+        private readonly List<AutorecoveringModel> _models = new List<AutorecoveringModel>();
+
+        internal int RecordedExchangesCount => _recordedExchanges.Count;
+
+        internal void RecordExchange(RecordedExchange exchange)
+        {
+            lock (_recordedEntitiesLock)
+            {
+                _recordedExchanges[exchange.Name] = exchange;
+            }
+        }
+
+        internal void DeleteRecordedExchange(string exchangeName)
+        {
+            lock (_recordedEntitiesLock)
+            {
+                _recordedExchanges.Remove(exchangeName);
+
+                // find bindings that need removal, check if some auto-delete exchanges might need the same
+                foreach (RecordedBinding binding in _recordedBindings.ToArray())
+                {
+                    if (binding.Destination == exchangeName)
+                    {
+                        DeleteRecordedBinding(binding);
+                        DeleteAutoDeleteExchange(binding.Source);
+                    }
+                }
+            }
+        }
+
+        public void DeleteAutoDeleteExchange(string exchangeName)
+        {
+            lock (_recordedEntitiesLock)
+            {
+                if (_recordedExchanges.TryGetValue(exchangeName, out var recordedExchange) && recordedExchange.IsAutoDelete)
+                {
+                    if (!AnyBindingsOnExchange(exchangeName))
+                    {
+                        // last binding where this exchange is the source is gone, remove recorded exchange if it is auto-deleted.
+                        _recordedExchanges.Remove(exchangeName);
+                    }
+                }
+            }
+
+            bool AnyBindingsOnExchange(string exchange)
+            {
+                foreach (var recordedBinding in _recordedBindings)
+                {
+                    if (recordedBinding.Source == exchange)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        internal int RecordedQueuesCount => _recordedQueues.Count;
+
+        internal void RecordQueue(RecordedQueue q)
+        {
+            lock (_recordedEntitiesLock)
+            {
+                _recordedQueues[q.Name] = q;
+            }
+        }
+
+        internal void DeleteRecordedQueue(string queueName)
+        {
+            lock (_recordedEntitiesLock)
+            {
+                _recordedQueues.Remove(queueName);
+                // find bindings that need removal, check if some auto-delete exchanges might need the same
+
+                foreach (RecordedBinding binding in _recordedBindings.ToArray())
+                {
+                    if (binding.Destination == queueName)
+                    {
+                        DeleteRecordedBinding(binding);
+                        DeleteAutoDeleteExchange(binding.Source);
+                    }
+                }
+            }
+        }
+
+        private void UpdateBindingsDestination(string oldName, string newName)
+        {
+            lock (_recordedEntitiesLock)
+            {
+                foreach (RecordedBinding b in _recordedBindings.ToArray())
+                {
+                    if (b.Destination == oldName)
+                    {
+                        _recordedBindings.Remove(b);
+                        b.Destination = newName;
+                        _recordedBindings.Add(b);
+                    }
+                }
+            }
+        }
+
+        private void UpdateConsumerQueue(string oldName, string newName)
+        {
+            lock (_recordedEntitiesLock)
+            {
+                foreach (KeyValuePair<string, RecordedConsumer> c in _recordedConsumers)
+                {
+                    if (c.Value.Queue == oldName)
+                    {
+                        c.Value.Queue = newName;
+                    }
+                }
+            }
+        }
+
+        internal void RecordBinding(RecordedBinding rb)
+        {
+            lock (_recordedEntitiesLock)
+            {
+                _recordedBindings.Add(rb);
+            }
+        }
+
+        internal void DeleteRecordedBinding(RecordedBinding rb)
+        {
+            lock (_recordedEntitiesLock)
+            {
+                _recordedBindings.Remove(rb);
+            }
+        }
+
+        internal void RecordConsumer(string consumerTag, RecordedConsumer consumer)
+        {
+            lock (_recordedEntitiesLock)
+            {
+                _recordedConsumers[consumerTag] = consumer;
+            }
+        }
+
+        internal void DeleteRecordedConsumer(string consumerTag)
+        {
+            lock (_recordedEntitiesLock)
+            {
+                if (_recordedConsumers.Remove(consumerTag, out var recordedConsumer))
+                {
+                    DeleteAutoDeleteQueue(recordedConsumer.Queue);
+                }
+            }
+
+            void DeleteAutoDeleteQueue(string queue)
+            {
+                if (_recordedQueues.TryGetValue(queue, out var recordedQueue) && recordedQueue.IsAutoDelete)
+                {
+                    // last consumer on this connection is gone, remove recorded queue if it is auto-deleted.
+                    if (!AnyConsumersOnQueue(queue))
+                    {
+                        _recordedQueues.Remove(queue);
+                    }
+                }
+            }
+
+            bool AnyConsumersOnQueue(string queue)
+            {
+                foreach (var pair in _recordedConsumers)
+                {
+                    if (pair.Value.Queue == queue)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        private void UpdateConsumer(string oldTag, string newTag, RecordedConsumer consumer)
+        {
+            lock (_recordedEntitiesLock)
+            {
+                // make sure server-generated tags are re-added
+                _recordedConsumers.Remove(oldTag);
+                _recordedConsumers.Add(newTag, consumer);
+            }
+        }
+
+        private void RecordChannel(AutorecoveringModel m)
+        {
+            lock (_models)
+            {
+                _models.Add(m);
+            }
+        }
+
+        internal void DeleteRecordedChannel(AutorecoveringModel model)
+        {
+            lock (_models)
+            {
+                _models.Remove(model);
+            }
+        }
+    }
+}

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recovery.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recovery.cs
@@ -281,7 +281,8 @@ namespace RabbitMQ.Client.Framing.Impl
 
                 try
                 {
-                    string newTag = cons.Recover();
+                    cons.Recover();
+                    string newTag = cons.ConsumerTag;
                     UpdateConsumer(oldTag, newTag, cons);
 
                     if (!_consumerTagChangeAfterRecoveryWrapper.IsEmpty)

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.cs
@@ -31,35 +31,24 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 
 using RabbitMQ.Client.Events;
-using RabbitMQ.Client.Exceptions;
 using RabbitMQ.Client.Impl;
-using RabbitMQ.Client.Logging;
 
 namespace RabbitMQ.Client.Framing.Impl
 {
     internal sealed partial class AutorecoveringConnection : IConnection
     {
+        private readonly ConnectionFactory _factory;
+
         private bool _disposed;
         private Connection _delegate;
-        private readonly ConnectionFactory _factory;
 
         // list of endpoints provided on initial connection.
         // on re-connection, the next host in the line is chosen using
         // IHostnameSelector
         private IEndpointResolver _endpoints;
-
-        private readonly object _recordedEntitiesLock = new object();
-
-        private readonly Dictionary<string, RecordedExchange> _recordedExchanges = new Dictionary<string, RecordedExchange>();
-        private readonly Dictionary<string, RecordedQueue> _recordedQueues = new Dictionary<string, RecordedQueue>();
-        private readonly Dictionary<RecordedBinding, byte> _recordedBindings = new Dictionary<RecordedBinding, byte>();
-        private readonly Dictionary<string, RecordedConsumer> _recordedConsumers = new Dictionary<string, RecordedConsumer>();
-
-        private readonly List<AutorecoveringModel> _models = new List<AutorecoveringModel>();
 
         public AutorecoveringConnection(ConnectionFactory factory, string clientProvidedName = null)
         {
@@ -161,38 +150,6 @@ namespace RabbitMQ.Client.Framing.Impl
 
         IProtocol IConnection.Protocol => Endpoint.Protocol;
 
-        private bool TryPerformAutomaticRecovery()
-        {
-            ESLog.Info("Performing automatic recovery");
-
-            try
-            {
-                if (TryRecoverConnectionDelegate())
-                {
-                    RecoverModels();
-                    if (_factory.TopologyRecoveryEnabled)
-                    {
-                        RecoverEntities();
-                        RecoverConsumers();
-                    }
-
-                    ESLog.Info("Connection recovery completed");
-                    ThrowIfDisposed();
-                    _recoverySucceededWrapper.Invoke(this, EventArgs.Empty);
-
-                    return true;
-                }
-
-                ESLog.Warn("Connection delegate was manually closed. Aborted recovery.");
-            }
-            catch (Exception e)
-            {
-                ESLog.Error("Exception when recovering connection. Will try again after retry interval.", e);
-            }
-
-            return false;
-        }
-
         public void Close(ShutdownEventArgs reason) => Delegate.Close(reason);
 
         public RecoveryAwareModel CreateNonRecoveringModel()
@@ -203,168 +160,15 @@ namespace RabbitMQ.Client.Framing.Impl
             return result;
         }
 
-        public void DeleteRecordedBinding(RecordedBinding rb)
-        {
-            lock (_recordedEntitiesLock)
-            {
-                _recordedBindings.Remove(rb);
-            }
-        }
-
-        public RecordedConsumer DeleteRecordedConsumer(string consumerTag)
-        {
-            RecordedConsumer rc;
-            lock (_recordedEntitiesLock)
-            {
-                if (_recordedConsumers.TryGetValue(consumerTag, out rc))
-                {
-                    _recordedConsumers.Remove(consumerTag);
-                }
-            }
-
-            return rc;
-        }
-
-        public void DeleteRecordedExchange(string name)
-        {
-            lock (_recordedEntitiesLock)
-            {
-                _recordedExchanges.Remove(name);
-
-                // find bindings that need removal, check if some auto-delete exchanges
-                // might need the same
-                IEnumerable<RecordedBinding> bs = _recordedBindings.Keys.Where(b => name.Equals(b.Destination)).ToArray();
-                foreach (RecordedBinding b in bs)
-                {
-                    DeleteRecordedBinding(b);
-                    MaybeDeleteRecordedAutoDeleteExchange(b.Source);
-                }
-            }
-        }
-
-        public void DeleteRecordedQueue(string name)
-        {
-            lock (_recordedEntitiesLock)
-            {
-                _recordedQueues.Remove(name);
-                // find bindings that need removal, check if some auto-delete exchanges
-                // might need the same
-                IEnumerable<RecordedBinding> bs = _recordedBindings.Keys.Where(b => name.Equals(b.Destination)).ToArray();
-                foreach (RecordedBinding b in bs)
-                {
-                    DeleteRecordedBinding(b);
-                    MaybeDeleteRecordedAutoDeleteExchange(b.Source);
-                }
-            }
-        }
-
-        public bool HasMoreConsumersOnQueue(ICollection<RecordedConsumer> consumers, string queue)
-        {
-            var cs = new List<RecordedConsumer>(consumers);
-            return cs.Exists(c => c.Queue.Equals(queue));
-        }
-
-        public bool HasMoreDestinationsBoundToExchange(ICollection<RecordedBinding> bindings, string exchange)
-        {
-            var bs = new List<RecordedBinding>(bindings);
-            return bs.Exists(b => b.Source.Equals(exchange));
-        }
-
-        public void MaybeDeleteRecordedAutoDeleteExchange(string exchange)
-        {
-            lock (_recordedEntitiesLock)
-            {
-                if (!HasMoreDestinationsBoundToExchange(_recordedBindings.Keys, exchange))
-                {
-                    _recordedExchanges.TryGetValue(exchange, out RecordedExchange rx);
-                    // last binding where this exchange is the source is gone,
-                    // remove recorded exchange
-                    // if it is auto-deleted. See bug 26364.
-                    if ((rx != null) && rx.IsAutoDelete)
-                    {
-                        _recordedExchanges.Remove(exchange);
-                    }
-                }
-            }
-        }
-
-        public void MaybeDeleteRecordedAutoDeleteQueue(string queue)
-        {
-            lock (_recordedEntitiesLock)
-            {
-                if (!HasMoreConsumersOnQueue(_recordedConsumers.Values, queue))
-                {
-                    _recordedQueues.TryGetValue(queue, out RecordedQueue rq);
-                    // last consumer on this connection is gone, remove recorded queue
-                    // if it is auto-deleted. See bug 26364.
-                    if ((rq != null) && rq.IsAutoDelete)
-                    {
-                        _recordedQueues.Remove(queue);
-                    }
-                }
-            }
-        }
-
-        public void RecordBinding(RecordedBinding rb)
-        {
-            lock (_recordedEntitiesLock)
-            {
-                if (!_recordedBindings.ContainsKey(rb))
-                {
-                    _recordedBindings.Add(rb, 0);
-                }
-            }
-        }
-
-        public void RecordConsumer(string name, RecordedConsumer c)
-        {
-            lock (_recordedEntitiesLock)
-            {
-                if (!_recordedConsumers.ContainsKey(name))
-                {
-                    _recordedConsumers.Add(name, c);
-                }
-            }
-        }
-
-        public void RecordExchange(string name, RecordedExchange x)
-        {
-            lock (_recordedEntitiesLock)
-            {
-                _recordedExchanges[name] = x;
-            }
-        }
-
-        public void RecordQueue(string name, RecordedQueue q)
-        {
-            lock (_recordedEntitiesLock)
-            {
-                _recordedQueues[name] = q;
-            }
-        }
-
         public override string ToString() => $"AutorecoveringConnection({Delegate.Id},{Endpoint},{GetHashCode()})";
-
-        public void UnregisterModel(AutorecoveringModel model)
-        {
-            lock (_models)
-            {
-                _models.Remove(model);
-            }
-        }
 
         public void Init() => Init(_factory.EndpointResolverFactory(new List<AmqpTcpEndpoint> { _factory.Endpoint }));
 
         public void Init(IEndpointResolver endpoints)
         {
+            ThrowIfDisposed();
             _endpoints = endpoints;
             IFrameHandler fh = endpoints.SelectOne(_factory.CreateFrameHandler);
-            Init(fh);
-        }
-
-        private void Init(IFrameHandler fh)
-        {
-            ThrowIfDisposed();
             _delegate = new Connection(_factory, false, fh, ClientProvidedName);
             ConnectionShutdown += HandleConnectionShutdown;
         }
@@ -470,10 +274,7 @@ namespace RabbitMQ.Client.Framing.Impl
         {
             EnsureIsOpen();
             AutorecoveringModel m = new AutorecoveringModel(this, CreateNonRecoveringModel());
-            lock (_models)
-            {
-                _models.Add(m);
-            }
+            RecordChannel(m);
             return m;
         }
 
@@ -482,28 +283,6 @@ namespace RabbitMQ.Client.Framing.Impl
         public void HandleConnectionBlocked(string reason) => Delegate.HandleConnectionBlocked(reason);
 
         public void HandleConnectionUnblocked() => Delegate.HandleConnectionUnblocked();
-
-        internal int RecordedExchangesCount
-        {
-            get
-            {
-                lock (_recordedEntitiesLock)
-                {
-                    return _recordedExchanges.Count;
-                }
-            }
-        }
-
-        internal int RecordedQueuesCount
-        {
-            get
-            {
-                lock (_recordedEntitiesLock)
-                {
-                    return _recordedExchanges.Count;
-                }
-            }
-        }
 
         private void Dispose(bool disposing)
         {
@@ -532,217 +311,6 @@ namespace RabbitMQ.Client.Framing.Impl
         }
 
         private void EnsureIsOpen() => Delegate.EnsureIsOpen();
-
-        private void HandleTopologyRecoveryException(TopologyRecoveryException e) => ESLog.Error("Topology recovery exception", e);
-
-        private void PropagateQueueNameChangeToBindings(string oldName, string newName)
-        {
-            lock (_recordedBindings)
-            {
-                foreach (RecordedBinding b in _recordedBindings.Keys)
-                {
-                    if (b.Destination.Equals(oldName))
-                    {
-                        b.Destination = newName;
-                    }
-                }
-            }
-        }
-
-        private void PropagateQueueNameChangeToConsumers(string oldName, string newName)
-        {
-            lock (_recordedConsumers)
-            {
-                foreach (KeyValuePair<string, RecordedConsumer> c in _recordedConsumers)
-                {
-                    if (c.Value.Queue.Equals(oldName))
-                    {
-                        c.Value.Queue = newName;
-                    }
-                }
-            }
-        }
-
-        private void RecoverBindings()
-        {
-            Dictionary<RecordedBinding, byte> recordedBindingsCopy;
-            lock (_recordedBindings)
-            {
-                recordedBindingsCopy = new Dictionary<RecordedBinding, byte>(_recordedBindings);
-            }
-
-            foreach (RecordedBinding b in recordedBindingsCopy.Keys)
-            {
-                try
-                {
-                    b.Recover();
-                }
-                catch (Exception cause)
-                {
-                    string s = string.Format("Caught an exception while recovering binding between {0} and {1}: {2}",
-                        b.Source, b.Destination, cause.Message);
-                    HandleTopologyRecoveryException(new TopologyRecoveryException(s, cause));
-                }
-            }
-        }
-
-        private bool TryRecoverConnectionDelegate()
-        {
-            ThrowIfDisposed();
-            try
-            {
-                IFrameHandler fh = _endpoints.SelectOne(_factory.CreateFrameHandler);
-                var defunctConnection = _delegate;
-                _delegate = new Connection(_factory, false, fh, ClientProvidedName);
-                _delegate.TakeOver(defunctConnection);
-                return true;
-            }
-            catch (Exception e)
-            {
-                ESLog.Error("Connection recovery exception.", e);
-                // Trigger recovery error events
-                if (!_connectionRecoveryErrorWrapper.IsEmpty)
-                {
-                    _connectionRecoveryErrorWrapper.Invoke(this, new ConnectionRecoveryErrorEventArgs(e));
-                }
-            }
-
-            return false;
-        }
-
-        private void RecoverConsumers()
-        {
-            ThrowIfDisposed();
-            Dictionary<string, RecordedConsumer> recordedConsumersCopy;
-            lock (_recordedConsumers)
-            {
-                recordedConsumersCopy = new Dictionary<string, RecordedConsumer>(_recordedConsumers);
-            }
-
-            foreach (KeyValuePair<string, RecordedConsumer> pair in recordedConsumersCopy)
-            {
-                string tag = pair.Key;
-                RecordedConsumer cons = pair.Value;
-
-                try
-                {
-                    string newTag = cons.Recover();
-                    lock (_recordedConsumers)
-                    {
-                        // make sure server-generated tags are re-added
-                        _recordedConsumers.Remove(tag);
-                        _recordedConsumers.Add(newTag, cons);
-                    }
-
-                    if (!_consumerTagChangeAfterRecoveryWrapper.IsEmpty)
-                    {
-                        _consumerTagChangeAfterRecoveryWrapper.Invoke(this, new ConsumerTagChangedAfterRecoveryEventArgs(tag, newTag));
-                    }
-                }
-                catch (Exception cause)
-                {
-                    string s = string.Format("Caught an exception while recovering consumer {0} on queue {1}: {2}",
-                        tag, cons.Queue, cause.Message);
-                    HandleTopologyRecoveryException(new TopologyRecoveryException(s, cause));
-                }
-            }
-        }
-
-        private void RecoverEntities()
-        {
-            // The recovery sequence is the following:
-            //
-            // 1. Recover exchanges
-            // 2. Recover queues
-            // 3. Recover bindings
-            // 4. Recover consumers
-            RecoverExchanges();
-            RecoverQueues();
-            RecoverBindings();
-        }
-
-        private void RecoverExchanges()
-        {
-            Dictionary<string, RecordedExchange> recordedExchangesCopy;
-            lock (_recordedEntitiesLock)
-            {
-                recordedExchangesCopy = new Dictionary<string, RecordedExchange>(_recordedExchanges);
-            }
-
-            foreach (RecordedExchange rx in recordedExchangesCopy.Values)
-            {
-                try
-                {
-                    rx.Recover();
-                }
-                catch (Exception cause)
-                {
-                    string s = string.Format("Caught an exception while recovering exchange {0}: {1}",
-                        rx.Name, cause.Message);
-                    HandleTopologyRecoveryException(new TopologyRecoveryException(s, cause));
-                }
-            }
-        }
-
-        private void RecoverModels()
-        {
-            lock (_models)
-            {
-                foreach (AutorecoveringModel m in _models)
-                {
-                    m.AutomaticallyRecover(this);
-                }
-            }
-        }
-
-        private void RecoverQueues()
-        {
-            Dictionary<string, RecordedQueue> recordedQueuesCopy;
-            lock (_recordedEntitiesLock)
-            {
-                recordedQueuesCopy = new Dictionary<string, RecordedQueue>(_recordedQueues);
-            }
-
-            foreach (KeyValuePair<string, RecordedQueue> pair in recordedQueuesCopy)
-            {
-                string oldName = pair.Key;
-                RecordedQueue rq = pair.Value;
-
-                try
-                {
-                    rq.Recover();
-                    string newName = rq.Name;
-
-                    if (!oldName.Equals(newName))
-                    {
-                        // Make sure server-named queues are re-added with
-                        // their new names.
-                        // We only remove old name after we've updated the bindings and consumers,
-                        // plus only for server-named queues, both to make sure we don't lose
-                        // anything to recover. MK.
-                        PropagateQueueNameChangeToBindings(oldName, newName);
-                        PropagateQueueNameChangeToConsumers(oldName, newName);
-                        // see rabbitmq/rabbitmq-dotnet-client#43
-                        if (rq.IsServerNamed)
-                        {
-                            DeleteRecordedQueue(oldName);
-                        }
-                        RecordQueue(newName, rq);
-
-                        if (!_queueNameChangeAfterRecoveryWrapper.IsEmpty)
-                        {
-                            _queueNameChangeAfterRecoveryWrapper.Invoke(this, new QueueNameChangedAfterRecoveryEventArgs(oldName, newName));
-                        }
-                    }
-                }
-                catch (Exception cause)
-                {
-                    string s = string.Format("Caught an exception while recovering queue {0}: {1}",
-                        oldName, cause.Message);
-                    HandleTopologyRecoveryException(new TopologyRecoveryException(s, cause));
-                }
-            }
-        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ThrowIfDisposed()

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
@@ -619,24 +619,17 @@ namespace RabbitMQ.Client.Impl
             IDictionary<string, object> arguments,
             IBasicConsumer consumer)
         {
-            string result = Delegate.BasicConsume(queue, autoAck, consumerTag, noLocal,
-                exclusive, arguments, consumer);
-            RecordedConsumer rc = new RecordedConsumer(this, queue).
-                WithConsumerTag(result).
-                WithConsumer(consumer).
-                WithExclusive(exclusive).
-                WithAutoAck(autoAck).
-                WithArguments(arguments);
+            string result = Delegate.BasicConsume(queue, autoAck, consumerTag, noLocal, exclusive, arguments, consumer);
+            RecordedConsumer rc = new RecordedConsumer(this, consumer, queue, autoAck, result, exclusive, arguments);
             _connection.RecordConsumer(result, rc);
             return result;
         }
 
-        public BasicGetResult BasicGet(string queue,
-            bool autoAck) => Delegate.BasicGet(queue, autoAck);
+        public BasicGetResult BasicGet(string queue, bool autoAck)
+            => Delegate.BasicGet(queue, autoAck);
 
-        public void BasicNack(ulong deliveryTag,
-            bool multiple,
-            bool requeue) => Delegate.BasicNack(deliveryTag, multiple, requeue);
+        public void BasicNack(ulong deliveryTag, bool multiple, bool requeue)
+            => Delegate.BasicNack(deliveryTag, multiple, requeue);
 
         public void BasicPublish(string exchange,
             string routingKey,
@@ -714,158 +707,102 @@ namespace RabbitMQ.Client.Impl
             _usesPublisherConfirms = true;
         }
 
-        public IBasicProperties CreateBasicProperties() => Delegate.CreateBasicProperties();
+        public IBasicProperties CreateBasicProperties()
+            => Delegate.CreateBasicProperties();
 
-        public void ExchangeBind(string destination,
-            string source,
-            string routingKey,
-            IDictionary<string, object> arguments)
+        public void ExchangeBind(string destination, string source, string routingKey, IDictionary<string, object> arguments)
         {
             ThrowIfDisposed();
-            RecordedBinding eb = new RecordedExchangeBinding(this).
-                WithSource(source).
-                WithDestination(destination).
-                WithRoutingKey(routingKey).
-                WithArguments(arguments);
+            RecordedBinding eb = new RecordedExchangeBinding(this, destination, source, routingKey, arguments);
             _connection.RecordBinding(eb);
             _delegate.ExchangeBind(destination, source, routingKey, arguments);
         }
 
-        public void ExchangeBindNoWait(string destination,
-            string source,
-            string routingKey,
-            IDictionary<string, object> arguments) => Delegate.ExchangeBindNoWait(destination, source, routingKey, arguments);
+        public void ExchangeBindNoWait(string destination, string source, string routingKey, IDictionary<string, object> arguments)
+            => Delegate.ExchangeBindNoWait(destination, source, routingKey, arguments);
 
-        public void ExchangeDeclare(string exchange, string type, bool durable,
-            bool autoDelete, IDictionary<string, object> arguments)
+        public void ExchangeDeclare(string exchange, string type, bool durable, bool autoDelete, IDictionary<string, object> arguments)
         {
             ThrowIfDisposed();
-            RecordedExchange rx = new RecordedExchange(this, exchange).
-                WithType(type).
-                WithDurable(durable).
-                WithAutoDelete(autoDelete).
-                WithArguments(arguments);
-            _delegate.ExchangeDeclare(exchange, type, durable,
-                autoDelete, arguments);
+            _delegate.ExchangeDeclare(exchange, type, durable, autoDelete, arguments);
+            RecordedExchange rx = new RecordedExchange(this, exchange, type, durable, autoDelete, arguments);
             _connection.RecordExchange(rx);
         }
 
-        public void ExchangeDeclareNoWait(string exchange,
-            string type,
-            bool durable,
-            bool autoDelete,
-            IDictionary<string, object> arguments)
+        public void ExchangeDeclareNoWait(string exchange, string type, bool durable, bool autoDelete, IDictionary<string, object> arguments)
         {
             ThrowIfDisposed();
-            RecordedExchange rx = new RecordedExchange(this, exchange).
-                WithType(type).
-                WithDurable(durable).
-                WithAutoDelete(autoDelete).
-                WithArguments(arguments);
-            _delegate.ExchangeDeclareNoWait(exchange, type, durable,
-                autoDelete, arguments);
+            _delegate.ExchangeDeclareNoWait(exchange, type, durable, autoDelete, arguments);
+            RecordedExchange rx = new RecordedExchange(this, exchange, type, durable, autoDelete, arguments);
             _connection.RecordExchange(rx);
         }
 
-        public void ExchangeDeclarePassive(string exchange) => Delegate.ExchangeDeclarePassive(exchange);
+        public void ExchangeDeclarePassive(string exchange)
+            => Delegate.ExchangeDeclarePassive(exchange);
 
-        public void ExchangeDelete(string exchange,
-            bool ifUnused)
+        public void ExchangeDelete(string exchange, bool ifUnused)
         {
             Delegate.ExchangeDelete(exchange, ifUnused);
             _connection.DeleteRecordedExchange(exchange);
         }
 
-        public void ExchangeDeleteNoWait(string exchange,
-            bool ifUnused)
+        public void ExchangeDeleteNoWait(string exchange, bool ifUnused)
         {
             Delegate.ExchangeDeleteNoWait(exchange, ifUnused);
             _connection.DeleteRecordedExchange(exchange);
         }
 
-        public void ExchangeUnbind(string destination,
-            string source,
-            string routingKey,
-            IDictionary<string, object> arguments)
+        public void ExchangeUnbind(string destination, string source, string routingKey, IDictionary<string, object> arguments)
         {
             ThrowIfDisposed();
-            RecordedBinding eb = new RecordedExchangeBinding(this).
-                WithSource(source).
-                WithDestination(destination).
-                WithRoutingKey(routingKey).
-                WithArguments(arguments);
+            RecordedBinding eb = new RecordedExchangeBinding(this, destination, source, routingKey, arguments);
             _connection.DeleteRecordedBinding(eb);
             _delegate.ExchangeUnbind(destination, source, routingKey, arguments);
             _connection.DeleteAutoDeleteExchange(source);
         }
 
-        public void ExchangeUnbindNoWait(string destination,
-            string source,
-            string routingKey,
-            IDictionary<string, object> arguments) => Delegate.ExchangeUnbind(destination, source, routingKey, arguments);
+        public void ExchangeUnbindNoWait(string destination, string source, string routingKey, IDictionary<string, object> arguments)
+            => Delegate.ExchangeUnbind(destination, source, routingKey, arguments);
 
-        public void QueueBind(string queue,
-            string exchange,
-            string routingKey,
-            IDictionary<string, object> arguments)
+        public void QueueBind(string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
         {
             ThrowIfDisposed();
-            RecordedBinding qb = new RecordedQueueBinding(this).
-                WithSource(exchange).
-                WithDestination(queue).
-                WithRoutingKey(routingKey).
-                WithArguments(arguments);
+            RecordedBinding qb = new RecordedQueueBinding(this, queue, exchange, routingKey, arguments);
             _connection.RecordBinding(qb);
             _delegate.QueueBind(queue, exchange, routingKey, arguments);
         }
 
-        public void QueueBindNoWait(string queue,
-            string exchange,
-            string routingKey,
-            IDictionary<string, object> arguments) => Delegate.QueueBind(queue, exchange, routingKey, arguments);
+        public void QueueBindNoWait(string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
+            => Delegate.QueueBind(queue, exchange, routingKey, arguments);
 
-        public QueueDeclareOk QueueDeclare(string queue, bool durable,
-                                           bool exclusive, bool autoDelete,
-                                           IDictionary<string, object> arguments)
+        public QueueDeclareOk QueueDeclare(string queue, bool durable, bool exclusive, bool autoDelete, IDictionary<string, object> arguments)
         {
             ThrowIfDisposed();
-            QueueDeclareOk result = _delegate.QueueDeclare(queue, durable, exclusive,
-                autoDelete, arguments);
-            RecordedQueue rq = new RecordedQueue(this, result.QueueName).
-                Durable(durable).
-                Exclusive(exclusive).
-                AutoDelete(autoDelete).
-                Arguments(arguments).
-                ServerNamed(string.Empty.Equals(queue));
+            QueueDeclareOk result = _delegate.QueueDeclare(queue, durable, exclusive, autoDelete, arguments);
+            RecordedQueue rq = new RecordedQueue(this, result.QueueName, queue.Length == 0, durable, exclusive, autoDelete, arguments);
             _connection.RecordQueue(rq);
             return result;
         }
 
-        public void QueueDeclareNoWait(string queue, bool durable,
-                                       bool exclusive, bool autoDelete,
-                                       IDictionary<string, object> arguments)
+        public void QueueDeclareNoWait(string queue, bool durable, bool exclusive, bool autoDelete, IDictionary<string, object> arguments)
         {
             ThrowIfDisposed();
             _delegate.QueueDeclareNoWait(queue, durable, exclusive,
                 autoDelete, arguments);
-            RecordedQueue rq = new RecordedQueue(this, queue).
-                Durable(durable).
-                Exclusive(exclusive).
-                AutoDelete(autoDelete).
-                Arguments(arguments).
-                ServerNamed(string.Empty.Equals(queue));
+            RecordedQueue rq = new RecordedQueue(this, queue, queue.Length == 0, durable, exclusive, autoDelete, arguments);
             _connection.RecordQueue(rq);
         }
 
-        public QueueDeclareOk QueueDeclarePassive(string queue) => Delegate.QueueDeclarePassive(queue);
+        public QueueDeclareOk QueueDeclarePassive(string queue)
+            => Delegate.QueueDeclarePassive(queue);
 
-        public uint MessageCount(string queue) => Delegate.MessageCount(queue);
+        public uint MessageCount(string queue)
+            => Delegate.MessageCount(queue);
 
-        public uint ConsumerCount(string queue) => Delegate.ConsumerCount(queue);
+        public uint ConsumerCount(string queue)
+            => Delegate.ConsumerCount(queue);
 
-        public uint QueueDelete(string queue,
-            bool ifUnused,
-            bool ifEmpty)
+        public uint QueueDelete(string queue, bool ifUnused, bool ifEmpty)
         {
             ThrowIfDisposed();
             uint result = _delegate.QueueDelete(queue, ifUnused, ifEmpty);
@@ -873,27 +810,19 @@ namespace RabbitMQ.Client.Impl
             return result;
         }
 
-        public void QueueDeleteNoWait(string queue,
-            bool ifUnused,
-            bool ifEmpty)
+        public void QueueDeleteNoWait(string queue, bool ifUnused, bool ifEmpty)
         {
             Delegate.QueueDeleteNoWait(queue, ifUnused, ifEmpty);
             _connection.DeleteRecordedQueue(queue);
         }
 
-        public uint QueuePurge(string queue) => Delegate.QueuePurge(queue);
+        public uint QueuePurge(string queue)
+            => Delegate.QueuePurge(queue);
 
-        public void QueueUnbind(string queue,
-            string exchange,
-            string routingKey,
-            IDictionary<string, object> arguments)
+        public void QueueUnbind(string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
         {
             ThrowIfDisposed();
-            RecordedBinding qb = new RecordedQueueBinding(this).
-                WithSource(exchange).
-                WithDestination(queue).
-                WithRoutingKey(routingKey).
-                WithArguments(arguments);
+            RecordedBinding qb = new RecordedQueueBinding(this, queue, exchange, routingKey, arguments);
             _connection.DeleteRecordedBinding(qb);
             _delegate.QueueUnbind(queue, exchange, routingKey, arguments);
             _connection.DeleteAutoDeleteExchange(exchange);

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
@@ -157,7 +157,7 @@ namespace RabbitMQ.Client.Impl
             }
             finally
             {
-                _connection.UnregisterModel(this);
+                _connection.DeleteRecordedChannel(this);
             }
         }
 
@@ -170,7 +170,7 @@ namespace RabbitMQ.Client.Impl
             }
             finally
             {
-                _connection.UnregisterModel(this);
+                _connection.DeleteRecordedChannel(this);
             }
         }
 
@@ -576,7 +576,7 @@ namespace RabbitMQ.Client.Impl
             }
             finally
             {
-                _connection.UnregisterModel(this);
+                _connection.DeleteRecordedChannel(this);
             }
         }
 
@@ -589,7 +589,7 @@ namespace RabbitMQ.Client.Impl
             }
             finally
             {
-                _connection.UnregisterModel(this);
+                _connection.DeleteRecordedChannel(this);
             }
         }
 
@@ -599,22 +599,14 @@ namespace RabbitMQ.Client.Impl
         public void BasicCancel(string consumerTag)
         {
             ThrowIfDisposed();
-            RecordedConsumer cons = _connection.DeleteRecordedConsumer(consumerTag);
-            if (cons != null)
-            {
-                _connection.MaybeDeleteRecordedAutoDeleteQueue(cons.Queue);
-            }
+            _connection.DeleteRecordedConsumer(consumerTag);
             _delegate.BasicCancel(consumerTag);
         }
 
         public void BasicCancelNoWait(string consumerTag)
         {
             ThrowIfDisposed();
-            RecordedConsumer cons = _connection.DeleteRecordedConsumer(consumerTag);
-            if (cons != null)
-            {
-                _connection.MaybeDeleteRecordedAutoDeleteQueue(cons.Queue);
-            }
+            _connection.DeleteRecordedConsumer(consumerTag);
             _delegate.BasicCancelNoWait(consumerTag);
         }
 
@@ -699,7 +691,7 @@ namespace RabbitMQ.Client.Impl
             }
             finally
             {
-                _connection.UnregisterModel(this);
+                _connection.DeleteRecordedChannel(this);
             }
         }
 
@@ -712,7 +704,7 @@ namespace RabbitMQ.Client.Impl
             }
             finally
             {
-                _connection.UnregisterModel(this);
+                _connection.DeleteRecordedChannel(this);
             }
         }
 
@@ -755,7 +747,7 @@ namespace RabbitMQ.Client.Impl
                 WithArguments(arguments);
             _delegate.ExchangeDeclare(exchange, type, durable,
                 autoDelete, arguments);
-            _connection.RecordExchange(exchange, rx);
+            _connection.RecordExchange(rx);
         }
 
         public void ExchangeDeclareNoWait(string exchange,
@@ -772,7 +764,7 @@ namespace RabbitMQ.Client.Impl
                 WithArguments(arguments);
             _delegate.ExchangeDeclareNoWait(exchange, type, durable,
                 autoDelete, arguments);
-            _connection.RecordExchange(exchange, rx);
+            _connection.RecordExchange(rx);
         }
 
         public void ExchangeDeclarePassive(string exchange) => Delegate.ExchangeDeclarePassive(exchange);
@@ -804,7 +796,7 @@ namespace RabbitMQ.Client.Impl
                 WithArguments(arguments);
             _connection.DeleteRecordedBinding(eb);
             _delegate.ExchangeUnbind(destination, source, routingKey, arguments);
-            _connection.MaybeDeleteRecordedAutoDeleteExchange(source);
+            _connection.DeleteAutoDeleteExchange(source);
         }
 
         public void ExchangeUnbindNoWait(string destination,
@@ -845,7 +837,7 @@ namespace RabbitMQ.Client.Impl
                 AutoDelete(autoDelete).
                 Arguments(arguments).
                 ServerNamed(string.Empty.Equals(queue));
-            _connection.RecordQueue(result.QueueName, rq);
+            _connection.RecordQueue(rq);
             return result;
         }
 
@@ -862,7 +854,7 @@ namespace RabbitMQ.Client.Impl
                 AutoDelete(autoDelete).
                 Arguments(arguments).
                 ServerNamed(string.Empty.Equals(queue));
-            _connection.RecordQueue(queue, rq);
+            _connection.RecordQueue(rq);
         }
 
         public QueueDeclareOk QueueDeclarePassive(string queue) => Delegate.QueueDeclarePassive(queue);
@@ -904,7 +896,7 @@ namespace RabbitMQ.Client.Impl
                 WithArguments(arguments);
             _connection.DeleteRecordedBinding(qb);
             _delegate.QueueUnbind(queue, exchange, routingKey, arguments);
-            _connection.MaybeDeleteRecordedAutoDeleteExchange(exchange);
+            _connection.DeleteAutoDeleteExchange(exchange);
         }
 
         public void TxCommit() => Delegate.TxCommit();

--- a/projects/RabbitMQ.Client/client/impl/RecordedConsumer.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedConsumer.cs
@@ -33,63 +33,30 @@ using System.Collections.Generic;
 
 namespace RabbitMQ.Client.Impl
 {
-    internal class RecordedConsumer : RecordedEntity
+    #nullable enable
+    internal sealed class RecordedConsumer : RecordedEntity
     {
-        public RecordedConsumer(AutorecoveringModel model, string queue) : base(model)
+        public RecordedConsumer(AutorecoveringModel channel, IBasicConsumer consumer, string queue, bool autoAck, string consumerTag, bool exclusive, IDictionary<string, object>? arguments)
+            : base(channel)
         {
+            Consumer = consumer;
             Queue = queue;
+            AutoAck = autoAck;
+            ConsumerTag = consumerTag;
+            Exclusive = exclusive;
+            Arguments = arguments;
         }
 
-        public IDictionary<string, object> Arguments { get; set; }
-        public bool AutoAck { get; set; }
-        public IBasicConsumer Consumer { get; set; }
-        public string ConsumerTag { get; set; }
-        public bool Exclusive { get; set; }
+        public IBasicConsumer Consumer { get; }
         public string Queue { get; set; }
+        public bool AutoAck { get; }
+        public string ConsumerTag { get; set; }
+        public bool Exclusive { get; }
+        public IDictionary<string, object>? Arguments { get; }
 
-        public string Recover()
+        public override void Recover()
         {
-            ConsumerTag = ModelDelegate.BasicConsume(Queue, AutoAck,
-                ConsumerTag, false, Exclusive,
-                Arguments, Consumer);
-
-            return ConsumerTag;
-        }
-
-        public RecordedConsumer WithArguments(IDictionary<string, object> value)
-        {
-            Arguments = value;
-            return this;
-        }
-
-        public RecordedConsumer WithAutoAck(bool value)
-        {
-            AutoAck = value;
-            return this;
-        }
-
-        public RecordedConsumer WithConsumer(IBasicConsumer value)
-        {
-            Consumer = value;
-            return this;
-        }
-
-        public RecordedConsumer WithConsumerTag(string value)
-        {
-            ConsumerTag = value;
-            return this;
-        }
-
-        public RecordedConsumer WithExclusive(bool value)
-        {
-            Exclusive = value;
-            return this;
-        }
-
-        public RecordedConsumer WithQueue(string value)
-        {
-            Queue = value;
-            return this;
+            ConsumerTag = ModelDelegate.BasicConsume(Queue, AutoAck, ConsumerTag, false, Exclusive, Arguments, Consumer);
         }
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/RecordedEntity.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedEntity.cs
@@ -31,18 +31,21 @@
 
 namespace RabbitMQ.Client.Impl
 {
+    #nullable enable
     internal abstract class RecordedEntity
     {
-        public RecordedEntity(AutorecoveringModel model)
-        {
-            Model = model;
-        }
+        private readonly AutorecoveringModel _channel;
 
-        public AutorecoveringModel Model { get; protected set; }
+        protected RecordedEntity(AutorecoveringModel channel)
+        {
+            _channel = channel;
+        }
 
         protected IModel ModelDelegate
         {
-            get { return Model.Delegate; }
+            get { return _channel.Delegate; }
         }
+
+        public abstract void Recover();
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/RecordedExchange.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedExchange.cs
@@ -33,49 +33,32 @@ using System.Collections.Generic;
 
 namespace RabbitMQ.Client.Impl
 {
-    internal class RecordedExchange : RecordedNamedEntity
+    #nullable enable
+    internal sealed class RecordedExchange : RecordedNamedEntity
     {
-        public RecordedExchange(AutorecoveringModel model, string name) : base(model, name)
+        private readonly IDictionary<string, object>? _arguments;
+        private readonly bool _durable;
+        private readonly string _type;
+
+        public bool IsAutoDelete { get; }
+
+        public RecordedExchange(AutorecoveringModel channel, string name, string type, bool durable, bool isAutoDelete, IDictionary<string, object>? arguments)
+            : base(channel, name)
         {
+            _type = type;
+            _durable = durable;
+            IsAutoDelete = isAutoDelete;
+            _arguments = arguments;
         }
 
-        public IDictionary<string, object> Arguments { get; private set; }
-        public bool Durable { get; private set; }
-        public bool IsAutoDelete { get; private set; }
-        public string Type { get; private set; }
-
-        public void Recover()
+        public override void Recover()
         {
-            ModelDelegate.ExchangeDeclare(Name, Type, Durable, IsAutoDelete, Arguments);
+            ModelDelegate.ExchangeDeclare(Name, _type, _durable, IsAutoDelete, _arguments);
         }
 
         public override string ToString()
         {
-            return $"{GetType().Name}: name = '{Name}', type = '{Type}', durable = {Durable}, autoDelete = {IsAutoDelete}, arguments = '{Arguments}'";
-        }
-
-        public RecordedExchange WithArguments(IDictionary<string, object> value)
-        {
-            Arguments = value;
-            return this;
-        }
-
-        public RecordedExchange WithAutoDelete(bool value)
-        {
-            IsAutoDelete = value;
-            return this;
-        }
-
-        public RecordedExchange WithDurable(bool value)
-        {
-            Durable = value;
-            return this;
-        }
-
-        public RecordedExchange WithType(string value)
-        {
-            Type = value;
-            return this;
+            return $"{GetType().Name}: name = '{Name}', type = '{_type}', durable = {_durable}, autoDelete = {IsAutoDelete}, arguments = '{_arguments}'";
         }
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/RecordedNamedEntity.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedNamedEntity.cs
@@ -31,9 +31,10 @@
 
 namespace RabbitMQ.Client.Impl
 {
-    internal class RecordedNamedEntity : RecordedEntity
+    #nullable enable
+    internal abstract class RecordedNamedEntity : RecordedEntity
     {
-        public RecordedNamedEntity(AutorecoveringModel model, string name) : base(model)
+        protected RecordedNamedEntity(AutorecoveringModel channel, string name) : base(channel)
         {
             Name = name;
         }


### PR DESCRIPTION
## Proposed Changes

This PR contains 3 changes:
- move out all code for recording out into its own partial file + some simplifications
- caching the Default Protocol so its not getting created over and over again
- replacing the builder pattern used in recordings

This is mostly simplification with some minor allocation improvements and code size reduction.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
