### PR TITLE
Framing benchmarks and optimizations

### DIFF
--- a/projects/Benchmarks/WireFormatting/MethodFraming.cs
+++ b/projects/Benchmarks/WireFormatting/MethodFraming.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Text;
+
+using BenchmarkDotNet.Attributes;
+
+using RabbitMQ.Client.Framing.Impl;
+using RabbitMQ.Client.Impl;
+
+namespace RabbitMQ.Benchmarks
+{
+    [Config(typeof(Config))]
+    [BenchmarkCategory("Framing")]
+    public class MethodFramingBasicAck
+    {
+        private readonly OutgoingCommand _basicAck = new OutgoingCommand(new BasicAck(ulong.MaxValue, true));
+
+        [Benchmark]
+        public ReadOnlyMemory<byte> BasicAckWrite() => _basicAck.SerializeToFrames(0, 1024 * 1024);
+    }
+
+    [Config(typeof(Config))]
+    [BenchmarkCategory("Framing")]
+    public class MethodFramingBasicPublish
+    {
+        private const string StringValue = "Exchange_OR_RoutingKey";
+        private readonly OutgoingContentCommand _basicPublish = new OutgoingContentCommand(new BasicPublish(StringValue, StringValue, false, false), new Client.Framing.BasicProperties(), ReadOnlyMemory<byte>.Empty);
+        private readonly OutgoingContentCommand _basicPublishMemory = new OutgoingContentCommand(new BasicPublishMemory(Encoding.UTF8.GetBytes(StringValue), Encoding.UTF8.GetBytes(StringValue), false, false), new Client.Framing.BasicProperties(), ReadOnlyMemory<byte>.Empty);
+
+        [Benchmark]
+        public ReadOnlyMemory<byte> BasicPublishWrite() => _basicPublish.SerializeToFrames(0, 1024 * 1024);
+
+        [Benchmark]
+        public ReadOnlyMemory<byte> BasicPublishMemoryWrite() => _basicPublishMemory.SerializeToFrames(0, 1024 * 1024);
+    }
+
+    [Config(typeof(Config))]
+    [BenchmarkCategory("Framing")]
+    public class MethodFramingChannelClose
+    {
+        private readonly OutgoingCommand _channelClose = new OutgoingCommand(new ChannelClose(333, string.Empty, 0099, 2999));
+
+        [Benchmark]
+        public ReadOnlyMemory<byte> ChannelCloseWrite() => _channelClose.SerializeToFrames(0, 1024 * 1024);
+    }
+}

--- a/projects/RabbitMQ.Client/client/impl/BasicPublishBatch.cs
+++ b/projects/RabbitMQ.Client/client/impl/BasicPublishBatch.cs
@@ -31,25 +31,26 @@
 
 using System;
 using System.Collections.Generic;
+
 using RabbitMQ.Client.Framing.Impl;
 
 namespace RabbitMQ.Client.Impl
 {
     internal sealed class BasicPublishBatch : IBasicPublishBatch
     {
-        private readonly List<OutgoingCommand> _commands;
+        private readonly List<OutgoingContentCommand> _commands;
         private readonly ModelBase _model;
 
-        internal BasicPublishBatch (ModelBase model)
+        internal BasicPublishBatch(ModelBase model)
         {
             _model = model;
-            _commands = new List<OutgoingCommand>();
+            _commands = new List<OutgoingContentCommand>();
         }
 
-        internal BasicPublishBatch (ModelBase model, int sizeHint)
+        internal BasicPublishBatch(ModelBase model, int sizeHint)
         {
             _model = model;
-            _commands = new List<OutgoingCommand>(sizeHint);
+            _commands = new List<OutgoingContentCommand>(sizeHint);
         }
 
         public void Add(string exchange, string routingKey, bool mandatory, IBasicProperties basicProperties, ReadOnlyMemory<byte> body)
@@ -60,13 +61,13 @@ namespace RabbitMQ.Client.Impl
                 _routingKey = routingKey,
                 _mandatory = mandatory
             };
-            _commands.Add(new OutgoingCommand(method, (ContentHeaderBase)(basicProperties ?? _model._emptyBasicProperties), body));
+            _commands.Add(new OutgoingContentCommand(method, (ContentHeaderBase)(basicProperties ?? _model._emptyBasicProperties), body));
         }
 
         public void Add(CachedString exchange, CachedString routingKey, bool mandatory, IBasicProperties basicProperties, ReadOnlyMemory<byte> body)
         {
             var method = new BasicPublishMemory(exchange.Bytes, routingKey.Bytes, mandatory, default);
-            _commands.Add(new OutgoingCommand(method, (ContentHeaderBase)(basicProperties ?? _model._emptyBasicProperties), body));
+            _commands.Add(new OutgoingContentCommand(method, (ContentHeaderBase)(basicProperties ?? _model._emptyBasicProperties), body));
         }
 
         public void Publish()

--- a/projects/RabbitMQ.Client/client/impl/ISession.cs
+++ b/projects/RabbitMQ.Client/client/impl/ISession.cs
@@ -31,6 +31,7 @@
 
 using System;
 using System.Collections.Generic;
+
 using RabbitMQ.Client.Framing.Impl;
 
 namespace RabbitMQ.Client.Impl
@@ -73,8 +74,7 @@ namespace RabbitMQ.Client.Impl
         void Close(ShutdownEventArgs reason, bool notify);
         bool HandleFrame(in InboundFrame frame);
         void Notify();
-        void Transmit(in OutgoingCommand cmd);
-        void Transmit(IList<OutgoingCommand> cmds);
-
+        void Transmit<T>(in T cmd) where T : struct, IOutgoingCommand;
+        void Transmit<T>(List<T> cmds) where T : struct, IOutgoingCommand;
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/MainSession.cs
+++ b/projects/RabbitMQ.Client/client/impl/MainSession.cs
@@ -35,6 +35,7 @@
 // that ever changes.
 
 using System;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Framing.Impl;
 
@@ -108,7 +109,7 @@ namespace RabbitMQ.Client.Impl
             }
         }
 
-        public override void Transmit(in OutgoingCommand cmd)
+        public override void Transmit<T>(in T cmd)
         {
             lock (_closingLock)
             {

--- a/projects/RabbitMQ.Client/client/impl/OutgoingCommand.cs
+++ b/projects/RabbitMQ.Client/client/impl/OutgoingCommand.cs
@@ -59,10 +59,7 @@ namespace RabbitMQ.Client.Impl
             // Will be returned by SocketFrameWriter.WriteLoop
             byte[] rentedArray = ArrayPool<byte>.Shared.Rent(size);
             int offset = Framing.Method.WriteTo(rentedArray, channelNumber, Method);
-#if DEBUG
             System.Diagnostics.Debug.Assert(offset == size, $"Serialized to wrong size, expect {size}, offset {offset}");
-#endif
-
             return new ReadOnlyMemory<byte>(rentedArray, 0, size);
         }
     }
@@ -106,10 +103,7 @@ namespace RabbitMQ.Client.Impl
                 }
             }
 
-#if DEBUG
             System.Diagnostics.Debug.Assert(offset == size, $"Serialized to wrong size, expect {size}, offset {offset}");
-#endif
-
             return new ReadOnlyMemory<byte>(rentedArray, 0, size);
         }
     }

--- a/projects/RabbitMQ.Client/client/impl/SessionBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/SessionBase.cs
@@ -32,6 +32,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+
 using RabbitMQ.Client.Exceptions;
 using RabbitMQ.Client.Framing.Impl;
 
@@ -124,7 +125,7 @@ namespace RabbitMQ.Client.Impl
             throw new Exception("Internal Error in Session.Close");
         }
 
-        public virtual void Transmit(in OutgoingCommand cmd)
+        public virtual void Transmit<T>(in T cmd) where T : struct, IOutgoingCommand
         {
             if (CloseReason != null)
             {
@@ -135,14 +136,15 @@ namespace RabbitMQ.Client.Impl
             }
             // We used to transmit *inside* the lock to avoid interleaving
             // of frames within a channel.  But that is fixed in socket frame handler instead, so no need to lock.
-            cmd.Transmit(ChannelNumber, Connection);
+            Connection.Write(cmd.SerializeToFrames(ChannelNumber, Connection.FrameMax));
         }
 
-        public virtual void Transmit(IList<OutgoingCommand> cmds)
+        public virtual void Transmit<T>(List<T> cmds) where T : struct, IOutgoingCommand
         {
+            uint frameMax = Connection.FrameMax;
             for (int i = 0; i < cmds.Count; i++)
             {
-                cmds[i].Transmit(ChannelNumber, Connection);
+                Connection.Write(cmds[i].SerializeToFrames(ChannelNumber, frameMax));
             }
         }
     }


### PR DESCRIPTION
## Proposed Changes

Added benchmarks for frame generation and added optimizations which should benefit all commands sent from the clients.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Main optimizations were done by reducing method calls, adding inlining and reducing code branches. There is definitely room for more improvements, but this is a pretty solid start :)

Benchmark results for serializing `BasicAck`, `BasicDeliver` and `ChannelClose` to their actual frames:
``` ini
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.21277
Intel Core i7-10700 CPU 2.90GHz, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=5.0.103
  [Host]     : .NET Core 3.1.12 (CoreCLR 4.700.21.6504, CoreFX 4.700.21.6905), X64 RyuJIT
  .NET 4.8 = .NET Framework 4.8 (4.8.4261.0), X64 RyuJIT
  Core 3.1 = .NET Core 3.1.12 (CoreCLR 4.700.21.6504, CoreFX 4.700.21.6905), X64 RyuJIT
```

**Before**
|                  Method |  Runtime |      Mean |    Error |   StdDev | Code Size |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------ |--------- |----------:|---------:|---------:|----------:|-------:|------:|------:|----------:|
|       ChannelCloseWrite | .NET 4.8 |  82.41 ns | 0.699 ns | 0.653 ns |    1817 B | 0.0088 |     - |     - |      56 B |
|       ChannelCloseWrite | Core 3.1 |  31.48 ns | 0.350 ns | 0.327 ns |    1117 B | 0.0067 |     - |     - |      56 B |
|       BasicPublishWrite | .NET 4.8 | 225.96 ns | 0.905 ns | 0.755 ns |    1817 B | 0.0241 |     - |     - |     152 B |
|       BasicPublishWrite | Core 3.1 | 116.96 ns | 0.684 ns | 0.640 ns |    1117 B | 0.0181 |     - |     - |     152 B |
| BasicPublishMemoryWrite | .NET 4.8 | 162.78 ns | 1.383 ns | 1.226 ns |    1817 B | 0.0241 |     - |     - |     152 B |
| BasicPublishMemoryWrite | Core 3.1 |  71.53 ns | 0.239 ns | 0.200 ns |    1117 B | 0.0181 |     - |     - |     152 B |
|           BasicAckWrite | .NET 4.8 |  70.30 ns | 0.504 ns | 0.472 ns |    1817 B | 0.0088 |     - |     - |      56 B |
|           BasicAckWrite | Core 3.1 |  27.09 ns | 0.508 ns | 0.450 ns |    1117 B | 0.0067 |     - |     - |      56 B |

**After:**
|                  Method |  Runtime |      Mean |   Diff |    Error |   StdDev | Code Size |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------ |--------- |----------:|-------:|---------:|---------:|----------:|-------:|------:|------:|----------:|
|       ChannelCloseWrite | .NET 4.8 |  69.72 ns | -15,4% | 0.440 ns | 0.411 ns |     759 B | 0.0088 |     - |     - |      56 B |
|       ChannelCloseWrite | Core 3.1 |  23.36 ns | -25,8% | 0.482 ns | 0.691 ns |    1195 B | 0.0067 |     - |     - |      56 B |
|       BasicPublishWrite | .NET 4.8 | 200.58 ns | -11,2% | 0.687 ns | 0.574 ns |    2814 B | 0.0241 |     - |     - |     152 B |
|       BasicPublishWrite | Core 3.1 |  98.16 ns | -16,1% | 0.381 ns | 0.356 ns |    2438 B | 0.0181 |     - |     - |     152 B |
| BasicPublishMemoryWrite | .NET 4.8 | 133.69 ns | -17,9% | 0.336 ns | 0.314 ns |    2942 B | 0.0241 |     - |     - |     152 B |
| BasicPublishMemoryWrite | Core 3.1 |  55.57 ns | -22,3% | 0.503 ns | 0.470 ns |    2438 B | 0.0181 |     - |     - |     152 B |
|           BasicAckWrite | .NET 4.8 |  58.54 ns | -16,7% | 0.245 ns | 0.229 ns |     759 B | 0.0089 |     - |     - |      56 B |
|           BasicAckWrite | Core 3.1 |  18.06 ns | -33.3% | 0.381 ns | 0.558 ns |    1195 B | 0.0067 |     - |     - |      56 B |
