### PR TITLE
Fix Semaphore Disposed Exception in AsyncConsumerWorkService

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/AsyncConsumerWorkService.cs
+++ b/projects/RabbitMQ.Client/client/impl/AsyncConsumerWorkService.cs
@@ -128,7 +128,7 @@ namespace RabbitMQ.Client.Impl
                 {
                     while (await _channel.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
                     {
-                        while (_channel.Reader.TryRead(out Work work))
+                        while (_channel.Reader.TryRead(out Work work) && !cancellationToken.IsCancellationRequested)
                         {
                             // Do a quick synchronous check before we resort to async/await with the state-machine overhead.
                             if (!_limiter.Wait(0))


### PR DESCRIPTION
## Proposed Changes

Fixes a `System.ObjectDisposedException` thrown when the `SemaphoreSlim` is Disposed on a `AsyncConsumerWorkService` with a Concurrency greater than 1.

#### Current State
When under load, the ChannelReader can return a Work item after the `_limiter` has been Disposed resulting in the Exception being thrown.
https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/d39bb71a0009784f1ebf64030bad404f067cee4d/projects/RabbitMQ.Client/client/impl/AsyncConsumerWorkService.cs#L131-L139

#### Proposed Fix
We check if the `cancellationToken` has been cancelled. If so, we avoid attempting to wait on the `_limiter` and will not see an Exception thrown.
https://github.com/ricado-group/rabbitmq-dotnet-client/blob/08854f1a83b3c4a1214f41518bbfa380ec673e1c/projects/RabbitMQ.Client/client/impl/AsyncConsumerWorkService.cs#L130-L139

## Types of Changes

- [X] Bug fix (non-breaking change which fixes issue #1014)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
