### PR TITLE
Reduce close / abort methods in public API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ TestResult.xml
 /NuGet
 .vscode/
 *.lock.json
-api/
 
 test.sh
 *.VisualState.xml

--- a/projects/RabbitMQ.Client/client/api/IConnection.cs
+++ b/projects/RabbitMQ.Client/client/api/IConnection.cs
@@ -31,12 +31,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Threading;
-
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Exceptions;
-using RabbitMQ.Client.Impl;
 
 namespace RabbitMQ.Client
 {
@@ -215,125 +211,14 @@ namespace RabbitMQ.Client
         void UpdateSecret(string newSecret, string reason);
 
         /// <summary>
-        /// Abort this connection and all its channels.
-        /// </summary>
-        /// <remarks>
-        /// Note that all active channels, sessions, and models will be closed if this method is called.
-        /// In comparison to normal <see cref="Close()"/> method, <see cref="Abort()"/> will not throw
-        /// <see cref="IOException"/> during closing connection.
-        ///This method waits infinitely for the in-progress close operation to complete.
-        /// </remarks>
-        void Abort();
-
-        /// <summary>
-        /// Abort this connection and all its channels.
-        /// </summary>
-        /// <remarks>
-        /// The method behaves in the same way as <see cref="Abort()"/>, with the only
-        /// difference that the connection is closed with the given connection close code and message.
-        /// <para>
-        /// The close code (See under "Reply Codes" in the AMQP 0-9-1 specification)
-        /// </para>
-        /// <para>
-        /// A message indicating the reason for closing the connection
-        /// </para>
-        /// </remarks>
-        void Abort(ushort reasonCode, string reasonText);
-
-        /// <summary>
-        /// Abort this connection and all its channels and wait with a
-        /// timeout for all the in-progress close operations to complete.
-        /// </summary>
-        /// <remarks>
-        /// This method, behaves in a similar way as method <see cref="Abort()"/> with the
-        /// only difference that it explictly specifies a timeout given
-        /// for all the in-progress close operations to complete.
-        /// If timeout is reached and the close operations haven't finished, then socket is forced to close.
-        /// <para>
-        /// To wait infinitely for the close operations to complete use <see cref="Timeout.Infinite"/>.
-        /// </para>
-        /// </remarks>
-        void Abort(TimeSpan timeout);
-
-        /// <summary>
-        /// Abort this connection and all its channels and wait with a
-        /// timeout for all the in-progress close operations to complete.
-        /// </summary>
-        /// <remarks>
-        /// The method behaves in the same way as <see cref="Abort(TimeSpan)"/>, with the only
-        /// difference that the connection is closed with the given connection close code and message.
-        /// <para>
-        /// The close code (See under "Reply Codes" in the AMQP 0-9-1 specification).
-        /// </para>
-        /// <para>
-        /// A message indicating the reason for closing the connection.
-        /// </para>
-        /// </remarks>
-        void Abort(ushort reasonCode, string reasonText, TimeSpan timeout);
-
-        /// <summary>
-        /// Close this connection and all its channels.
-        /// </summary>
-        /// <remarks>
-        /// Note that all active channels, sessions, and models will be
-        /// closed if this method is called. It will wait for the in-progress
-        /// close operation to complete. This method will not return to the caller
-        /// until the shutdown is complete. If the connection is already closed
-        /// (or closing), then this method will do nothing.
-        /// It can also throw <see cref="IOException"/> when socket was closed unexpectedly.
-        /// </remarks>
-        void Close();
-
-        /// <summary>
-        /// Close this connection and all its channels.
-        /// </summary>
-        /// <remarks>
-        /// The method behaves in the same way as <see cref="Close()"/>, with the only
-        /// difference that the connection is closed with the given connection close code and message.
-        /// <para>
-        /// The close code (See under "Reply Codes" in the AMQP specification).
-        /// </para>
-        /// <para>
-        /// A message indicating the reason for closing the connection.
-        /// </para>
-        /// </remarks>
-        void Close(ushort reasonCode, string reasonText);
-
-        /// <summary>
         /// Close this connection and all its channels
         /// and wait with a timeout for all the in-progress close operations to complete.
         /// </summary>
-        /// <remarks>
-        /// Note that all active channels, sessions, and models will be
-        /// closed if this method is called. It will wait for the in-progress
-        /// close operation to complete with a timeout. If the connection is
-        /// already closed (or closing), then this method will do nothing.
-        /// It can also throw <see cref="IOException"/> when socket was closed unexpectedly.
-        /// If timeout is reached and the close operations haven't finished, then socket is forced to close.
-        /// <para>
-        /// To wait infinitely for the close operations to complete use <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>.
-        /// </para>
-        /// </remarks>
-        void Close(TimeSpan timeout);
-
-        /// <summary>
-        /// Close this connection and all its channels
-        /// and wait with a timeout for all the in-progress close operations to complete.
-        /// </summary>
-        /// <remarks>
-        /// The method behaves in the same way as <see cref="Close(TimeSpan)"/>, with the only
-        /// difference that the connection is closed with the given connection close code and message.
-        /// <para>
-        /// The close code (See under "Reply Codes" in the AMQP 0-9-1 specification).
-        /// </para>
-        /// <para>
-        /// A message indicating the reason for closing the connection.
-        /// </para>
-        /// <para>
-        /// Operation timeout.
-        /// </para>
-        /// </remarks>
-        void Close(ushort reasonCode, string reasonText, TimeSpan timeout);
+        /// <param name="reasonCode">The close code (See under "Reply Codes" in the AMQP 0-9-1 specification).</param>
+        /// <param name="reasonText">A message indicating the reason for closing the connection.</param>
+        /// <param name="timeout">Operation timeout.</param>
+        /// <param name="abort">Whether or not this close is an abort (ignores certain exceptions).</param>
+        void Close(ushort reasonCode, string reasonText, TimeSpan timeout, bool abort);
 
         /// <summary>
         /// Create and return a fresh channel, session, and model.

--- a/projects/RabbitMQ.Client/client/api/IConnectionExtensions.cs
+++ b/projects/RabbitMQ.Client/client/api/IConnectionExtensions.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+
+namespace RabbitMQ.Client
+{
+    public static class IConnectionExtensions
+    {
+        /// <summary>
+        /// Close this connection and all its channels.
+        /// </summary>
+        /// <remarks>
+        /// Note that all active channels, sessions, and models will be
+        /// closed if this method is called. It will wait for the in-progress
+        /// close operation to complete. This method will not return to the caller
+        /// until the shutdown is complete. If the connection is already closed
+        /// (or closing), then this method will do nothing.
+        /// It can also throw <see cref="IOException"/> when socket was closed unexpectedly.
+        /// </remarks>
+        public static void Close(this IConnection connection)
+        {
+            connection.Close(Constants.ReplySuccess, "Goodbye", Timeout.InfiniteTimeSpan, false);
+        }
+
+        /// <summary>
+        /// Close this connection and all its channels.
+        /// </summary>
+        /// <remarks>
+        /// The method behaves in the same way as <see cref="Close(IConnection)"/>, with the only
+        /// difference that the connection is closed with the given connection close code and message.
+        /// <para>
+        /// The close code (See under "Reply Codes" in the AMQP specification).
+        /// </para>
+        /// <para>
+        /// A message indicating the reason for closing the connection.
+        /// </para>
+        /// </remarks>
+        public static void Close(this IConnection connection, ushort reasonCode, string reasonText)
+        {
+            connection.Close(reasonCode, reasonText, Timeout.InfiniteTimeSpan, false);
+        }
+
+        /// <summary>
+        /// Close this connection and all its channels
+        /// and wait with a timeout for all the in-progress close operations to complete.
+        /// </summary>
+        /// <remarks>
+        /// Note that all active channels, sessions, and models will be
+        /// closed if this method is called. It will wait for the in-progress
+        /// close operation to complete with a timeout. If the connection is
+        /// already closed (or closing), then this method will do nothing.
+        /// It can also throw <see cref="IOException"/> when socket was closed unexpectedly.
+        /// If timeout is reached and the close operations haven't finished, then socket is forced to close.
+        /// <para>
+        /// To wait infinitely for the close operations to complete use <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>.
+        /// </para>
+        /// </remarks>
+        public static void Close(this IConnection connection, TimeSpan timeout)
+        {
+            connection.Close(Constants.ReplySuccess, "Goodbye", timeout, false);
+        }
+
+        /// <summary>
+        /// Close this connection and all its channels
+        /// and wait with a timeout for all the in-progress close operations to complete.
+        /// </summary>
+        /// <remarks>
+        /// The method behaves in the same way as <see cref="Close(IConnection,TimeSpan)"/>, with the only
+        /// difference that the connection is closed with the given connection close code and message.
+        /// <para>
+        /// The close code (See under "Reply Codes" in the AMQP 0-9-1 specification).
+        /// </para>
+        /// <para>
+        /// A message indicating the reason for closing the connection.
+        /// </para>
+        /// <para>
+        /// Operation timeout.
+        /// </para>
+        /// </remarks>
+        public static void Close(this IConnection connection, ushort reasonCode, string reasonText, TimeSpan timeout)
+        {
+            connection.Close(reasonCode, reasonText, timeout, false);
+        }
+
+        /// <summary>
+        /// Abort this connection and all its channels.
+        /// </summary>
+        /// <remarks>
+        /// Note that all active channels, sessions, and models will be closed if this method is called.
+        /// In comparison to normal <see cref="Close(IConnection)"/> method, <see cref="Abort(IConnection)"/> will not throw
+        /// <see cref="IOException"/> during closing connection.
+        ///This method waits infinitely for the in-progress close operation to complete.
+        /// </remarks>
+        public static void Abort(this IConnection connection)
+        {
+            connection.Close(Constants.ReplySuccess, "Connection close forced", Timeout.InfiniteTimeSpan, true);
+        }
+
+        /// <summary>
+        /// Abort this connection and all its channels.
+        /// </summary>
+        /// <remarks>
+        /// The method behaves in the same way as <see cref="Abort(IConnection)"/>, with the only
+        /// difference that the connection is closed with the given connection close code and message.
+        /// <para>
+        /// The close code (See under "Reply Codes" in the AMQP 0-9-1 specification)
+        /// </para>
+        /// <para>
+        /// A message indicating the reason for closing the connection
+        /// </para>
+        /// </remarks>
+        public static void Abort(this IConnection connection, ushort reasonCode, string reasonText)
+        {
+            connection.Close(reasonCode, reasonText, Timeout.InfiniteTimeSpan, true);
+        }
+
+        /// <summary>
+        /// Abort this connection and all its channels and wait with a
+        /// timeout for all the in-progress close operations to complete.
+        /// </summary>
+        /// <remarks>
+        /// This method, behaves in a similar way as method <see cref="Abort(IConnection)"/> with the
+        /// only difference that it explictly specifies a timeout given
+        /// for all the in-progress close operations to complete.
+        /// If timeout is reached and the close operations haven't finished, then socket is forced to close.
+        /// <para>
+        /// To wait infinitely for the close operations to complete use <see cref="Timeout.Infinite"/>.
+        /// </para>
+        /// </remarks>
+        public static void Abort(this IConnection connection, TimeSpan timeout)
+        {
+            connection.Close(Constants.ReplySuccess, "Connection close forced", timeout, true);
+        }
+
+        /// <summary>
+        /// Abort this connection and all its channels and wait with a
+        /// timeout for all the in-progress close operations to complete.
+        /// </summary>
+        /// <remarks>
+        /// The method behaves in the same way as <see cref="Abort(IConnection,TimeSpan)"/>, with the only
+        /// difference that the connection is closed with the given connection close code and message.
+        /// <para>
+        /// The close code (See under "Reply Codes" in the AMQP 0-9-1 specification).
+        /// </para>
+        /// <para>
+        /// A message indicating the reason for closing the connection.
+        /// </para>
+        /// </remarks>
+        public static void Abort(this IConnection connection, ushort reasonCode, string reasonText, TimeSpan timeout)
+        {
+            connection.Close(reasonCode, reasonText, timeout, true);
+        }
+    }
+}

--- a/projects/RabbitMQ.Client/client/api/IModel.cs
+++ b/projects/RabbitMQ.Client/client/api/IModel.cs
@@ -144,34 +144,6 @@ namespace RabbitMQ.Client
         event EventHandler<ShutdownEventArgs> ModelShutdown;
 
         /// <summary>
-        /// Abort this session.
-        /// </summary>
-        /// <remarks>
-        /// If the session is already closed (or closing), then this
-        /// method does nothing but wait for the in-progress close
-        /// operation to complete. This method will not return to the
-        /// caller until the shutdown is complete.
-        /// In comparison to normal <see cref="Close()"/> method, <see cref="Abort()"/> will not throw
-        /// <see cref="Exceptions.AlreadyClosedException"/> or <see cref="System.IO.IOException"/> or any other <see cref="Exception"/> during closing model.
-        /// </remarks>
-        void Abort();
-
-        /// <summary>
-        /// Abort this session.
-        /// </summary>
-        /// <remarks>
-        /// The method behaves in the same way as <see cref="Abort()"/>, with the only
-        /// difference that the model is closed with the given model close code and message.
-        /// <para>
-        /// The close code (See under "Reply Codes" in the AMQP specification)
-        /// </para>
-        /// <para>
-        /// A message indicating the reason for closing the model
-        /// </para>
-        /// </remarks>
-        void Abort(ushort replyCode, string replyText);
-
-        /// <summary>
         /// Acknowledge one or more delivered message(s).
         /// </summary>
         void BasicAck(ulong deliveryTag, bool multiple);
@@ -247,27 +219,10 @@ namespace RabbitMQ.Client
         void BasicReject(ulong deliveryTag, bool requeue);
 
         /// <summary>Close this session.</summary>
-        /// <remarks>
-        /// If the session is already closed (or closing), then this
-        /// method does nothing but wait for the in-progress close
-        /// operation to complete. This method will not return to the
-        /// caller until the shutdown is complete.
-        /// </remarks>
-        void Close();
-
-        /// <summary>Close this session.</summary>
-        /// <remarks>
-        /// The method behaves in the same way as Close(), with the only
-        /// difference that the model is closed with the given model
-        /// close code and message.
-        /// <para>
-        /// The close code (See under "Reply Codes" in the AMQP specification)
-        /// </para>
-        /// <para>
-        /// A message indicating the reason for closing the model
-        /// </para>
-        /// </remarks>
-        void Close(ushort replyCode, string replyText);
+        /// <param name="replyCode">The reply code to send for closing (See under "Reply Codes" in the AMQP specification).</param>
+        /// <param name="replyText">The reply text to send for closing.</param>
+        /// <param name="abort">Whether or not the close is an abort (ignoring certain exceptions).</param>
+        void Close(ushort replyCode, string replyText, bool abort);
 
         /// <summary>
         /// Enable publisher acknowledgements.

--- a/projects/RabbitMQ.Client/client/api/IModelExtensions.cs
+++ b/projects/RabbitMQ.Client/client/api/IModelExtensions.cs
@@ -216,5 +216,68 @@ namespace RabbitMQ.Client
         {
             model.QueueUnbind(queue, exchange, routingKey, arguments);
         }
+
+        /// <summary>
+        /// Abort this session.
+        /// </summary>
+        /// <remarks>
+        /// If the session is already closed (or closing), then this
+        /// method does nothing but wait for the in-progress close
+        /// operation to complete. This method will not return to the
+        /// caller until the shutdown is complete.
+        /// In comparison to normal <see cref="Close(IModel)"/> method, <see cref="Abort(IModel)"/> will not throw
+        /// <see cref="Exceptions.AlreadyClosedException"/> or <see cref="System.IO.IOException"/> or any other <see cref="Exception"/> during closing model.
+        /// </remarks>
+        public static void Abort(this IModel model)
+        {
+            model.Close(Constants.ReplySuccess, "Goodbye", true);
+        }
+
+        /// <summary>
+        /// Abort this session.
+        /// </summary>
+        /// <remarks>
+        /// The method behaves in the same way as <see cref="Abort(IModel)"/>, with the only
+        /// difference that the model is closed with the given model close code and message.
+        /// <para>
+        /// The close code (See under "Reply Codes" in the AMQP specification)
+        /// </para>
+        /// <para>
+        /// A message indicating the reason for closing the model
+        /// </para>
+        /// </remarks>
+        public static void Abort(this IModel model, ushort replyCode, string replyText)
+        {
+            model.Close(replyCode, replyText, true);
+        }
+
+        /// <summary>Close this session.</summary>
+        /// <remarks>
+        /// If the session is already closed (or closing), then this
+        /// method does nothing but wait for the in-progress close
+        /// operation to complete. This method will not return to the
+        /// caller until the shutdown is complete.
+        /// </remarks>
+        public static void Close(this IModel model)
+        {
+            model.Close(Constants.ReplySuccess, "Goodbye", false);
+        }
+
+        /// <summary>Close this session.</summary>
+        /// <remarks>
+        /// The method behaves in the same way as Close(), with the only
+        /// difference that the model is closed with the given model
+        /// close code and message.
+        /// <para>
+        /// The close code (See under "Reply Codes" in the AMQP specification)
+        /// </para>
+        /// <para>
+        /// A message indicating the reason for closing the model
+        /// </para>
+        /// </remarks>
+        public static void Close(this IModel model, ushort replyCode, string replyText)
+        {
+            model.Close(replyCode, replyText, false);
+        }
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.cs
@@ -150,8 +150,6 @@ namespace RabbitMQ.Client.Framing.Impl
 
         IProtocol IConnection.Protocol => Endpoint.Protocol;
 
-        public void Close(ShutdownEventArgs reason) => Delegate.Close(reason);
-
         public RecoveryAwareModel CreateNonRecoveringModel()
         {
             ISession session = Delegate.CreateSession();
@@ -182,91 +180,14 @@ namespace RabbitMQ.Client.Framing.Impl
             _factory.Password = newSecret;
         }
 
-        ///<summary>API-side invocation of connection abort.</summary>
-        public void Abort()
-        {
-            ThrowIfDisposed();
-            StopRecoveryLoop();
-            if (_delegate.IsOpen)
-            {
-                _delegate.Abort();
-            }
-        }
-
-        ///<summary>API-side invocation of connection abort.</summary>
-        public void Abort(ushort reasonCode, string reasonText)
-        {
-            ThrowIfDisposed();
-            StopRecoveryLoop();
-            if (_delegate.IsOpen)
-            {
-                _delegate.Abort(reasonCode, reasonText);
-            }
-        }
-
-        ///<summary>API-side invocation of connection abort with timeout.</summary>
-        public void Abort(TimeSpan timeout)
-        {
-            ThrowIfDisposed();
-            StopRecoveryLoop();
-            if (_delegate.IsOpen)
-            {
-                _delegate.Abort(timeout);
-            }
-        }
-
-        ///<summary>API-side invocation of connection abort with timeout.</summary>
-        public void Abort(ushort reasonCode, string reasonText, TimeSpan timeout)
-        {
-            ThrowIfDisposed();
-            StopRecoveryLoop();
-            if (_delegate.IsOpen)
-            {
-                _delegate.Abort(reasonCode, reasonText, timeout);
-            }
-        }
-
-        ///<summary>API-side invocation of connection.close.</summary>
-        public void Close()
-        {
-            ThrowIfDisposed();
-            StopRecoveryLoop();
-            if (_delegate.IsOpen)
-            {
-                _delegate.Close();
-            }
-        }
-
-        ///<summary>API-side invocation of connection.close.</summary>
-        public void Close(ushort reasonCode, string reasonText)
-        {
-            ThrowIfDisposed();
-            StopRecoveryLoop();
-            if (_delegate.IsOpen)
-            {
-                _delegate.Close(reasonCode, reasonText);
-            }
-        }
-
         ///<summary>API-side invocation of connection.close with timeout.</summary>
-        public void Close(TimeSpan timeout)
+        public void Close(ushort reasonCode, string reasonText, TimeSpan timeout, bool abort)
         {
             ThrowIfDisposed();
             StopRecoveryLoop();
             if (_delegate.IsOpen)
             {
-                _delegate.Close(timeout);
-            }
-        }
-
-        ///<summary>API-side invocation of connection.close with timeout.</summary>
-        public void Close(ushort reasonCode, string reasonText, TimeSpan timeout)
-        {
-            ThrowIfDisposed();
-            StopRecoveryLoop();
-            if (_delegate.IsOpen)
-            {
-                _delegate.Close(reasonCode, reasonText, timeout);
+                _delegate.Close(reasonCode, reasonText, timeout, abort);
             }
         }
 
@@ -295,7 +216,7 @@ namespace RabbitMQ.Client.Framing.Impl
             {
                 try
                 {
-                    Abort();
+                    this.Abort();
                 }
                 catch (Exception)
                 {

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
@@ -161,19 +161,6 @@ namespace RabbitMQ.Client.Impl
             }
         }
 
-        public void Close(ShutdownEventArgs reason, bool abort)
-        {
-            ThrowIfDisposed();
-            try
-            {
-                _delegate.Close(reason, abort).GetAwaiter().GetResult();;
-            }
-            finally
-            {
-                _connection.DeleteRecordedChannel(this);
-            }
-        }
-
         public override string ToString() => Delegate.ToString();
 
         void IDisposable.Dispose() => Dispose(true);
@@ -187,7 +174,7 @@ namespace RabbitMQ.Client.Impl
 
             if (disposing)
             {
-                Abort();
+                this.Abort();
 
                 _connection = null;
                 _delegate = null;
@@ -566,32 +553,6 @@ namespace RabbitMQ.Client.Impl
         public uint _Private_QueueDelete(string queue, bool ifUnused, bool ifEmpty, bool nowait) => RecoveryAwareDelegate._Private_QueueDelete(queue, ifUnused, ifEmpty, nowait);
 
         public uint _Private_QueuePurge(string queue, bool nowait) => RecoveryAwareDelegate._Private_QueuePurge(queue, nowait);
-
-        public void Abort()
-        {
-            ThrowIfDisposed();
-            try
-            {
-                _delegate.Abort();
-            }
-            finally
-            {
-                _connection.DeleteRecordedChannel(this);
-            }
-        }
-
-        public void Abort(ushort replyCode, string replyText)
-        {
-            ThrowIfDisposed();
-            try
-            {
-                _delegate.Abort(replyCode, replyText);
-            }
-            finally
-            {
-                _connection.DeleteRecordedChannel(this);
-            }
-        }
 
         public void BasicAck(ulong deliveryTag,
             bool multiple) => Delegate.BasicAck(deliveryTag, multiple);

--- a/projects/RabbitMQ.Client/client/impl/ModelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ModelBase.cs
@@ -201,10 +201,10 @@ namespace RabbitMQ.Client.Impl
 
         public void Close(ushort replyCode, string replyText, bool abort)
         {
-            _ = Close(new ShutdownEventArgs(ShutdownInitiator.Application, replyCode, replyText), abort);
+            _ = CloseAsync(new ShutdownEventArgs(ShutdownInitiator.Application, replyCode, replyText), abort);
         }
 
-        private async Task Close(ShutdownEventArgs reason, bool abort)
+        private async Task CloseAsync(ShutdownEventArgs reason, bool abort)
         {
             var k = new ShutdownContinuation();
             ModelShutdown += k.OnConnectionShutdown;
@@ -1355,14 +1355,14 @@ namespace RabbitMQ.Client.Impl
                     return;
                 }
 
-                await Close(
+                await CloseAsync(
                     new ShutdownEventArgs(ShutdownInitiator.Application, Constants.ReplySuccess, "Nacks Received",
                         new IOException("nack received")),
                     false).ConfigureAwait(false);
             }
             catch (TaskCanceledException exception)
             {
-                await Close(new ShutdownEventArgs(ShutdownInitiator.Application,
+                await CloseAsync(new ShutdownEventArgs(ShutdownInitiator.Application,
                         Constants.ReplySuccess,
                         "Timed out waiting for acks",
                         exception),

--- a/projects/RabbitMQ.Client/client/impl/ModelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ModelBase.cs
@@ -795,11 +795,8 @@ namespace RabbitMQ.Client.Impl
         {
             if (m_connectionStartCell is null)
             {
-                var reason =
-                    new ShutdownEventArgs(ShutdownInitiator.Library,
-                        Constants.CommandInvalid,
-                        "Unexpected Connection.Start");
-                ((Connection)Session.Connection).Close(reason);
+                var reason = new ShutdownEventArgs(ShutdownInitiator.Library, Constants.CommandInvalid, "Unexpected Connection.Start");
+                Session.Connection.Close(reason, false, Timeout.InfiniteTimeSpan);
             }
             var details = new ConnectionStartDetails
             {

--- a/projects/RabbitMQ.Client/client/impl/ModelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ModelBase.cs
@@ -199,14 +199,12 @@ namespace RabbitMQ.Client.Impl
             _recoveryWrapper.Takeover(other._recoveryWrapper);
         }
 
-        public Task Close(ushort replyCode, string replyText, bool abort)
+        public void Close(ushort replyCode, string replyText, bool abort)
         {
-            return Close(new ShutdownEventArgs(ShutdownInitiator.Application,
-                replyCode, replyText),
-                abort);
+            _ = Close(new ShutdownEventArgs(ShutdownInitiator.Application, replyCode, replyText), abort);
         }
 
-        public async Task Close(ShutdownEventArgs reason, bool abort)
+        private async Task Close(ShutdownEventArgs reason, bool abort)
         {
             var k = new ShutdownContinuation();
             ModelShutdown += k.OnConnectionShutdown;
@@ -468,7 +466,7 @@ namespace RabbitMQ.Client.Impl
             if (disposing)
             {
                 // dispose managed resources
-                Abort();
+                this.Abort();
             }
 
             // dispose unmanaged resources
@@ -958,16 +956,6 @@ namespace RabbitMQ.Client.Impl
         public abstract uint _Private_QueuePurge(string queue,
             bool nowait);
 
-        public void Abort()
-        {
-            Abort(Constants.ReplySuccess, "Goodbye");
-        }
-
-        public void Abort(ushort replyCode, string replyText)
-        {
-            Close(replyCode, replyText, true);
-        }
-
         public abstract void BasicAck(ulong deliveryTag, bool multiple);
 
         public void BasicCancel(string consumerTag)
@@ -1137,16 +1125,6 @@ namespace RabbitMQ.Client.Impl
 
         public abstract void BasicReject(ulong deliveryTag,
             bool requeue);
-
-        public void Close()
-        {
-            Close(Constants.ReplySuccess, "Goodbye");
-        }
-
-        public void Close(ushort replyCode, string replyText)
-        {
-            Close(replyCode, replyText, false);
-        }
 
         public void ConfirmSelect()
         {

--- a/projects/Unit/APIApproval.Approve.verified.txt
+++ b/projects/Unit/APIApproval.Approve.verified.txt
@@ -325,18 +325,22 @@ namespace RabbitMQ.Client
         event System.EventHandler<RabbitMQ.Client.Events.ConsumerTagChangedAfterRecoveryEventArgs> ConsumerTagChangeAfterRecovery;
         event System.EventHandler<RabbitMQ.Client.Events.QueueNameChangedAfterRecoveryEventArgs> QueueNameChangeAfterRecovery;
         event System.EventHandler<System.EventArgs> RecoverySucceeded;
-        void Abort();
-        void Abort(System.TimeSpan timeout);
-        void Abort(ushort reasonCode, string reasonText);
-        void Abort(ushort reasonCode, string reasonText, System.TimeSpan timeout);
-        void Close();
-        void Close(System.TimeSpan timeout);
-        void Close(ushort reasonCode, string reasonText);
-        void Close(ushort reasonCode, string reasonText, System.TimeSpan timeout);
+        void Close(ushort reasonCode, string reasonText, System.TimeSpan timeout, bool abort);
         RabbitMQ.Client.IModel CreateModel();
         void HandleConnectionBlocked(string reason);
         void HandleConnectionUnblocked();
         void UpdateSecret(string newSecret, string reason);
+    }
+    public static class IConnectionExtensions
+    {
+        public static void Abort(this RabbitMQ.Client.IConnection connection) { }
+        public static void Abort(this RabbitMQ.Client.IConnection connection, System.TimeSpan timeout) { }
+        public static void Abort(this RabbitMQ.Client.IConnection connection, ushort reasonCode, string reasonText) { }
+        public static void Abort(this RabbitMQ.Client.IConnection connection, ushort reasonCode, string reasonText, System.TimeSpan timeout) { }
+        public static void Close(this RabbitMQ.Client.IConnection connection) { }
+        public static void Close(this RabbitMQ.Client.IConnection connection, System.TimeSpan timeout) { }
+        public static void Close(this RabbitMQ.Client.IConnection connection, ushort reasonCode, string reasonText) { }
+        public static void Close(this RabbitMQ.Client.IConnection connection, ushort reasonCode, string reasonText, System.TimeSpan timeout) { }
     }
     public interface IConnectionFactory
     {
@@ -386,8 +390,6 @@ namespace RabbitMQ.Client
         event System.EventHandler<RabbitMQ.Client.Events.CallbackExceptionEventArgs> CallbackException;
         event System.EventHandler<RabbitMQ.Client.Events.FlowControlEventArgs> FlowControl;
         event System.EventHandler<RabbitMQ.Client.ShutdownEventArgs> ModelShutdown;
-        void Abort();
-        void Abort(ushort replyCode, string replyText);
         void BasicAck(ulong deliveryTag, bool multiple);
         void BasicCancel(string consumerTag);
         void BasicCancelNoWait(string consumerTag);
@@ -400,8 +402,7 @@ namespace RabbitMQ.Client
         void BasicRecover(bool requeue);
         void BasicRecoverAsync(bool requeue);
         void BasicReject(ulong deliveryTag, bool requeue);
-        void Close();
-        void Close(ushort replyCode, string replyText);
+        void Close(ushort replyCode, string replyText, bool abort);
         void ConfirmSelect();
         uint ConsumerCount(string queue);
         RabbitMQ.Client.IBasicProperties CreateBasicProperties();
@@ -434,6 +435,8 @@ namespace RabbitMQ.Client
     }
     public static class IModelExtensions
     {
+        public static void Abort(this RabbitMQ.Client.IModel model) { }
+        public static void Abort(this RabbitMQ.Client.IModel model, ushort replyCode, string replyText) { }
         public static string BasicConsume(this RabbitMQ.Client.IModel model, string queue, bool autoAck, RabbitMQ.Client.IBasicConsumer consumer) { }
         public static string BasicConsume(this RabbitMQ.Client.IModel model, string queue, bool autoAck, string consumerTag, RabbitMQ.Client.IBasicConsumer consumer) { }
         public static string BasicConsume(this RabbitMQ.Client.IModel model, string queue, bool autoAck, string consumerTag, System.Collections.Generic.IDictionary<string, object> arguments, RabbitMQ.Client.IBasicConsumer consumer) { }
@@ -442,6 +445,8 @@ namespace RabbitMQ.Client
         public static void BasicPublish(this RabbitMQ.Client.IModel model, RabbitMQ.Client.CachedString exchange, RabbitMQ.Client.CachedString routingKey, RabbitMQ.Client.IBasicProperties basicProperties, System.ReadOnlyMemory<byte> body) { }
         public static void BasicPublish(this RabbitMQ.Client.IModel model, string exchange, string routingKey, RabbitMQ.Client.IBasicProperties basicProperties, System.ReadOnlyMemory<byte> body) { }
         public static void BasicPublish(this RabbitMQ.Client.IModel model, string exchange, string routingKey, bool mandatory = false, RabbitMQ.Client.IBasicProperties basicProperties = null, System.ReadOnlyMemory<byte> body = default) { }
+        public static void Close(this RabbitMQ.Client.IModel model) { }
+        public static void Close(this RabbitMQ.Client.IModel model, ushort replyCode, string replyText) { }
         public static void ExchangeBind(this RabbitMQ.Client.IModel model, string destination, string source, string routingKey, System.Collections.Generic.IDictionary<string, object> arguments = null) { }
         public static void ExchangeBindNoWait(this RabbitMQ.Client.IModel model, string destination, string source, string routingKey, System.Collections.Generic.IDictionary<string, object> arguments = null) { }
         public static void ExchangeDeclare(this RabbitMQ.Client.IModel model, string exchange, string type, bool durable = false, bool autoDelete = false, System.Collections.Generic.IDictionary<string, object> arguments = null) { }


### PR DESCRIPTION
## Proposed Changes

There are 3 close / abort functions in the public API. This forces a lot of similar implementations in AutorecoveryConnection. 
This PR removes all of them except one in the public API and replaces it with extension methods with the same parameters. (This means a recompile should be enough for customers, if they haven't mocked the interface itself)

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
