### PR TITLE
#1012 Fixed exception when consumer tag cannot be found in the consumers dictionary

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/ModelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ModelBase.cs
@@ -425,7 +425,7 @@ namespace RabbitMQ.Client.Impl
             SetCloseReason(reason);
             OnModelShutdown(reason);
             BroadcastShutdownToConsumers(_consumers, reason);
-            ConsumerDispatcher.Shutdown(this).GetAwaiter().GetResult();;
+            ConsumerDispatcher.Shutdown(this).GetAwaiter().GetResult(); ;
         }
 
         protected void BroadcastShutdownToConsumers(Dictionary<string, IBasicConsumer> cs, ShutdownEventArgs reason)
@@ -553,8 +553,10 @@ namespace RabbitMQ.Client.Impl
             IBasicConsumer consumer;
             lock (_consumers)
             {
-                consumer = _consumers[consumerTag];
-                _consumers.Remove(consumerTag);
+                if (_consumers.TryGetValue(consumerTag, out consumer))
+                {
+                    _consumers.Remove(consumerTag);
+                }
             }
             if (consumer is null)
             {
@@ -574,12 +576,24 @@ namespace RabbitMQ.Client.Impl
                             consumerTag
                             ));
             */
+            IBasicConsumer consumer;
+
             lock (_consumers)
             {
-                k.m_consumer = _consumers[consumerTag];
-                _consumers.Remove(consumerTag);
+                if (_consumers.TryGetValue(consumerTag, out consumer))
+                {
+                    k.m_consumer = consumer;
+                    _consumers.Remove(consumerTag);
+                }
             }
+
+            if (consumer == null)
+            {
+                k.m_consumer = DefaultConsumer;
+            }
+
             ConsumerDispatcher.HandleBasicCancelOk(k.m_consumer, consumerTag);
+
             k.HandleCommand(IncomingCommand.Empty); // release the continuation.
         }
 
@@ -608,7 +622,7 @@ namespace RabbitMQ.Client.Impl
             IBasicConsumer consumer;
             lock (_consumers)
             {
-                consumer = _consumers[consumerTag];
+                _consumers.TryGetValue(consumerTag, out consumer);
             }
             if (consumer is null)
             {


### PR DESCRIPTION
## Proposed Changes

Closes #1012.

In ModelBase.cs HandleBasicCancel function, if the consumerTag cannot be found in the _consumers dictionary, it throws an exception, and keeps retrying that function call.  

I changed the lookup in the _consumers dictionary to try and find the consumerTag.  If we can't find it, then we fall back to using a default consumer so that no exception is thrown.

I haven't isolated the original cause of this as to why the consumer entry is not in the dictionary.  In my environment, it happened after a timeout of the BasicCancel request, so there may be some relation to that.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
