### PR TITLE
Optimizing (de)serialization bounds-checks

### DIFF
--- a/projects/Benchmarks/WireFormatting/DataTypeSerialization.cs
+++ b/projects/Benchmarks/WireFormatting/DataTypeSerialization.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Text;
 
 using BenchmarkDotNet.Attributes;
 
@@ -38,48 +36,48 @@ namespace RabbitMQ.Benchmarks
 
         public override void SetUp()
         {
-            _fieldNullBuffer = new byte[WireFormatting.GetFieldValueByteCount(null)];
-            WireFormatting.WriteFieldValue(_fieldNullBuffer.Span, null);
+            _fieldNullBuffer = new byte[WireFormatting.GetFieldValueByteCount((object)null)];
+            WireFormatting.WriteFieldValue(_fieldNullBuffer.Span, 0, null);
             _fieldIntBuffer = new byte[WireFormatting.GetFieldValueByteCount(_intObject)];
-            WireFormatting.WriteFieldValue(_fieldIntBuffer.Span, _intObject);
+            WireFormatting.WriteFieldValue(_fieldIntBuffer.Span, 0, _intObject);
             _fieldStringBuffer = new byte[WireFormatting.GetFieldValueByteCount(_shortString)];
-            WireFormatting.WriteFieldValue(_fieldStringBuffer.Span, _shortString);
+            WireFormatting.WriteFieldValue(_fieldStringBuffer.Span, 0, _shortString);
             _fieldArrayBuffer = new byte[WireFormatting.GetFieldValueByteCount(_byteArray)];
-            WireFormatting.WriteFieldValue(_fieldArrayBuffer.Span, _byteArray);
+            WireFormatting.WriteFieldValue(_fieldArrayBuffer.Span, 0, _byteArray);
             _fieldDictBuffer = new byte[WireFormatting.GetFieldValueByteCount(_emptyDictionary)];
-            WireFormatting.WriteFieldValue(_fieldDictBuffer.Span, _emptyDictionary);
+            WireFormatting.WriteFieldValue(_fieldDictBuffer.Span, 0, _emptyDictionary);
             _fieldBinaryTableValueBuffer = new byte[WireFormatting.GetFieldValueByteCount(_binaryTableValue)];
-            WireFormatting.WriteFieldValue(_fieldBinaryTableValueBuffer.Span, _binaryTableValue);
+            WireFormatting.WriteFieldValue(_fieldBinaryTableValueBuffer.Span, 0, _binaryTableValue);
         }
 
         [Benchmark]
-        public object NullRead() => WireFormatting.ReadFieldValue(_fieldNullBuffer.Span, out int _);
+        public object NullRead() => WireFormatting.ReadFieldValue(_fieldNullBuffer.Span, 0, out int _);
         [Benchmark]
-        public object IntRead() => WireFormatting.ReadFieldValue(_fieldIntBuffer.Span, out int _);
+        public object IntRead() => WireFormatting.ReadFieldValue(_fieldIntBuffer.Span, 0, out int _);
         [Benchmark]
-        public object StringRead() => WireFormatting.ReadFieldValue(_fieldStringBuffer.Span, out int _);
+        public object StringRead() => WireFormatting.ReadFieldValue(_fieldStringBuffer.Span, 0, out int _);
         [Benchmark]
-        public object ArrayRead() => WireFormatting.ReadFieldValue(_fieldArrayBuffer.Span, out int _);
+        public object ArrayRead() => WireFormatting.ReadFieldValue(_fieldArrayBuffer.Span, 0, out int _);
         [Benchmark]
-        public object DictRead() => WireFormatting.ReadFieldValue(_fieldDictBuffer.Span, out int _);
+        public object DictRead() => WireFormatting.ReadFieldValue(_fieldDictBuffer.Span, 0, out int _);
         [Benchmark]
-        public object BinaryTableValueRead() => WireFormatting.ReadFieldValue(_fieldBinaryTableValueBuffer.Span, out int _);
+        public object BinaryTableValueRead() => WireFormatting.ReadFieldValue(_fieldBinaryTableValueBuffer.Span, 0, out int _);
 
         [Benchmark]
-        public int NullWrite() => WireFormatting.WriteFieldValue(_buffer.Span,null);
+        public int NullWrite() => WireFormatting.WriteFieldValue(_buffer.Span, 0, null);
         [Benchmark]
-        public int IntWrite() => WireFormatting.WriteFieldValue(_buffer.Span, _intObject);
+        public int IntWrite() => WireFormatting.WriteFieldValue(_buffer.Span, 0, _intObject);
         [Benchmark]
-        public int StringWrite() => WireFormatting.WriteFieldValue(_buffer.Span, _shortString);
+        public int StringWrite() => WireFormatting.WriteFieldValue(_buffer.Span, 0, _shortString);
         [Benchmark]
-        public int ArrayWrite() => WireFormatting.WriteFieldValue(_buffer.Span, _byteArray);
+        public int ArrayWrite() => WireFormatting.WriteFieldValue(_buffer.Span, 0, _byteArray);
         [Benchmark]
-        public int DictWrite() => WireFormatting.WriteFieldValue(_buffer.Span, _emptyDictionary);
+        public int DictWrite() => WireFormatting.WriteFieldValue(_buffer.Span, 0, _emptyDictionary);
         [Benchmark]
-        public int BinaryTableValueWrite() => WireFormatting.WriteFieldValue(_buffer.Span, _binaryTableValue);
+        public int BinaryTableValueWrite() => WireFormatting.WriteFieldValue(_buffer.Span, 0, _binaryTableValue);
 
         [Benchmark]
-        public int NullGetSize() => WireFormatting.GetFieldValueByteCount(null);
+        public int NullGetSize() => WireFormatting.GetFieldValueByteCount((object)null);
         [Benchmark]
         public int IntGetSize() => WireFormatting.GetFieldValueByteCount(_intObject);
         [Benchmark]
@@ -103,23 +101,23 @@ namespace RabbitMQ.Benchmarks
         {
             _array = new List<object> { "longstring", 1234, 12.34m, _timestamp };
             _emptyArrayBuffer = new byte[WireFormatting.GetArrayByteCount(_emptyArray)];
-            WireFormatting.WriteArray(_emptyArrayBuffer.Span, _emptyArray);
+            WireFormatting.WriteArray(_emptyArrayBuffer.Span, 0, _emptyArray);
 
             _populatedArrayBuffer = new byte[WireFormatting.GetArrayByteCount(_array)];
-            WireFormatting.WriteArray(_populatedArrayBuffer.Span, _array);
+            WireFormatting.WriteArray(_populatedArrayBuffer.Span, 0, _array);
         }
 
         [Benchmark]
-        public IList ArrayReadEmpty() => WireFormatting.ReadArray(_emptyArrayBuffer.Span, out _);
+        public int ArrayReadEmpty() => WireFormatting.ReadArray(_emptyArrayBuffer.Span, 0, out _);
 
         [Benchmark]
-        public IList ArrayReadPopulated() => WireFormatting.ReadArray(_populatedArrayBuffer.Span, out _);
+        public int ArrayReadPopulated() => WireFormatting.ReadArray(_populatedArrayBuffer.Span, 0, out _);
 
         [Benchmark]
-        public int ArrayWriteEmpty() => WireFormatting.WriteArray(_buffer.Span, _emptyArray);
+        public int ArrayWriteEmpty() => WireFormatting.WriteArray(_buffer.Span, 0, _emptyArray);
 
         [Benchmark]
-        public int ArrayWritePopulated() => WireFormatting.WriteArray(_buffer.Span, _array);
+        public int ArrayWritePopulated() => WireFormatting.WriteArray(_buffer.Span, 0, _array);
 
         [Benchmark]
         public int ArrayGetSizeEmpty() => WireFormatting.GetArrayByteCount(_emptyArray);
@@ -149,23 +147,23 @@ namespace RabbitMQ.Benchmarks
             };
 
             _emptyDictionaryBuffer = new byte[WireFormatting.GetTableByteCount(_emptyDict)];
-            WireFormatting.WriteTable(_emptyDictionaryBuffer.Span, _emptyDict);
+            WireFormatting.WriteTable(_emptyDictionaryBuffer.Span, 0, _emptyDict);
 
             _populatedDictionaryBuffer = new byte[WireFormatting.GetTableByteCount(_populatedDict)];
-            WireFormatting.WriteTable(_populatedDictionaryBuffer.Span, _populatedDict);
+            WireFormatting.WriteTable(_populatedDictionaryBuffer.Span, 0, _populatedDict);
         }
 
         [Benchmark]
-        public int TableReadEmpty() => WireFormatting.ReadDictionary(_emptyDictionaryBuffer.Span, out _);
+        public int TableReadEmpty() => WireFormatting.ReadDictionary(_emptyDictionaryBuffer.Span, 0, out _);
 
         [Benchmark]
-        public int TableReadPopulated() => WireFormatting.ReadDictionary(_populatedDictionaryBuffer.Span, out _);
+        public int TableReadPopulated() => WireFormatting.ReadDictionary(_populatedDictionaryBuffer.Span, 0, out _);
 
         [Benchmark]
-        public int TableWriteEmpty() => WireFormatting.WriteTable(_buffer.Span, _emptyDict);
+        public int TableWriteEmpty() => WireFormatting.WriteTable(_buffer.Span, 0, _emptyDict);
 
         [Benchmark]
-        public int TableWritePopulated() => WireFormatting.WriteTable(_buffer.Span, _populatedDict);
+        public int TableWritePopulated() => WireFormatting.WriteTable(_buffer.Span, 0, _populatedDict);
 
         [Benchmark]
         public int TableGetSizeEmpty() => WireFormatting.GetTableByteCount(_emptyDict);
@@ -181,27 +179,27 @@ namespace RabbitMQ.Benchmarks
         private readonly Memory<byte> _populatedLongStringBuffer = GenerateLongStringBuffer(new string('X', 4096));
 
         [Benchmark]
-        public int LongstrReadEmpty() => WireFormatting.ReadLongstr(_emptyLongStringBuffer.Span, out _);
+        public int LongstrReadEmpty() => WireFormatting.ReadLongstr(_emptyLongStringBuffer.Span, 0, out _);
 
         [Benchmark]
-        public int LongstrReadPopulated() => WireFormatting.ReadLongstr(_populatedLongStringBuffer.Span, out _);
+        public int LongstrReadPopulated() => WireFormatting.ReadLongstr(_populatedLongStringBuffer.Span, 0, out _);
 
         [Benchmark]
-        public int LongstrWriteEmpty() => WireFormatting.WriteLongstr(_buffer.Span, string.Empty);
+        public int LongstrWriteEmpty() => WireFormatting.WriteLongstr(_buffer.Span, 0, string.Empty);
 
         [Benchmark]
-        public int LongstrWritePopulated() => WireFormatting.WriteLongstr(_buffer.Span, _longString);
+        public int LongstrWritePopulated() => WireFormatting.WriteLongstr(_buffer.Span, 0, _longString);
 
         [Benchmark]
-        public int LongstrGetSizeEmpty() => WireFormatting.GetFieldValueByteCount(string.Empty);
+        public int LongstrGetSizeEmpty() => WireFormatting.GetLongstrByteCount(string.Empty);
 
         [Benchmark]
-        public int LongstrGetSizePopulated() => WireFormatting.GetFieldValueByteCount(_longString);
+        public int LongstrGetSizePopulated() => WireFormatting.GetLongstrByteCount(_longString);
 
         private static byte[] GenerateLongStringBuffer(string val)
         {
-            byte[] _buffer = new byte[5 + Encoding.UTF8.GetByteCount(val)];
-            WireFormatting.WriteLongstr(_buffer, val);
+            byte[] _buffer = new byte[WireFormatting.GetLongstrByteCount(val)];
+            WireFormatting.WriteLongstr(_buffer, 0, val);
             return _buffer;
         }
     }
@@ -213,27 +211,27 @@ namespace RabbitMQ.Benchmarks
         private readonly Memory<byte> _populatedShortStringBuffer = GenerateStringBuffer(new string('X', 255));
 
         [Benchmark]
-        public int ShortstrReadEmpty() => WireFormatting.ReadShortstr(_emptyShortStringBuffer.Span, out _);
+        public int ShortstrReadEmpty() => WireFormatting.ReadShortstr(_emptyShortStringBuffer.Span, 0, out _);
 
         [Benchmark]
-        public int ShortstrReadPopulated() => WireFormatting.ReadShortstr(_populatedShortStringBuffer.Span, out _);
+        public int ShortstrReadPopulated() => WireFormatting.ReadShortstr(_populatedShortStringBuffer.Span, 0, out _);
 
         [Benchmark]
-        public int ShortstrWriteEmpty() => WireFormatting.WriteShortstr(_buffer.Span, string.Empty);
+        public int ShortstrWriteEmpty() => WireFormatting.WriteShortstr(_buffer.Span, 0, string.Empty);
 
         [Benchmark]
-        public int ShortstrWritePopulated() => WireFormatting.WriteShortstr(_buffer.Span, _shortString);
+        public int ShortstrWritePopulated() => WireFormatting.WriteShortstr(_buffer.Span, 0, _shortString);
 
         [Benchmark]
-        public int ShortstrGetSizeEmpty() => WireFormatting.GetByteCount(string.Empty);
+        public int ShortstrGetSizeEmpty() => WireFormatting.GetShortstrByteCount(string.Empty);
 
         [Benchmark]
-        public int ShortstrGetSizePopulated() => WireFormatting.GetByteCount(_shortString);
+        public int ShortstrGetSizePopulated() => WireFormatting.GetShortstrByteCount(_shortString);
 
         private static byte[] GenerateStringBuffer(string val)
         {
-            byte[] _buffer = new byte[2 + Encoding.UTF8.GetByteCount(val)];
-            WireFormatting.WriteShortstr(_buffer, val);
+            byte[] _buffer = new byte[WireFormatting.GetShortstrByteCount(val)];
+            WireFormatting.WriteShortstr(_buffer, 0, val);
             return _buffer;
         }
     }

--- a/projects/Benchmarks/WireFormatting/MethodFraming.cs
+++ b/projects/Benchmarks/WireFormatting/MethodFraming.cs
@@ -12,10 +12,10 @@ namespace RabbitMQ.Benchmarks
     [BenchmarkCategory("Framing")]
     public class MethodFramingBasicAck
     {
-        private readonly OutgoingCommand _basicAck = new OutgoingCommand(new BasicAck(ulong.MaxValue, true));
+        private readonly BasicAck _basicAck = new BasicAck(ulong.MaxValue, true);
 
         [Benchmark]
-        public ReadOnlyMemory<byte> BasicAckWrite() => _basicAck.SerializeToFrames(0, 1024 * 1024);
+        public ReadOnlyMemory<byte> BasicAckWrite() => _basicAck.SerializeToFrames(0);
     }
 
     [Config(typeof(Config))]
@@ -23,23 +23,24 @@ namespace RabbitMQ.Benchmarks
     public class MethodFramingBasicPublish
     {
         private const string StringValue = "Exchange_OR_RoutingKey";
-        private readonly OutgoingContentCommand _basicPublish = new OutgoingContentCommand(new BasicPublish(StringValue, StringValue, false, false), new Client.Framing.BasicProperties(), ReadOnlyMemory<byte>.Empty);
-        private readonly OutgoingContentCommand _basicPublishMemory = new OutgoingContentCommand(new BasicPublishMemory(Encoding.UTF8.GetBytes(StringValue), Encoding.UTF8.GetBytes(StringValue), false, false), new Client.Framing.BasicProperties(), ReadOnlyMemory<byte>.Empty);
+        private readonly Client.Framing.BasicProperties _header = new Client.Framing.BasicProperties();
+        private readonly BasicPublish _basicPublish = new BasicPublish(StringValue, StringValue, false, false);
+        private readonly BasicPublishMemory _basicPublishMemory = new BasicPublishMemory(Encoding.UTF8.GetBytes(StringValue), Encoding.UTF8.GetBytes(StringValue), false, false);
 
         [Benchmark]
-        public ReadOnlyMemory<byte> BasicPublishWrite() => _basicPublish.SerializeToFrames(0, 1024 * 1024);
+        public ReadOnlyMemory<byte> BasicPublishWrite() => _basicPublish.SerializeToFrames(_header, ReadOnlyMemory<byte>.Empty, 0, 1024 * 1024);
 
         [Benchmark]
-        public ReadOnlyMemory<byte> BasicPublishMemoryWrite() => _basicPublishMemory.SerializeToFrames(0, 1024 * 1024);
+        public ReadOnlyMemory<byte> BasicPublishMemoryWrite() => _basicPublishMemory.SerializeToFrames(_header, ReadOnlyMemory<byte>.Empty, 0, 1024 * 1024);
     }
 
     [Config(typeof(Config))]
     [BenchmarkCategory("Framing")]
     public class MethodFramingChannelClose
     {
-        private readonly OutgoingCommand _channelClose = new OutgoingCommand(new ChannelClose(333, string.Empty, 0099, 2999));
+        private readonly ChannelClose _channelClose = new ChannelClose(333, string.Empty, 0099, 2999);
 
         [Benchmark]
-        public ReadOnlyMemory<byte> ChannelCloseWrite() => _channelClose.SerializeToFrames(0, 1024 * 1024);
+        public ReadOnlyMemory<byte> ChannelCloseWrite() => _channelClose.SerializeToFrames(0);
     }
 }

--- a/projects/Benchmarks/WireFormatting/MethodSerialization.cs
+++ b/projects/Benchmarks/WireFormatting/MethodSerialization.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+
 using BenchmarkDotNet.Attributes;
 
 using RabbitMQ.Client.Framing;
@@ -37,11 +38,11 @@ namespace RabbitMQ.Benchmarks
 
         public override void SetUp()
         {
-            int offset = RabbitMQ.Client.Impl.WireFormatting.WriteShortstr(_buffer.Span, string.Empty);
-            offset += RabbitMQ.Client.Impl.WireFormatting.WriteLonglong(_buffer.Slice(offset).Span, 0);
-            offset += RabbitMQ.Client.Impl.WireFormatting.WriteBits(_buffer.Slice(offset).Span, false);
-            offset += RabbitMQ.Client.Impl.WireFormatting.WriteShortstr(_buffer.Slice(offset).Span, string.Empty);
-            RabbitMQ.Client.Impl.WireFormatting.WriteShortstr(_buffer.Slice(offset).Span, string.Empty);
+            int offset = RabbitMQ.Client.Impl.WireFormatting.WriteShortstr(_buffer.Span, 0, string.Empty);
+            offset += RabbitMQ.Client.Impl.WireFormatting.WriteLonglong(_buffer.Span, offset, 0);
+            offset += RabbitMQ.Client.Impl.WireFormatting.WriteBits(ref _buffer.Span[offset], false);
+            offset += RabbitMQ.Client.Impl.WireFormatting.WriteShortstr(_buffer.Span, offset, string.Empty);
+            RabbitMQ.Client.Impl.WireFormatting.WriteShortstr(_buffer.Span, offset, string.Empty);
         }
 
         [Benchmark]

--- a/projects/Benchmarks/WireFormatting/PrimitivesSerialization.cs
+++ b/projects/Benchmarks/WireFormatting/PrimitivesSerialization.cs
@@ -19,80 +19,80 @@ namespace RabbitMQ.Benchmarks
 
     public class PrimitivesBool : PrimitivesBase
     {
-        public override void Setup() => WireFormatting.WriteBits(_buffer.Span, true, false, true, false, true);
+        public override void Setup() => WireFormatting.WriteBits(ref _buffer.Span[0], true, false, true, false, true);
 
         [Benchmark]
-        public int BoolRead2() => WireFormatting.ReadBits(_buffer.Span, out bool _, out bool _);
+        public int BoolRead2() => WireFormatting.ReadBits(_buffer.Span, 0, out bool _, out bool _);
 
         [Benchmark]
-        public int BoolRead5() => WireFormatting.ReadBits(_buffer.Span, out bool _, out bool _, out bool _, out bool _, out bool _);
-
-        [Benchmark]
-        [Arguments(true, false)]
-        public int BoolWrite2(bool param1, bool param2) => WireFormatting.WriteBits(_buffer.Span, param1, param2);
+        public int BoolRead5() => WireFormatting.ReadBits(_buffer.Span, 0, out bool _, out bool _, out bool _, out bool _, out bool _);
 
         [Benchmark]
         [Arguments(true, false)]
-        public int BoolWrite5(bool param1, bool param2) => WireFormatting.WriteBits(_buffer.Span, param1, param2, param1, param2, param1);
+        public int BoolWrite2(bool param1, bool param2) => WireFormatting.WriteBits(ref _buffer.Span[0], param1, param2);
+
+        [Benchmark]
+        [Arguments(true, false)]
+        public int BoolWrite5(bool param1, bool param2) => WireFormatting.WriteBits(ref _buffer.Span[0], param1, param2, param1, param2, param1);
     }
 
     public class PrimitivesDecimal : PrimitivesBase
     {
-        public override void Setup() => WireFormatting.WriteDecimal(_buffer.Span, 123.45m);
+        public override void Setup() => WireFormatting.WriteDecimal(_buffer.Span, 0, 123.45m);
 
         [Benchmark]
-        public decimal DecimalRead() => WireFormatting.ReadDecimal(_buffer.Span);
+        public decimal DecimalRead() => WireFormatting.ReadDecimal(_buffer.Span, 0);
 
         [Benchmark]
-        public int DecimalWrite() => WireFormatting.WriteDecimal(_buffer.Span, 123.45m);
+        public int DecimalWrite() => WireFormatting.WriteDecimal(_buffer.Span, 0, 123.45m);
     }
 
     public class PrimitivesLong : PrimitivesBase
     {
-        public override void Setup() => WireFormatting.WriteLong(_buffer.Span, 12345u);
+        public override void Setup() => WireFormatting.WriteLong(_buffer.Span, 0, 12345u);
 
         [Benchmark]
-        public int LongRead() => WireFormatting.ReadLong(_buffer.Span, out _);
+        public int LongRead() => WireFormatting.ReadLong(_buffer.Span, 0, out _);
 
         [Benchmark]
         [Arguments(12345u)]
-        public int LongWrite(uint value) => WireFormatting.WriteLong(_buffer.Span, value);
+        public int LongWrite(uint value) => WireFormatting.WriteLong(_buffer.Span, 0, value);
     }
 
     public class PrimitivesLonglong : PrimitivesBase
     {
-        public override void Setup() => WireFormatting.WriteLonglong(_buffer.Span, 12345ul);
+        public override void Setup() => WireFormatting.WriteLonglong(_buffer.Span, 0, 12345ul);
 
         [Benchmark]
-        public int LonglongRead() => WireFormatting.ReadLonglong(_buffer.Span, out _);
+        public int LonglongRead() => WireFormatting.ReadLonglong(_buffer.Span, 0, out _);
 
         [Benchmark]
         [Arguments(12345ul)]
-        public int LonglongWrite(ulong value) => WireFormatting.WriteLonglong(_buffer.Span, value);
+        public int LonglongWrite(ulong value) => WireFormatting.WriteLonglong(_buffer.Span, 0, value);
     }
 
     public class PrimitivesShort : PrimitivesBase
     {
-        public override void Setup() => WireFormatting.WriteShort(_buffer.Span, 12345);
+        public override void Setup() => WireFormatting.WriteShort(_buffer.Span, 0, 12345);
 
         [Benchmark]
-        public int ShortRead() => WireFormatting.ReadShort(_buffer.Span, out _);
+        public int ShortRead() => WireFormatting.ReadShort(_buffer.Span, 0, out _);
 
         [Benchmark]
         [Arguments(12345)]
-        public int ShortWrite(ushort value) => WireFormatting.WriteShort(_buffer.Span, value);
+        public int ShortWrite(ushort value) => WireFormatting.WriteShort(_buffer.Span, 0, value);
     }
 
     public class PrimitivesTimestamp : PrimitivesBase
     {
         AmqpTimestamp _timestamp = new AmqpTimestamp(DateTimeOffset.UtcNow.ToUnixTimeSeconds());
 
-        public override void Setup() => WireFormatting.WriteTimestamp(_buffer.Span, _timestamp);
+        public override void Setup() => WireFormatting.WriteTimestamp(_buffer.Span, 0, _timestamp);
 
         [Benchmark]
-        public int TimestampRead() => WireFormatting.ReadTimestamp(_buffer.Span, out _);
+        public int TimestampRead() => WireFormatting.ReadTimestamp(_buffer.Span, 0, out _);
 
         [Benchmark]
-        public int TimestampWrite() => WireFormatting.WriteTimestamp(_buffer.Span, _timestamp);
+        public int TimestampWrite() => WireFormatting.WriteTimestamp(_buffer.Span, 0, _timestamp);
     }
 }

--- a/projects/RabbitMQ.Client/RabbitMQ.Client.csproj
+++ b/projects/RabbitMQ.Client/RabbitMQ.Client.csproj
@@ -33,6 +33,7 @@
 
   <PropertyGroup>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(CONCOURSE_CI_BUILD)' == 'true'">

--- a/projects/RabbitMQ.Client/client/framing/BasicCancel.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicCancel.cs
@@ -30,7 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
-using System.Text;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -53,8 +53,8 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public BasicCancel(ReadOnlySpan<byte> span)
         {
-            int offset = WireFormatting.ReadShortstr(span, out _consumerTag);
-            WireFormatting.ReadBits(span.Slice(offset), out _nowait);
+            int offset = WireFormatting.ReadShortstr(span, 0, out _consumerTag);
+            WireFormatting.ReadBits(span, offset, out _nowait);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.BasicCancel;
@@ -63,8 +63,8 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteShortstr(span, _consumerTag);
-            return offset + WireFormatting.WriteBits(span.Slice(offset), _nowait);
+            int offset = WireFormatting.WriteShortstr(span, 0, _consumerTag);
+            return offset + WireFormatting.WriteBits(ref span[offset], _nowait);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/BasicCancelOk.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicCancelOk.cs
@@ -51,7 +51,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public BasicCancelOk(ReadOnlySpan<byte> span)
         {
-            WireFormatting.ReadShortstr(span, out _consumerTag);
+            WireFormatting.ReadShortstr(span, 0, out _consumerTag);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.BasicCancelOk;
@@ -60,7 +60,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            return WireFormatting.WriteShortstr(span, _consumerTag);
+            return WireFormatting.WriteShortstr(span, 0, _consumerTag);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/BasicConsume.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicConsume.cs
@@ -31,6 +31,7 @@
 
 using System;
 using System.Collections.Generic;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -66,10 +67,10 @@ namespace RabbitMQ.Client.Framing.Impl
         public BasicConsume(ReadOnlySpan<byte> span)
         {
             int offset = 2;
-            offset += WireFormatting.ReadShortstr(span, out _queue);
-            offset += WireFormatting.ReadShortstr(span, out _consumerTag);
-            offset += WireFormatting.ReadBits(span.Slice(offset), out _noLocal, out _noAck, out _exclusive, out _nowait);
-            WireFormatting.ReadDictionary(span.Slice(offset), out var tmpDictionary);
+            offset += WireFormatting.ReadShortstr(span, offset, out _queue);
+            offset += WireFormatting.ReadShortstr(span, offset, out _consumerTag);
+            offset += WireFormatting.ReadBits(span, offset, out _noLocal, out _noAck, out _exclusive, out _nowait);
+            WireFormatting.ReadDictionary(span, offset, out var tmpDictionary);
             _arguments = tmpDictionary;
         }
 
@@ -79,11 +80,11 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteShort(span, default);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _queue);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _consumerTag);
-            offset += WireFormatting.WriteBits(span.Slice(offset), _noLocal, _noAck, _exclusive, _nowait);
-            return offset + WireFormatting.WriteTable(span.Slice(offset), _arguments);
+            int offset = WireFormatting.WriteShort(span, 0, default);
+            offset += WireFormatting.WriteShortstr(span, offset, _queue);
+            offset += WireFormatting.WriteShortstr(span, offset, _consumerTag);
+            offset += WireFormatting.WriteBits(ref span[offset], _noLocal, _noAck, _exclusive, _nowait);
+            return offset + WireFormatting.WriteTable(span, offset, _arguments);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/BasicConsumeOk.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicConsumeOk.cs
@@ -51,7 +51,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public BasicConsumeOk(ReadOnlySpan<byte> span)
         {
-            WireFormatting.ReadShortstr(span, out _consumerTag);
+            WireFormatting.ReadShortstr(span, 0, out _consumerTag);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.BasicConsumeOk;
@@ -60,7 +60,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            return WireFormatting.WriteShortstr(span, _consumerTag);
+            return WireFormatting.WriteShortstr(span, 0, _consumerTag);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/BasicDeliver.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicDeliver.cs
@@ -30,8 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
-using System.Buffers.Binary;
-using System.Text;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -60,11 +59,11 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public BasicDeliver(ReadOnlySpan<byte> span)
         {
-            int offset = WireFormatting.ReadShortstr(span, out _consumerTag);
-            offset += WireFormatting.ReadLonglong(span.Slice(offset), out _deliveryTag);
-            offset += WireFormatting.ReadBits(span.Slice(offset), out _redelivered);
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _exchange);
-            WireFormatting.ReadShortstr(span.Slice(offset), out _routingKey);
+            int offset = WireFormatting.ReadShortstr(span, 0, out _consumerTag);
+            offset += WireFormatting.ReadLonglong(span, offset, out _deliveryTag);
+            offset += WireFormatting.ReadBits(span, offset, out _redelivered);
+            offset += WireFormatting.ReadShortstr(span, offset, out _exchange);
+            WireFormatting.ReadShortstr(span, offset, out _routingKey);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.BasicDeliver;
@@ -73,11 +72,11 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteShortstr(span, _consumerTag);
-            offset += WireFormatting.WriteLonglong(span.Slice(offset), _deliveryTag);
-            offset += WireFormatting.WriteBits(span.Slice(offset), _redelivered);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _exchange);
-            return offset + WireFormatting.WriteShortstr(span.Slice(offset), _routingKey);
+            int offset = WireFormatting.WriteShortstr(span, 0, _consumerTag);
+            offset += WireFormatting.WriteLonglong(span, offset, _deliveryTag);
+            offset += WireFormatting.WriteBits(ref span[offset], _redelivered);
+            offset += WireFormatting.WriteShortstr(span, offset, _exchange);
+            return offset + WireFormatting.WriteShortstr(span, offset, _routingKey);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/BasicGet.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicGet.cs
@@ -30,6 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -55,8 +56,8 @@ namespace RabbitMQ.Client.Framing.Impl
         public BasicGet(ReadOnlySpan<byte> span)
         {
             int offset = 2;
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _queue);
-            WireFormatting.ReadBits(span.Slice(offset), out _noAck);
+            offset += WireFormatting.ReadShortstr(span, offset, out _queue);
+            WireFormatting.ReadBits(span, offset, out _noAck);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.BasicGet;
@@ -65,9 +66,9 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteShort(span, default);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _queue);
-            return offset + WireFormatting.WriteBits(span.Slice(offset), _noAck);
+            int offset = WireFormatting.WriteShort(span, 0, default);
+            offset += WireFormatting.WriteShortstr(span, offset, _queue);
+            return offset + WireFormatting.WriteBits(ref span[offset], _noAck);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/BasicGetOk.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicGetOk.cs
@@ -30,7 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
-using System.Text;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -59,11 +59,11 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public BasicGetOk(ReadOnlySpan<byte> span)
         {
-            int offset = WireFormatting.ReadLonglong(span, out _deliveryTag);
-            offset += WireFormatting.ReadBits(span.Slice(offset), out _redelivered);
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _exchange);
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _routingKey);
-            WireFormatting.ReadLong(span.Slice(offset), out _messageCount);
+            int offset = WireFormatting.ReadLonglong(span, 0, out _deliveryTag);
+            offset += WireFormatting.ReadBits(span, offset, out _redelivered);
+            offset += WireFormatting.ReadShortstr(span, offset, out _exchange);
+            offset += WireFormatting.ReadShortstr(span, offset, out _routingKey);
+            WireFormatting.ReadLong(span, offset, out _messageCount);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.BasicGetOk;
@@ -72,11 +72,11 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteLonglong(span, _deliveryTag);
-            offset += WireFormatting.WriteBits(span.Slice(offset), _redelivered);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _exchange);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _routingKey);
-            return offset + WireFormatting.WriteLong(span.Slice(offset), _messageCount);
+            int offset = WireFormatting.WriteLonglong(span, 0, _deliveryTag);
+            offset += WireFormatting.WriteBits(ref span[offset], _redelivered);
+            offset += WireFormatting.WriteShortstr(span, offset, _exchange);
+            offset += WireFormatting.WriteShortstr(span, offset, _routingKey);
+            return offset + WireFormatting.WriteLong(span, offset, _messageCount);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/BasicNack.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicNack.cs
@@ -30,6 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -54,8 +55,8 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public BasicNack(ReadOnlySpan<byte> span)
         {
-            int offset = WireFormatting.ReadLonglong(span, out _deliveryTag);
-            WireFormatting.ReadBits(span.Slice(offset), out _multiple, out _requeue);
+            int offset = WireFormatting.ReadLonglong(span, 0, out _deliveryTag);
+            WireFormatting.ReadBits(span, offset, out _multiple, out _requeue);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.BasicNack;
@@ -64,8 +65,8 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteLonglong(span, _deliveryTag);
-            return offset + WireFormatting.WriteBits(span.Slice(offset), _multiple, _requeue);
+            int offset = WireFormatting.WriteLonglong(span, 0, _deliveryTag);
+            return offset + WireFormatting.WriteBits(ref span[offset], _multiple, _requeue);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/BasicProperties.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicProperties.cs
@@ -31,7 +31,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
+
 using RabbitMQ.Client.Impl;
 
 namespace RabbitMQ.Client.Framing
@@ -200,7 +200,7 @@ namespace RabbitMQ.Client.Framing
 
         public BasicProperties(ReadOnlySpan<byte> span)
         {
-            int offset = WireFormatting.ReadBits(span,
+            int offset = WireFormatting.ReadBits(span[0], span[1],
                 out bool contentType_present,
                 out bool contentEncoding_present,
                 out bool headers_present,
@@ -215,20 +215,20 @@ namespace RabbitMQ.Client.Framing
                 out bool userId_present,
                 out bool appId_present,
                 out bool clusterId_present);
-            if (contentType_present) { offset += WireFormatting.ReadShortstr(span.Slice(offset), out _contentType); }
-            if (contentEncoding_present) { offset += WireFormatting.ReadShortstr(span.Slice(offset), out _contentEncoding); }
-            if (headers_present) { offset += WireFormatting.ReadDictionary(span.Slice(offset), out var tmpDirectory); _headers = tmpDirectory; }
+            if (contentType_present) { offset += WireFormatting.ReadShortstr(span, offset, out _contentType); }
+            if (contentEncoding_present) { offset += WireFormatting.ReadShortstr(span, offset, out _contentEncoding); }
+            if (headers_present) { offset += WireFormatting.ReadDictionary(span, offset, out var tmpDirectory); _headers = tmpDirectory; }
             if (deliveryMode_present) { _deliveryMode = span[offset++]; }
             if (priority_present) { _priority = span[offset++]; }
-            if (correlationId_present) { offset += WireFormatting.ReadShortstr(span.Slice(offset), out _correlationId); }
-            if (replyTo_present) { offset += WireFormatting.ReadShortstr(span.Slice(offset), out _replyTo); }
-            if (expiration_present) { offset += WireFormatting.ReadShortstr(span.Slice(offset), out _expiration); }
-            if (messageId_present) { offset += WireFormatting.ReadShortstr(span.Slice(offset), out _messageId); }
-            if (timestamp_present) { offset += WireFormatting.ReadTimestamp(span.Slice(offset), out _timestamp); }
-            if (type_present) { offset += WireFormatting.ReadShortstr(span.Slice(offset), out _type); }
-            if (userId_present) { offset += WireFormatting.ReadShortstr(span.Slice(offset), out _userId); }
-            if (appId_present) { offset += WireFormatting.ReadShortstr(span.Slice(offset), out _appId); }
-            if (clusterId_present) { WireFormatting.ReadShortstr(span.Slice(offset), out _clusterId); }
+            if (correlationId_present) { offset += WireFormatting.ReadShortstr(span, offset, out _correlationId); }
+            if (replyTo_present) { offset += WireFormatting.ReadShortstr(span, offset, out _replyTo); }
+            if (expiration_present) { offset += WireFormatting.ReadShortstr(span, offset, out _expiration); }
+            if (messageId_present) { offset += WireFormatting.ReadShortstr(span, offset, out _messageId); }
+            if (timestamp_present) { offset += WireFormatting.ReadTimestamp(span, offset, out _timestamp); }
+            if (type_present) { offset += WireFormatting.ReadShortstr(span, offset, out _type); }
+            if (userId_present) { offset += WireFormatting.ReadShortstr(span, offset, out _userId); }
+            if (appId_present) { offset += WireFormatting.ReadShortstr(span, offset, out _appId); }
+            if (clusterId_present) { WireFormatting.ReadShortstr(span, offset, out _clusterId); }
         }
 
         public override ushort ProtocolClassId => 60;
@@ -236,24 +236,24 @@ namespace RabbitMQ.Client.Framing
 
         internal override int WritePropertiesTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteBits(span,
+            int offset = WireFormatting.WriteBits(span,0,
                 IsContentTypePresent(), IsContentEncodingPresent(), IsHeadersPresent(), IsDeliveryModePresent(), IsPriorityPresent(),
                 IsCorrelationIdPresent(), IsReplyToPresent(), IsExpirationPresent(), IsMessageIdPresent(), IsTimestampPresent(),
                 IsTypePresent(), IsUserIdPresent(), IsAppIdPresent(), IsClusterIdPresent());
-            if (IsContentTypePresent()) { offset += WireFormatting.WriteShortstr(span.Slice(offset), _contentType); }
-            if (IsContentEncodingPresent()) { offset += WireFormatting.WriteShortstr(span.Slice(offset), _contentEncoding); }
-            if (IsHeadersPresent()) { offset += WireFormatting.WriteTable(span.Slice(offset), _headers); }
+            if (IsContentTypePresent()) { offset += WireFormatting.WriteShortstr(span, offset, _contentType); }
+            if (IsContentEncodingPresent()) { offset += WireFormatting.WriteShortstr(span, offset, _contentEncoding); }
+            if (IsHeadersPresent()) { offset += WireFormatting.WriteTable(span, offset, _headers); }
             if (IsDeliveryModePresent()) { span[offset++] = _deliveryMode; }
             if (IsPriorityPresent()) { span[offset++] = _priority; }
-            if (IsCorrelationIdPresent()) { offset += WireFormatting.WriteShortstr(span.Slice(offset), _correlationId); }
-            if (IsReplyToPresent()) { offset += WireFormatting.WriteShortstr(span.Slice(offset), _replyTo); }
-            if (IsExpirationPresent()) { offset += WireFormatting.WriteShortstr(span.Slice(offset), _expiration); }
-            if (IsMessageIdPresent()) { offset += WireFormatting.WriteShortstr(span.Slice(offset), _messageId); }
-            if (IsTimestampPresent()) { offset += WireFormatting.WriteTimestamp(span.Slice(offset), _timestamp); }
-            if (IsTypePresent()) { offset += WireFormatting.WriteShortstr(span.Slice(offset), _type); }
-            if (IsUserIdPresent()) { offset += WireFormatting.WriteShortstr(span.Slice(offset), _userId); }
-            if (IsAppIdPresent()) { offset += WireFormatting.WriteShortstr(span.Slice(offset), _appId); }
-            if (IsClusterIdPresent()) { offset += WireFormatting.WriteShortstr(span.Slice(offset), _clusterId); }
+            if (IsCorrelationIdPresent()) { offset += WireFormatting.WriteShortstr(span, offset, _correlationId); }
+            if (IsReplyToPresent()) { offset += WireFormatting.WriteShortstr(span, offset, _replyTo); }
+            if (IsExpirationPresent()) { offset += WireFormatting.WriteShortstr(span, offset, _expiration); }
+            if (IsMessageIdPresent()) { offset += WireFormatting.WriteShortstr(span, offset, _messageId); }
+            if (IsTimestampPresent()) { offset += WireFormatting.WriteTimestamp(span, offset, _timestamp); }
+            if (IsTypePresent()) { offset += WireFormatting.WriteShortstr(span, offset, _type); }
+            if (IsUserIdPresent()) { offset += WireFormatting.WriteShortstr(span, offset, _userId); }
+            if (IsAppIdPresent()) { offset += WireFormatting.WriteShortstr(span, offset, _appId); }
+            if (IsClusterIdPresent()) { offset += WireFormatting.WriteShortstr(span, offset, _clusterId); }
             return offset;
         }
 

--- a/projects/RabbitMQ.Client/client/framing/BasicPublish.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicPublish.cs
@@ -30,6 +30,8 @@
 //---------------------------------------------------------------------------
 
 using System;
+using System.Runtime.CompilerServices;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -59,9 +61,9 @@ namespace RabbitMQ.Client.Framing.Impl
         public BasicPublish(ReadOnlySpan<byte> span)
         {
             int offset = 2;
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _exchange);
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _routingKey);
-            WireFormatting.ReadBits(span.Slice(offset), out _mandatory, out _immediate);
+            offset += WireFormatting.ReadShortstr(span, offset, out _exchange);
+            offset += WireFormatting.ReadShortstr(span, offset, out _routingKey);
+            WireFormatting.ReadBits(span, offset, out _mandatory, out _immediate);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.BasicPublish;
@@ -70,10 +72,10 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteShort(span, default);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _exchange);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _routingKey);
-            return offset + WireFormatting.WriteBits(span.Slice(offset), _mandatory, _immediate);
+            int offset = WireFormatting.WriteShort(span, 0, default);
+            offset += WireFormatting.WriteShortstr(span, offset, _exchange);
+            offset += WireFormatting.WriteShortstr(span, offset, _routingKey);
+            return offset + WireFormatting.WriteBits(ref span[offset], _mandatory, _immediate);
         }
 
         public override int GetRequiredBufferSize()
@@ -108,10 +110,10 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteShort(span, default);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _exchange.Span);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _routingKey.Span);
-            return offset + WireFormatting.WriteBits(span.Slice(offset), _mandatory, _immediate);
+            int offset = WireFormatting.WriteShort(span, 0, default);
+            offset += WireFormatting.WriteShortstr(span, offset, _exchange.Span);
+            offset += WireFormatting.WriteShortstr(span, offset, _routingKey.Span);
+            return offset + WireFormatting.WriteBits(ref span[offset], _mandatory, _immediate);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/BasicQos.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicQos.cs
@@ -30,6 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -54,9 +55,9 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public BasicQos(ReadOnlySpan<byte> span)
         {
-            int offset = WireFormatting.ReadLong(span, out _prefetchSize);
-            offset += WireFormatting.ReadShort(span.Slice(offset), out _prefetchCount);
-            WireFormatting.ReadBits(span.Slice(offset), out _global);
+            int offset = WireFormatting.ReadLong(span, 0, out _prefetchSize);
+            offset += WireFormatting.ReadShort(span, offset, out _prefetchCount);
+            WireFormatting.ReadBits(span, offset, out _global);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.BasicQos;
@@ -65,9 +66,9 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteLong(span, _prefetchSize);
-            offset += WireFormatting.WriteShort(span.Slice(offset), _prefetchCount);
-            return offset + WireFormatting.WriteBits(span.Slice(offset), _global);
+            int offset = WireFormatting.WriteLong(span, 0, _prefetchSize);
+            offset += WireFormatting.WriteShort(span, offset, _prefetchCount);
+            return offset + WireFormatting.WriteBits(ref span[offset], _global);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/BasicRecover.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicRecover.cs
@@ -30,6 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -50,7 +51,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public BasicRecover(ReadOnlySpan<byte> span)
         {
-            WireFormatting.ReadBits(span, out _requeue);
+            WireFormatting.ReadBits(span, 0, out _requeue);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.BasicRecover;
@@ -59,7 +60,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            return WireFormatting.WriteBits(span, _requeue);
+            return WireFormatting.WriteBits(ref span[0], _requeue);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/BasicRecoverAsync.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicRecoverAsync.cs
@@ -30,6 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -50,7 +51,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public BasicRecoverAsync(ReadOnlySpan<byte> span)
         {
-            WireFormatting.ReadBits(span, out _requeue);
+            WireFormatting.ReadBits(span, 0, out _requeue);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.BasicRecoverAsync;
@@ -59,7 +60,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            return WireFormatting.WriteBits(span, _requeue);
+            return WireFormatting.WriteBits(ref span[0], _requeue);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/BasicReject.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicReject.cs
@@ -30,6 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -52,8 +53,8 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public BasicReject(ReadOnlySpan<byte> span)
         {
-            int offset = WireFormatting.ReadLonglong(span, out _deliveryTag);
-            WireFormatting.ReadBits(span.Slice(offset), out _requeue);
+            int offset = WireFormatting.ReadLonglong(span, 0, out _deliveryTag);
+            WireFormatting.ReadBits(span, offset, out _requeue);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.BasicReject;
@@ -62,8 +63,8 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteLonglong(span, _deliveryTag);
-            return offset + WireFormatting.WriteBits(span.Slice(offset), _requeue);
+            int offset = WireFormatting.WriteLonglong(span, 0, _deliveryTag);
+            return offset + WireFormatting.WriteBits(ref span[offset], _requeue);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/BasicReturn.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicReturn.cs
@@ -30,7 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
-using System.Text;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -57,10 +57,10 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public BasicReturn(ReadOnlySpan<byte> span)
         {
-            int offset = WireFormatting.ReadShort(span, out _replyCode);
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _replyText);
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _exchange);
-            WireFormatting.ReadShortstr(span.Slice(offset), out _routingKey);
+            int offset = WireFormatting.ReadShort(span, 0, out _replyCode);
+            offset += WireFormatting.ReadShortstr(span, offset, out _replyText);
+            offset += WireFormatting.ReadShortstr(span, offset, out _exchange);
+            WireFormatting.ReadShortstr(span, offset, out _routingKey);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.BasicReturn;
@@ -69,10 +69,10 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteShort(span, _replyCode);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _replyText);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _exchange);
-            return offset + WireFormatting.WriteShortstr(span.Slice(offset), _routingKey);
+            int offset = WireFormatting.WriteShort(span, 0, _replyCode);
+            offset += WireFormatting.WriteShortstr(span, offset, _replyText);
+            offset += WireFormatting.WriteShortstr(span, offset, _exchange);
+            return offset + WireFormatting.WriteShortstr(span, offset, _routingKey);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/ChannelFlow.cs
+++ b/projects/RabbitMQ.Client/client/framing/ChannelFlow.cs
@@ -30,6 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -50,7 +51,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public ChannelFlow(ReadOnlySpan<byte> span)
         {
-            WireFormatting.ReadBits(span, out _active);
+            WireFormatting.ReadBits(span, 0, out _active);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.ChannelFlow;
@@ -59,7 +60,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            return WireFormatting.WriteBits(span, _active);
+            return WireFormatting.WriteBits(ref span[0], _active);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/ChannelFlowOk.cs
+++ b/projects/RabbitMQ.Client/client/framing/ChannelFlowOk.cs
@@ -30,6 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -50,7 +51,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public ChannelFlowOk(ReadOnlySpan<byte> span)
         {
-            WireFormatting.ReadBits(span, out _active);
+            WireFormatting.ReadBits(span, 0, out _active);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.ChannelFlowOk;
@@ -59,7 +60,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            return WireFormatting.WriteBits(span, _active);
+            return WireFormatting.WriteBits(ref span[0], _active);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/ConfirmSelect.cs
+++ b/projects/RabbitMQ.Client/client/framing/ConfirmSelect.cs
@@ -30,6 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -50,7 +51,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public ConfirmSelect(ReadOnlySpan<byte> span)
         {
-            WireFormatting.ReadBits(span, out _nowait);
+            WireFormatting.ReadBits(span, 0, out _nowait);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.ConfirmSelect;
@@ -59,7 +60,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            return WireFormatting.WriteBits(span, _nowait);
+            return WireFormatting.WriteBits(ref span[0], _nowait);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/ConnectionBlocked.cs
+++ b/projects/RabbitMQ.Client/client/framing/ConnectionBlocked.cs
@@ -51,7 +51,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public ConnectionBlocked(ReadOnlySpan<byte> span)
         {
-            WireFormatting.ReadShortstr(span, out _reason);
+            WireFormatting.ReadShortstr(span, 0, out _reason);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.ConnectionBlocked;
@@ -60,7 +60,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            return WireFormatting.WriteShortstr(span, _reason);
+            return WireFormatting.WriteShortstr(span, 0, _reason);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/ConnectionClose.cs
+++ b/projects/RabbitMQ.Client/client/framing/ConnectionClose.cs
@@ -57,10 +57,10 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public ConnectionClose(ReadOnlySpan<byte> span)
         {
-            int offset = WireFormatting.ReadShort(span, out _replyCode);
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _replyText);
-            offset += WireFormatting.ReadShort(span.Slice(offset), out _classId);
-            WireFormatting.ReadShort(span.Slice(offset), out _methodId);
+            int offset = WireFormatting.ReadShort(span, 0, out _replyCode);
+            offset += WireFormatting.ReadShortstr(span, offset, out _replyText);
+            offset += WireFormatting.ReadShort(span, offset, out _classId);
+            WireFormatting.ReadShort(span, offset, out _methodId);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.ConnectionClose;
@@ -69,10 +69,10 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteShort(span, _replyCode);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _replyText);
-            offset += WireFormatting.WriteShort(span.Slice(offset), _classId);
-            return offset + WireFormatting.WriteShort(span.Slice(offset), _methodId);
+            int offset = WireFormatting.WriteShort(span, 0, _replyCode);
+            offset += WireFormatting.WriteShortstr(span, offset, _replyText);
+            offset += WireFormatting.WriteShort(span, offset, _classId);
+            return offset + WireFormatting.WriteShort(span, offset, _methodId);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/ConnectionOpen.cs
+++ b/projects/RabbitMQ.Client/client/framing/ConnectionOpen.cs
@@ -53,7 +53,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public ConnectionOpen(ReadOnlySpan<byte> span)
         {
-            WireFormatting.ReadShortstr(span, out _virtualHost);
+            WireFormatting.ReadShortstr(span, 0, out _virtualHost);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.ConnectionOpen;
@@ -62,7 +62,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteShortstr(span, _virtualHost);
+            int offset = WireFormatting.WriteShortstr(span, 0, _virtualHost);
             span[offset++] = 0; // _reserved1
             span[offset++] = 0; // _reserved2
             return offset;

--- a/projects/RabbitMQ.Client/client/framing/ConnectionSecure.cs
+++ b/projects/RabbitMQ.Client/client/framing/ConnectionSecure.cs
@@ -50,7 +50,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public ConnectionSecure(ReadOnlySpan<byte> span)
         {
-            WireFormatting.ReadLongstr(span, out _challenge);
+            WireFormatting.ReadLongstr(span, 0, out _challenge);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.ConnectionSecure;
@@ -59,7 +59,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            return WireFormatting.WriteLongstr(span, _challenge);
+            return WireFormatting.WriteLongstr(span, 0, _challenge);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/ConnectionSecureOk.cs
+++ b/projects/RabbitMQ.Client/client/framing/ConnectionSecureOk.cs
@@ -50,7 +50,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public ConnectionSecureOk(ReadOnlySpan<byte> span)
         {
-            WireFormatting.ReadLongstr(span, out _response);
+            WireFormatting.ReadLongstr(span, 0, out _response);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.ConnectionSecureOk;
@@ -59,7 +59,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            return WireFormatting.WriteLongstr(span, _response);
+            return WireFormatting.WriteLongstr(span, 0, _response);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/ConnectionStart.cs
+++ b/projects/RabbitMQ.Client/client/framing/ConnectionStart.cs
@@ -31,6 +31,7 @@
 
 using System;
 using System.Collections.Generic;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -61,9 +62,9 @@ namespace RabbitMQ.Client.Framing.Impl
         {
             _versionMajor = span[0];
             _versionMinor = span[1];
-            int offset = 2 + WireFormatting.ReadDictionary(span.Slice(2), out _serverProperties);
-            offset += WireFormatting.ReadLongstr(span.Slice(offset), out _mechanisms);
-            WireFormatting.ReadLongstr(span.Slice(offset), out _locales);
+            int offset = 2 + WireFormatting.ReadDictionary(span, 2, out _serverProperties);
+            offset += WireFormatting.ReadLongstr(span, offset, out _mechanisms);
+            WireFormatting.ReadLongstr(span, offset, out _locales);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.ConnectionStart;
@@ -74,9 +75,9 @@ namespace RabbitMQ.Client.Framing.Impl
         {
             span[0] = _versionMajor;
             span[1] = _versionMinor;
-            int offset = 2 + WireFormatting.WriteTable(span.Slice(2), (IDictionary<string, object>)_serverProperties);
-            offset += WireFormatting.WriteLongstr(span.Slice(offset), _mechanisms);
-            return offset + WireFormatting.WriteLongstr(span.Slice(offset), _locales);
+            int offset = 2 + WireFormatting.WriteTable(span, 2, (IDictionary<string, object>)_serverProperties);
+            offset += WireFormatting.WriteLongstr(span, offset, _mechanisms);
+            return offset + WireFormatting.WriteLongstr(span, offset, _locales);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/ConnectionStartOk.cs
+++ b/projects/RabbitMQ.Client/client/framing/ConnectionStartOk.cs
@@ -31,7 +31,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -58,11 +58,11 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public ConnectionStartOk(ReadOnlySpan<byte> span)
         {
-            int offset = WireFormatting.ReadDictionary(span, out var tmpDictionary);
+            int offset = WireFormatting.ReadDictionary(span, 0, out var tmpDictionary);
             _clientProperties = tmpDictionary;
-            offset += WireFormatting.ReadShortstr(span, out _mechanism);
-            offset += WireFormatting.ReadLongstr(span, out _response);
-            WireFormatting.ReadShortstr(span.Slice(offset), out _locale);
+            offset += WireFormatting.ReadShortstr(span, offset, out _mechanism);
+            offset += WireFormatting.ReadLongstr(span, offset, out _response);
+            WireFormatting.ReadShortstr(span, offset, out _locale);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.ConnectionStartOk;
@@ -71,15 +71,15 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteTable(span, _clientProperties);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _mechanism);
-            offset += WireFormatting.WriteLongstr(span.Slice(offset), _response);
-            return offset + WireFormatting.WriteShortstr(span.Slice(offset), _locale);
+            int offset = WireFormatting.WriteTable(span, 0, _clientProperties);
+            offset += WireFormatting.WriteShortstr(span, offset, _mechanism);
+            offset += WireFormatting.WriteLongstr(span, offset, _response);
+            return offset + WireFormatting.WriteShortstr(span, offset, _locale);
         }
 
         public override int GetRequiredBufferSize()
         {
-            int bufferSize = 1 + 4 +1; // bytes for length of _mechanism, length of _response, length of _locale
+            int bufferSize = 1 + 4 + 1; // bytes for length of _mechanism, length of _response, length of _locale
             bufferSize += WireFormatting.GetTableByteCount(_clientProperties); // _clientProperties in bytes
             bufferSize += WireFormatting.GetByteCount(_mechanism); // _mechanism in bytes
             bufferSize += _response.Length; // _response in bytes

--- a/projects/RabbitMQ.Client/client/framing/ConnectionTune.cs
+++ b/projects/RabbitMQ.Client/client/framing/ConnectionTune.cs
@@ -54,9 +54,9 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public ConnectionTune(ReadOnlySpan<byte> span)
         {
-            int offset = WireFormatting.ReadShort(span, out _channelMax);
-            offset += WireFormatting.ReadLong(span.Slice(offset), out _frameMax);
-            WireFormatting.ReadShort(span.Slice(offset), out _heartbeat);
+            int offset = WireFormatting.ReadShort(span, 0, out _channelMax);
+            offset += WireFormatting.ReadLong(span, offset, out _frameMax);
+            WireFormatting.ReadShort(span, offset, out _heartbeat);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.ConnectionTune;
@@ -65,9 +65,9 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteShort(span, _channelMax);
-            offset += WireFormatting.WriteLong(span.Slice(offset), _frameMax);
-            return offset + WireFormatting.WriteShort(span.Slice(offset), _heartbeat);
+            int offset = WireFormatting.WriteShort(span, 0, _channelMax);
+            offset += WireFormatting.WriteLong(span, offset, _frameMax);
+            return offset + WireFormatting.WriteShort(span, offset, _heartbeat);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/ConnectionTuneOk.cs
+++ b/projects/RabbitMQ.Client/client/framing/ConnectionTuneOk.cs
@@ -54,9 +54,9 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public ConnectionTuneOk(ReadOnlySpan<byte> span)
         {
-            int offset = WireFormatting.ReadShort(span, out _channelMax);
-            offset += WireFormatting.ReadLong(span.Slice(offset), out _frameMax);
-            WireFormatting.ReadShort(span.Slice(offset), out _heartbeat);
+            int offset = WireFormatting.ReadShort(span, 0, out _channelMax);
+            offset += WireFormatting.ReadLong(span, offset, out _frameMax);
+            WireFormatting.ReadShort(span, offset, out _heartbeat);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.ConnectionTuneOk;
@@ -65,9 +65,9 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteShort(span, _channelMax);
-            offset += WireFormatting.WriteLong(span.Slice(offset), _frameMax);
-            return offset + WireFormatting.WriteShort(span.Slice(offset), _heartbeat);
+            int offset = WireFormatting.WriteShort(span, 0, _channelMax);
+            offset += WireFormatting.WriteLong(span, offset, _frameMax);
+            return offset + WireFormatting.WriteShort(span, offset, _heartbeat);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/ConnectionUpdateSecret.cs
+++ b/projects/RabbitMQ.Client/client/framing/ConnectionUpdateSecret.cs
@@ -53,8 +53,8 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public ConnectionUpdateSecret(ReadOnlySpan<byte> span)
         {
-            int offset = WireFormatting.ReadLongstr(span, out _newSecret);
-            WireFormatting.ReadShortstr(span.Slice(offset), out _reason);
+            int offset = WireFormatting.ReadLongstr(span, 0, out _newSecret);
+            WireFormatting.ReadShortstr(span, offset, out _reason);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.ConnectionUpdateSecret;
@@ -63,8 +63,8 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteLongstr(span, _newSecret);
-            return offset + WireFormatting.WriteShortstr(span.Slice(offset), _reason);
+            int offset = WireFormatting.WriteLongstr(span, 0, _newSecret);
+            return offset + WireFormatting.WriteShortstr(span, offset, _reason);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/ExchangeBind.cs
+++ b/projects/RabbitMQ.Client/client/framing/ExchangeBind.cs
@@ -31,6 +31,7 @@
 
 using System;
 using System.Collections.Generic;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -62,11 +63,11 @@ namespace RabbitMQ.Client.Framing.Impl
         public ExchangeBind(ReadOnlySpan<byte> span)
         {
             int offset = 2;
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _destination);
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _source);
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _routingKey);
-            offset += WireFormatting.ReadBits(span.Slice(offset), out _nowait);
-            WireFormatting.ReadDictionary(span.Slice(offset), out var tmpDictionary);
+            offset += WireFormatting.ReadShortstr(span, offset, out _destination);
+            offset += WireFormatting.ReadShortstr(span, offset, out _source);
+            offset += WireFormatting.ReadShortstr(span, offset, out _routingKey);
+            offset += WireFormatting.ReadBits(span, offset, out _nowait);
+            WireFormatting.ReadDictionary(span, offset, out var tmpDictionary);
             _arguments = tmpDictionary;
         }
 
@@ -76,12 +77,12 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteShort(span, default);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _destination);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _source);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _routingKey);
-            offset += WireFormatting.WriteBits(span.Slice(offset), _nowait);
-            return offset + WireFormatting.WriteTable(span.Slice(offset), _arguments);
+            int offset = WireFormatting.WriteShort(span, 0, default);
+            offset += WireFormatting.WriteShortstr(span, offset, _destination);
+            offset += WireFormatting.WriteShortstr(span, offset, _source);
+            offset += WireFormatting.WriteShortstr(span, offset, _routingKey);
+            offset += WireFormatting.WriteBits(ref span[offset], _nowait);
+            return offset + WireFormatting.WriteTable(span, offset, _arguments);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/ExchangeDeclare.cs
+++ b/projects/RabbitMQ.Client/client/framing/ExchangeDeclare.cs
@@ -31,6 +31,7 @@
 
 using System;
 using System.Collections.Generic;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -68,10 +69,10 @@ namespace RabbitMQ.Client.Framing.Impl
         public ExchangeDeclare(ReadOnlySpan<byte> span)
         {
             int offset = 2;
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _exchange);
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _type);
-            offset += WireFormatting.ReadBits(span.Slice(offset), out _passive, out _durable, out _autoDelete, out _internal, out _nowait);
-            WireFormatting.ReadDictionary(span.Slice(offset), out var tmpDictionary);
+            offset += WireFormatting.ReadShortstr(span, offset, out _exchange);
+            offset += WireFormatting.ReadShortstr(span, offset, out _type);
+            offset += WireFormatting.ReadBits(span, offset, out _passive, out _durable, out _autoDelete, out _internal, out _nowait);
+            WireFormatting.ReadDictionary(span, offset, out var tmpDictionary);
             _arguments = tmpDictionary;
         }
 
@@ -81,11 +82,11 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteShort(span, default);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _exchange);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _type);
-            offset += WireFormatting.WriteBits(span.Slice(offset), _passive, _durable, _autoDelete, _internal, _nowait);
-            return offset + WireFormatting.WriteTable(span.Slice(offset), _arguments);
+            int offset = WireFormatting.WriteShort(span, 0, default);
+            offset += WireFormatting.WriteShortstr(span, offset, _exchange);
+            offset += WireFormatting.WriteShortstr(span, offset, _type);
+            offset += WireFormatting.WriteBits(ref span[offset], _passive, _durable, _autoDelete, _internal, _nowait);
+            return offset + WireFormatting.WriteTable(span, offset, _arguments);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/ExchangeDelete.cs
+++ b/projects/RabbitMQ.Client/client/framing/ExchangeDelete.cs
@@ -30,6 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -57,8 +58,8 @@ namespace RabbitMQ.Client.Framing.Impl
         public ExchangeDelete(ReadOnlySpan<byte> span)
         {
             int offset = 2;
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _exchange);
-            WireFormatting.ReadBits(span.Slice(offset), out _ifUnused, out _nowait);
+            offset += WireFormatting.ReadShortstr(span, offset, out _exchange);
+            WireFormatting.ReadBits(span, offset, out _ifUnused, out _nowait);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.ExchangeDelete;
@@ -67,9 +68,9 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteShort(span, default);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _exchange);
-            return offset + WireFormatting.WriteBits(span.Slice(offset), _ifUnused, _nowait);
+            int offset = WireFormatting.WriteShort(span, 0, default);
+            offset += WireFormatting.WriteShortstr(span, offset, _exchange);
+            return offset + WireFormatting.WriteBits(ref span[offset], _ifUnused, _nowait);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/ExchangeUnbind.cs
+++ b/projects/RabbitMQ.Client/client/framing/ExchangeUnbind.cs
@@ -31,6 +31,7 @@
 
 using System;
 using System.Collections.Generic;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -62,11 +63,11 @@ namespace RabbitMQ.Client.Framing.Impl
         public ExchangeUnbind(ReadOnlySpan<byte> span)
         {
             int offset = 2;
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _destination);
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _source);
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _routingKey);
-            offset += WireFormatting.ReadBits(span.Slice(offset), out _nowait);
-            WireFormatting.ReadDictionary(span.Slice(offset), out var tmpDictionary);
+            offset += WireFormatting.ReadShortstr(span, offset, out _destination);
+            offset += WireFormatting.ReadShortstr(span, offset, out _source);
+            offset += WireFormatting.ReadShortstr(span, offset, out _routingKey);
+            offset += WireFormatting.ReadBits(span, offset, out _nowait);
+            WireFormatting.ReadDictionary(span, offset, out var tmpDictionary);
             _arguments = tmpDictionary;
         }
 
@@ -76,12 +77,12 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteShort(span, default);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _destination);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _source);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _routingKey);
-            offset += WireFormatting.WriteBits(span.Slice(offset), _nowait);
-            return offset + WireFormatting.WriteTable(span.Slice(offset), _arguments);
+            int offset = WireFormatting.WriteShort(span, 0, default);
+            offset += WireFormatting.WriteShortstr(span, offset, _destination);
+            offset += WireFormatting.WriteShortstr(span, offset, _source);
+            offset += WireFormatting.WriteShortstr(span, offset, _routingKey);
+            offset += WireFormatting.WriteBits(ref span[offset], _nowait);
+            return offset + WireFormatting.WriteTable(span, offset, _arguments);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/Model.cs
+++ b/projects/RabbitMQ.Client/client/framing/Model.cs
@@ -31,12 +31,13 @@
 
 using System;
 using System.Collections.Generic;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
 namespace RabbitMQ.Client.Framing.Impl
 {
-    internal class Model: ModelBase
+    internal class Model : ModelBase
     {
         public Model(bool dispatchAsync, int concurrency, ISession session) : base(dispatchAsync, concurrency, session)
         {
@@ -64,12 +65,12 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override void _Private_BasicPublish(string exchange, string routingKey, bool mandatory, IBasicProperties basicProperties, ReadOnlyMemory<byte> body)
         {
-            ModelSend(new BasicPublish(exchange, routingKey, mandatory, default), (BasicProperties) basicProperties, body);
+            ModelSend(new BasicPublish(exchange, routingKey, mandatory, default), (BasicProperties)basicProperties, body);
         }
 
         public override void _Private_BasicPublishMemory(ReadOnlyMemory<byte> exchange, ReadOnlyMemory<byte> routingKey, bool mandatory, IBasicProperties basicProperties, ReadOnlyMemory<byte> body)
         {
-            ModelSend(new BasicPublishMemory(exchange, routingKey, mandatory, default), (BasicProperties) basicProperties, body);
+            ModelSend(new BasicPublishMemory(exchange, routingKey, mandatory, default), (BasicProperties)basicProperties, body);
         }
 
         public override void _Private_BasicRecover(bool requeue)
@@ -94,7 +95,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override void _Private_ChannelOpen()
         {
-            ModelRpc<ChannelOpenOk>(new ChannelOpen());
+            ModelRpc<ChannelOpen, ChannelOpenOk>(new ChannelOpen());
         }
 
         public override void _Private_ConfirmSelect(bool nowait)
@@ -106,7 +107,7 @@ namespace RabbitMQ.Client.Framing.Impl
             }
             else
             {
-                ModelRpc<ConfirmSelectOk>(method);
+                ModelRpc<ConfirmSelect, ConfirmSelectOk>(method);
             }
         }
 
@@ -132,7 +133,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override void _Private_UpdateSecret(byte[] newSecret, string reason)
         {
-            ModelRpc<ConnectionUpdateSecretOk>(new ConnectionUpdateSecret(newSecret, reason));
+            ModelRpc<ConnectionUpdateSecret, ConnectionUpdateSecretOk>(new ConnectionUpdateSecret(newSecret, reason));
         }
 
         public override void _Private_ExchangeBind(string destination, string source, string routingKey, bool nowait, IDictionary<string, object> arguments)
@@ -144,7 +145,7 @@ namespace RabbitMQ.Client.Framing.Impl
             }
             else
             {
-                ModelRpc<ExchangeBindOk>(method);
+                ModelRpc<ExchangeBind, ExchangeBindOk>(method);
             }
         }
 
@@ -157,7 +158,7 @@ namespace RabbitMQ.Client.Framing.Impl
             }
             else
             {
-                ModelRpc<ExchangeDeclareOk>(method);
+                ModelRpc<ExchangeDeclare, ExchangeDeclareOk>(method);
             }
         }
 
@@ -170,7 +171,7 @@ namespace RabbitMQ.Client.Framing.Impl
             }
             else
             {
-                ModelRpc<ExchangeDeleteOk>(method);
+                ModelRpc<ExchangeDelete, ExchangeDeleteOk>(method);
             }
         }
 
@@ -183,7 +184,7 @@ namespace RabbitMQ.Client.Framing.Impl
             }
             else
             {
-                ModelRpc<ExchangeUnbindOk>(method);
+                ModelRpc<ExchangeUnbind, ExchangeUnbindOk>(method);
             }
         }
 
@@ -196,7 +197,7 @@ namespace RabbitMQ.Client.Framing.Impl
             }
             else
             {
-                ModelRpc<QueueBindOk>(method);
+                ModelRpc<QueueBind, QueueBindOk>(method);
             }
         }
 
@@ -222,7 +223,7 @@ namespace RabbitMQ.Client.Framing.Impl
                 return 0xFFFFFFFF;
             }
 
-            return ModelRpc<QueueDeleteOk>(method)._messageCount;
+            return ModelRpc<QueueDelete, QueueDeleteOk>(method)._messageCount;
         }
 
         public override uint _Private_QueuePurge(string queue, bool nowait)
@@ -234,7 +235,7 @@ namespace RabbitMQ.Client.Framing.Impl
                 return 0xFFFFFFFF;
             }
 
-            return ModelRpc<QueuePurgeOk>(method)._messageCount;
+            return ModelRpc<QueuePurge, QueuePurgeOk>(method)._messageCount;
         }
 
         public override void BasicAck(ulong deliveryTag, bool multiple)
@@ -249,7 +250,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override void BasicQos(uint prefetchSize, ushort prefetchCount, bool global)
         {
-            ModelRpc<BasicQosOk>(new BasicQos(prefetchSize, prefetchCount, global));
+            ModelRpc<BasicQos, BasicQosOk>(new BasicQos(prefetchSize, prefetchCount, global));
         }
 
         public override void BasicRecoverAsync(bool requeue)
@@ -269,22 +270,22 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override void QueueUnbind(string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
         {
-            ModelRpc<QueueUnbindOk>(new QueueUnbind(queue, exchange, routingKey, arguments));
+            ModelRpc<QueueUnbind, QueueUnbindOk>(new QueueUnbind(queue, exchange, routingKey, arguments));
         }
 
         public override void TxCommit()
         {
-            ModelRpc<TxCommitOk>(new TxCommit());
+            ModelRpc<TxCommit, TxCommitOk>(new TxCommit());
         }
 
         public override void TxRollback()
         {
-            ModelRpc<TxRollbackOk>(new TxRollback());
+            ModelRpc<TxRollback, TxRollbackOk>(new TxRollback());
         }
 
         public override void TxSelect()
         {
-            ModelRpc<TxSelectOk>(new TxSelect());
+            ModelRpc<TxSelect, TxSelectOk>(new TxSelect());
         }
 
         protected override bool DispatchAsynchronous(in IncomingCommand cmd)
@@ -292,121 +293,121 @@ namespace RabbitMQ.Client.Framing.Impl
             switch (cmd.Method.ProtocolCommandId)
             {
                 case ProtocolCommandId.BasicDeliver:
-                {
-                    var __impl = (BasicDeliver)cmd.Method;
-                    HandleBasicDeliver(__impl._consumerTag, __impl._deliveryTag, __impl._redelivered, __impl._exchange, __impl._routingKey, (IBasicProperties) cmd.Header, cmd.Body, cmd.TakeoverPayload());
-                    return true;
-                }
+                    {
+                        var __impl = (BasicDeliver)cmd.Method;
+                        HandleBasicDeliver(__impl._consumerTag, __impl._deliveryTag, __impl._redelivered, __impl._exchange, __impl._routingKey, (IBasicProperties)cmd.Header, cmd.Body, cmd.TakeoverPayload());
+                        return true;
+                    }
                 case ProtocolCommandId.BasicAck:
-                {
-                    var __impl = (BasicAck)cmd.Method;
-                    HandleBasicAck(__impl._deliveryTag, __impl._multiple);
-                    return true;
-                }
+                    {
+                        var __impl = (BasicAck)cmd.Method;
+                        HandleBasicAck(__impl._deliveryTag, __impl._multiple);
+                        return true;
+                    }
                 case ProtocolCommandId.BasicCancel:
-                {
-                    var __impl = (BasicCancel)cmd.Method;
-                    HandleBasicCancel(__impl._consumerTag);
-                    return true;
-                }
+                    {
+                        var __impl = (BasicCancel)cmd.Method;
+                        HandleBasicCancel(__impl._consumerTag);
+                        return true;
+                    }
                 case ProtocolCommandId.BasicCancelOk:
-                {
-                    var __impl = (BasicCancelOk)cmd.Method;
-                    HandleBasicCancelOk(__impl._consumerTag);
-                    return true;
-                }
+                    {
+                        var __impl = (BasicCancelOk)cmd.Method;
+                        HandleBasicCancelOk(__impl._consumerTag);
+                        return true;
+                    }
                 case ProtocolCommandId.BasicConsumeOk:
-                {
-                    var __impl = (BasicConsumeOk)cmd.Method;
-                    HandleBasicConsumeOk(__impl._consumerTag);
-                    return true;
-                }
+                    {
+                        var __impl = (BasicConsumeOk)cmd.Method;
+                        HandleBasicConsumeOk(__impl._consumerTag);
+                        return true;
+                    }
                 case ProtocolCommandId.BasicGetEmpty:
-                {
-                    HandleBasicGetEmpty();
-                    return true;
-                }
+                    {
+                        HandleBasicGetEmpty();
+                        return true;
+                    }
                 case ProtocolCommandId.BasicGetOk:
-                {
-                    var __impl = (BasicGetOk)cmd.Method;
-                    HandleBasicGetOk(__impl._deliveryTag, __impl._redelivered, __impl._exchange, __impl._routingKey, __impl._messageCount, (IBasicProperties) cmd.Header, cmd.Body, cmd.TakeoverPayload());
-                    return true;
-                }
+                    {
+                        var __impl = (BasicGetOk)cmd.Method;
+                        HandleBasicGetOk(__impl._deliveryTag, __impl._redelivered, __impl._exchange, __impl._routingKey, __impl._messageCount, (IBasicProperties)cmd.Header, cmd.Body, cmd.TakeoverPayload());
+                        return true;
+                    }
                 case ProtocolCommandId.BasicNack:
-                {
-                    var __impl = (BasicNack)cmd.Method;
-                    HandleBasicNack(__impl._deliveryTag, __impl._multiple, __impl._requeue);
-                    return true;
-                }
+                    {
+                        var __impl = (BasicNack)cmd.Method;
+                        HandleBasicNack(__impl._deliveryTag, __impl._multiple, __impl._requeue);
+                        return true;
+                    }
                 case ProtocolCommandId.BasicRecoverOk:
-                {
-                    HandleBasicRecoverOk();
-                    return true;
-                }
+                    {
+                        HandleBasicRecoverOk();
+                        return true;
+                    }
                 case ProtocolCommandId.BasicReturn:
-                {
-                    var __impl = (BasicReturn)cmd.Method;
-                    HandleBasicReturn(__impl._replyCode, __impl._replyText, __impl._exchange, __impl._routingKey, (IBasicProperties) cmd.Header, cmd.Body, cmd.TakeoverPayload());
-                    return true;
-                }
+                    {
+                        var __impl = (BasicReturn)cmd.Method;
+                        HandleBasicReturn(__impl._replyCode, __impl._replyText, __impl._exchange, __impl._routingKey, (IBasicProperties)cmd.Header, cmd.Body, cmd.TakeoverPayload());
+                        return true;
+                    }
                 case ProtocolCommandId.ChannelClose:
-                {
-                    var __impl = (ChannelClose)cmd.Method;
-                    HandleChannelClose(__impl._replyCode, __impl._replyText, __impl._classId, __impl._methodId);
-                    return true;
-                }
+                    {
+                        var __impl = (ChannelClose)cmd.Method;
+                        HandleChannelClose(__impl._replyCode, __impl._replyText, __impl.ProtocolCommandId);
+                        return true;
+                    }
                 case ProtocolCommandId.ChannelCloseOk:
-                {
-                    HandleChannelCloseOk();
-                    return true;
-                }
+                    {
+                        HandleChannelCloseOk();
+                        return true;
+                    }
                 case ProtocolCommandId.ChannelFlow:
-                {
-                    var __impl = (ChannelFlow)cmd.Method;
-                    HandleChannelFlow(__impl._active);
-                    return true;
-                }
+                    {
+                        var __impl = (ChannelFlow)cmd.Method;
+                        HandleChannelFlow(__impl._active);
+                        return true;
+                    }
                 case ProtocolCommandId.ConnectionBlocked:
-                {
-                    var __impl = (ConnectionBlocked)cmd.Method;
-                    HandleConnectionBlocked(__impl._reason);
-                    return true;
-                }
+                    {
+                        var __impl = (ConnectionBlocked)cmd.Method;
+                        HandleConnectionBlocked(__impl._reason);
+                        return true;
+                    }
                 case ProtocolCommandId.ConnectionClose:
-                {
-                    var __impl = (ConnectionClose)cmd.Method;
-                    HandleConnectionClose(__impl._replyCode, __impl._replyText, __impl._classId, __impl._methodId);
-                    return true;
-                }
+                    {
+                        var __impl = (ConnectionClose)cmd.Method;
+                        HandleConnectionClose(__impl._replyCode, __impl._replyText, __impl._classId, __impl._methodId);
+                        return true;
+                    }
                 case ProtocolCommandId.ConnectionSecure:
-                {
-                    var __impl = (ConnectionSecure)cmd.Method;
-                    HandleConnectionSecure(__impl._challenge);
-                    return true;
-                }
+                    {
+                        var __impl = (ConnectionSecure)cmd.Method;
+                        HandleConnectionSecure(__impl._challenge);
+                        return true;
+                    }
                 case ProtocolCommandId.ConnectionStart:
-                {
-                    var __impl = (ConnectionStart)cmd.Method;
-                    HandleConnectionStart(__impl._versionMajor, __impl._versionMinor, __impl._serverProperties, __impl._mechanisms, __impl._locales);
-                    return true;
-                }
+                    {
+                        var __impl = (ConnectionStart)cmd.Method;
+                        HandleConnectionStart(__impl._versionMajor, __impl._versionMinor, __impl._serverProperties, __impl._mechanisms, __impl._locales);
+                        return true;
+                    }
                 case ProtocolCommandId.ConnectionTune:
-                {
-                    var __impl = (ConnectionTune)cmd.Method;
-                    HandleConnectionTune(__impl._channelMax, __impl._frameMax, __impl._heartbeat);
-                    return true;
-                }
+                    {
+                        var __impl = (ConnectionTune)cmd.Method;
+                        HandleConnectionTune(__impl._channelMax, __impl._frameMax, __impl._heartbeat);
+                        return true;
+                    }
                 case ProtocolCommandId.ConnectionUnblocked:
-                {
-                    HandleConnectionUnblocked();
-                    return true;
-                }
+                    {
+                        HandleConnectionUnblocked();
+                        return true;
+                    }
                 case ProtocolCommandId.QueueDeclareOk:
-                {
-                    var __impl = (QueueDeclareOk)cmd.Method;
-                    HandleQueueDeclareOk(__impl._queue, __impl._messageCount, __impl._consumerCount);
-                    return true;
-                }
+                    {
+                        var __impl = (QueueDeclareOk)cmd.Method;
+                        HandleQueueDeclareOk(__impl._queue, __impl._messageCount, __impl._consumerCount);
+                        return true;
+                    }
                 default: return false;
             }
         }

--- a/projects/RabbitMQ.Client/client/framing/Protocol.cs
+++ b/projects/RabbitMQ.Client/client/framing/Protocol.cs
@@ -60,8 +60,8 @@ namespace RabbitMQ.Client.Framing
             return DecodeMethodFrom(commandId, span.Slice(4));
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ProtocolCommandId ReadCommandId(ReadOnlySpan<byte> span) => (ProtocolCommandId)Util.NetworkOrderDeserializer.ReadUInt32(span);
+        [MethodImpl(RabbitMQMethodImplOptions.Optimized)]
+        public static ProtocolCommandId ReadCommandId(ReadOnlySpan<byte> span) => (ProtocolCommandId)Util.NetworkOrderDeserializer.ReadUInt32(span, 0);
 
         private static Client.Impl.MethodBase DecodeMethodFrom(ProtocolCommandId commandId, ReadOnlySpan<byte> span)
         {

--- a/projects/RabbitMQ.Client/client/framing/QueueBind.cs
+++ b/projects/RabbitMQ.Client/client/framing/QueueBind.cs
@@ -31,6 +31,7 @@
 
 using System;
 using System.Collections.Generic;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -62,11 +63,11 @@ namespace RabbitMQ.Client.Framing.Impl
         public QueueBind(ReadOnlySpan<byte> span)
         {
             int offset = 2;
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _queue);
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _exchange);
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _routingKey);
-            offset += WireFormatting.ReadBits(span.Slice(offset), out _nowait);
-            WireFormatting.ReadDictionary(span.Slice(offset), out var tmpDictionary);
+            offset += WireFormatting.ReadShortstr(span, offset, out _queue);
+            offset += WireFormatting.ReadShortstr(span, offset, out _exchange);
+            offset += WireFormatting.ReadShortstr(span, offset, out _routingKey);
+            offset += WireFormatting.ReadBits(span, offset, out _nowait);
+            WireFormatting.ReadDictionary(span, offset, out var tmpDictionary);
             _arguments = tmpDictionary;
         }
 
@@ -76,12 +77,12 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteShort(span, default);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _queue);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _exchange);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _routingKey);
-            offset += WireFormatting.WriteBits(span.Slice(offset), _nowait);
-            return offset + WireFormatting.WriteTable(span.Slice(offset), _arguments);
+            int offset = WireFormatting.WriteShort(span, 0, default);
+            offset += WireFormatting.WriteShortstr(span, offset, _queue);
+            offset += WireFormatting.WriteShortstr(span, offset, _exchange);
+            offset += WireFormatting.WriteShortstr(span, offset, _routingKey);
+            offset += WireFormatting.WriteBits(ref span[offset], _nowait);
+            return offset + WireFormatting.WriteTable(span, offset, _arguments);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/QueueDeclare.cs
+++ b/projects/RabbitMQ.Client/client/framing/QueueDeclare.cs
@@ -31,6 +31,7 @@
 
 using System;
 using System.Collections.Generic;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -66,9 +67,9 @@ namespace RabbitMQ.Client.Framing.Impl
         public QueueDeclare(ReadOnlySpan<byte> span)
         {
             int offset = 2;
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _queue);
-            offset += WireFormatting.ReadBits(span.Slice(offset), out _passive,  out _durable, out _exclusive, out _autoDelete, out _nowait);
-            WireFormatting.ReadDictionary(span.Slice(offset), out var tmpDictionary);
+            offset += WireFormatting.ReadShortstr(span, offset, out _queue);
+            offset += WireFormatting.ReadBits(span, offset, out _passive, out _durable, out _exclusive, out _autoDelete, out _nowait);
+            WireFormatting.ReadDictionary(span, offset, out var tmpDictionary);
             _arguments = tmpDictionary;
         }
 
@@ -78,10 +79,10 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteShort(span, default);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _queue);
-            offset += WireFormatting.WriteBits(span.Slice(offset), _passive, _durable, _exclusive, _autoDelete, _nowait);
-            return offset + WireFormatting.WriteTable(span.Slice(offset), _arguments);
+            int offset = WireFormatting.WriteShort(span, 0, default);
+            offset += WireFormatting.WriteShortstr(span, offset, _queue);
+            offset += WireFormatting.WriteBits(ref span[offset], _passive, _durable, _exclusive, _autoDelete, _nowait);
+            return offset + WireFormatting.WriteTable(span, offset, _arguments);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/QueueDeclareOk.cs
+++ b/projects/RabbitMQ.Client/client/framing/QueueDeclareOk.cs
@@ -55,9 +55,9 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public QueueDeclareOk(ReadOnlySpan<byte> span)
         {
-            int offset = WireFormatting.ReadShortstr(span, out _queue);
-            offset += WireFormatting.ReadLong(span.Slice(offset), out _messageCount);
-            WireFormatting.ReadLong(span.Slice(offset), out _consumerCount);
+            int offset = WireFormatting.ReadShortstr(span, 0, out _queue);
+            offset += WireFormatting.ReadLong(span, offset, out _messageCount);
+            WireFormatting.ReadLong(span, offset, out _consumerCount);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.QueueDeclareOk;
@@ -66,9 +66,9 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteShortstr(span, _queue);
-            offset += WireFormatting.WriteLong(span.Slice(offset), _messageCount);
-            return offset + WireFormatting.WriteLong(span.Slice(offset), _consumerCount);
+            int offset = WireFormatting.WriteShortstr(span, 0, _queue);
+            offset += WireFormatting.WriteLong(span, offset, _messageCount);
+            return offset + WireFormatting.WriteLong(span, offset, _consumerCount);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/QueueDelete.cs
+++ b/projects/RabbitMQ.Client/client/framing/QueueDelete.cs
@@ -30,6 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -59,8 +60,8 @@ namespace RabbitMQ.Client.Framing.Impl
         public QueueDelete(ReadOnlySpan<byte> span)
         {
             int offset = 2;
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _queue);
-            WireFormatting.ReadBits(span.Slice(offset), out _ifUnused, out _ifEmpty, out _nowait);
+            offset += WireFormatting.ReadShortstr(span, offset, out _queue);
+            WireFormatting.ReadBits(span, offset, out _ifUnused, out _ifEmpty, out _nowait);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.QueueDelete;
@@ -69,9 +70,9 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteShort(span, default);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _queue);
-            return offset + WireFormatting.WriteBits(span.Slice(offset), _ifUnused, _ifEmpty, _nowait);
+            int offset = WireFormatting.WriteShort(span, 0, default);
+            offset += WireFormatting.WriteShortstr(span, offset, _queue);
+            return offset + WireFormatting.WriteBits(ref span[offset], _ifUnused, _ifEmpty, _nowait);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/QueueDeleteOk.cs
+++ b/projects/RabbitMQ.Client/client/framing/QueueDeleteOk.cs
@@ -30,6 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -50,7 +51,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public QueueDeleteOk(ReadOnlySpan<byte> span)
         {
-            WireFormatting.ReadLong(span, out _messageCount);
+            WireFormatting.ReadLong(span, 0, out _messageCount);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.QueueDeleteOk;
@@ -59,7 +60,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            return WireFormatting.WriteLong(span, _messageCount);
+            return WireFormatting.WriteLong(span, 0, _messageCount);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/QueuePurge.cs
+++ b/projects/RabbitMQ.Client/client/framing/QueuePurge.cs
@@ -30,6 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -55,8 +56,8 @@ namespace RabbitMQ.Client.Framing.Impl
         public QueuePurge(ReadOnlySpan<byte> span)
         {
             int offset = 2;
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _queue);
-            WireFormatting.ReadBits(span.Slice(offset), out _nowait);
+            offset += WireFormatting.ReadShortstr(span, offset, out _queue);
+            WireFormatting.ReadBits(span, offset, out _nowait);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.QueuePurge;
@@ -65,9 +66,9 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteShort(span, default);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _queue);
-            return offset + WireFormatting.WriteBits(span.Slice(offset), _nowait);
+            int offset = WireFormatting.WriteShort(span, 0, default);
+            offset += WireFormatting.WriteShortstr(span, offset, _queue);
+            return offset + WireFormatting.WriteBits(ref span[offset], _nowait);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/QueuePurgeOk.cs
+++ b/projects/RabbitMQ.Client/client/framing/QueuePurgeOk.cs
@@ -30,6 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -50,7 +51,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public QueuePurgeOk(ReadOnlySpan<byte> span)
         {
-            WireFormatting.ReadLong(span, out _messageCount);
+            WireFormatting.ReadLong(span, 0, out _messageCount);
         }
 
         public override ProtocolCommandId ProtocolCommandId => ProtocolCommandId.QueuePurgeOk;
@@ -59,7 +60,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            return WireFormatting.WriteLong(span, _messageCount);
+            return WireFormatting.WriteLong(span, 0, _messageCount);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/framing/QueueUnbind.cs
+++ b/projects/RabbitMQ.Client/client/framing/QueueUnbind.cs
@@ -60,10 +60,10 @@ namespace RabbitMQ.Client.Framing.Impl
         public QueueUnbind(ReadOnlySpan<byte> span)
         {
             int offset = 2;
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _queue);
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _exchange);
-            offset += WireFormatting.ReadShortstr(span.Slice(offset), out _routingKey);
-            WireFormatting.ReadDictionary(span.Slice(offset), out var tmpDictionary);
+            offset += WireFormatting.ReadShortstr(span, offset, out _queue);
+            offset += WireFormatting.ReadShortstr(span, offset, out _exchange);
+            offset += WireFormatting.ReadShortstr(span, offset, out _routingKey);
+            WireFormatting.ReadDictionary(span, offset, out var tmpDictionary);
             _arguments = tmpDictionary;
         }
 
@@ -73,11 +73,11 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override int WriteArgumentsTo(Span<byte> span)
         {
-            int offset = WireFormatting.WriteShort(span, default);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _queue);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _exchange);
-            offset += WireFormatting.WriteShortstr(span.Slice(offset), _routingKey);
-            return offset + WireFormatting.WriteTable(span.Slice(offset), _arguments);
+            int offset = WireFormatting.WriteShort(span, 0, default);
+            offset += WireFormatting.WriteShortstr(span, offset, _queue);
+            offset += WireFormatting.WriteShortstr(span, offset, _exchange);
+            offset += WireFormatting.WriteShortstr(span, offset, _routingKey);
+            return offset + WireFormatting.WriteTable(span, offset, _arguments);
         }
 
         public override int GetRequiredBufferSize()

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.cs
@@ -231,7 +231,7 @@ namespace RabbitMQ.Client.Framing.Impl
         private void EnsureIsOpen()
             => InnerConnection.EnsureIsOpen();
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(RabbitMQMethodImplOptions.Optimized)]
         private void ThrowIfDisposed()
         {
             if (_disposed)

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
@@ -426,7 +426,7 @@ namespace RabbitMQ.Client.Impl
         public IBasicPublishBatch CreateBasicPublishBatch(int sizeHint)
             => InnerChannel.CreateBasicPublishBatch(sizeHint);
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(RabbitMQMethodImplOptions.Optimized)]
         private void ThrowIfDisposed()
         {
             if (_disposed)

--- a/projects/RabbitMQ.Client/client/impl/BasicPublishBatch.cs
+++ b/projects/RabbitMQ.Client/client/impl/BasicPublishBatch.cs
@@ -61,6 +61,7 @@ namespace RabbitMQ.Client.Impl
                 _routingKey = routingKey,
                 _mandatory = mandatory
             };
+
             _commands.Add(new OutgoingContentCommand(method, (ContentHeaderBase)(basicProperties ?? _model._emptyBasicProperties), body));
         }
 

--- a/projects/RabbitMQ.Client/client/impl/CommandAssembler.cs
+++ b/projects/RabbitMQ.Client/client/impl/CommandAssembler.cs
@@ -115,8 +115,8 @@ namespace RabbitMQ.Client.Impl
             }
 
             ReadOnlySpan<byte> span = frame.Payload.Span;
-            _header = _protocol.DecodeContentHeaderFrom(NetworkOrderDeserializer.ReadUInt16(span), span.Slice(12));
-            ulong totalBodyBytes = NetworkOrderDeserializer.ReadUInt64(span.Slice(4));
+            _header = _protocol.DecodeContentHeaderFrom(NetworkOrderDeserializer.ReadUInt16(span, 0), span.Slice(12));
+            ulong totalBodyBytes = NetworkOrderDeserializer.ReadUInt64(span, 4);
             if (totalBodyBytes > MaxArrayOfBytesSize)
             {
                 throw new UnexpectedFrameException(frame.Type);

--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -269,7 +269,7 @@ namespace RabbitMQ.Client.Framing.Impl
                 {
                     // Try to send connection.close
                     // Wait for CloseOk in the MainLoop
-                    _session0.Transmit(new OutgoingCommand(new Impl.ConnectionClose(reason.ReplyCode, reason.ReplyText, 0, 0)));
+                    _session0.Transmit(new Impl.ConnectionClose(reason.ReplyCode, reason.ReplyText, 0, 0));
                 }
                 catch (AlreadyClosedException)
                 {
@@ -397,7 +397,7 @@ namespace RabbitMQ.Client.Framing.Impl
                 _session0.SetSessionClosing(false);
                 try
                 {
-                    _session0.Transmit(new OutgoingCommand(new ConnectionClose(hpe.ShutdownReason.ReplyCode, hpe.ShutdownReason.ReplyText, 0, 0)));
+                    _session0.Transmit(new ConnectionClose(hpe.ShutdownReason.ReplyCode, hpe.ShutdownReason.ReplyText, 0, 0));
                     return true;
                 }
                 catch (IOException ioe)
@@ -634,7 +634,7 @@ namespace RabbitMQ.Client.Framing.Impl
             // our peer. The peer will respond through the lower
             // layers - specifically, through the QuiescingSession we
             // installed above.
-            newSession.Transmit(new OutgoingCommand(new Impl.ChannelClose(pe.ReplyCode, pe.Message, 0, 0)));
+            newSession.Transmit(new Impl.ChannelClose(pe.ReplyCode, pe.Message, 0, 0));
         }
 
         private bool SetCloseReason(ShutdownEventArgs reason)
@@ -925,7 +925,7 @@ namespace RabbitMQ.Client.Framing.Impl
             MaybeStartHeartbeatTimers();
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(RabbitMQMethodImplOptions.Optimized)]
         private void ThrowIfDisposed()
         {
             if (_disposed)

--- a/projects/RabbitMQ.Client/client/impl/ConsumerDispatching/ConsumerDispatcherChannelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ConsumerDispatching/ConsumerDispatcherChannelBase.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Threading.Channels;
 using System.Threading.Tasks;
+
 using RabbitMQ.Client.Impl;
 
 namespace RabbitMQ.Client.ConsumerDispatching
 {
-    #nullable enable
+#nullable enable
     internal abstract class ConsumerDispatcherChannelBase : ConsumerDispatcherBase, IConsumerDispatcher
     {
         protected readonly ModelBase _model;
@@ -48,7 +49,7 @@ namespace RabbitMQ.Client.ConsumerDispatching
             if (!IsShutdown)
             {
                 AddConsumer(consumer, consumerTag);
-               _writer.TryWrite(new WorkStruct(WorkType.ConsumeOk, consumer, consumerTag));
+                _writer.TryWrite(new WorkStruct(WorkType.ConsumeOk, consumer, consumerTag));
             }
         }
 
@@ -104,12 +105,12 @@ namespace RabbitMQ.Client.ConsumerDispatching
         {
             public readonly IBasicConsumer Consumer;
             public IAsyncBasicConsumer AsyncConsumer => (IAsyncBasicConsumer)Consumer;
-            public readonly string ConsumerTag;
+            public readonly string? ConsumerTag;
             public readonly ulong DeliveryTag;
             public readonly bool Redelivered;
-            public readonly string Exchange;
-            public readonly string RoutingKey;
-            public readonly IBasicProperties BasicProperties;
+            public readonly string? Exchange;
+            public readonly string? RoutingKey;
+            public readonly IBasicProperties? BasicProperties;
             public readonly ReadOnlyMemory<byte> Body;
             public readonly byte[]? RentedArray;
             public readonly ShutdownEventArgs? Reason;

--- a/projects/RabbitMQ.Client/client/impl/Frame.cs
+++ b/projects/RabbitMQ.Client/client/impl/Frame.cs
@@ -65,15 +65,15 @@ namespace RabbitMQ.Client.Impl
              * +----------+-----------+-----------+ */
             public const int FrameSize = BaseFrameSize + 2 + 2;
 
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            [MethodImpl(RabbitMQMethodImplOptions.Optimized)]
             public static int WriteTo<T>(Span<byte> span, ushort channel, T method) where T : MethodBase
             {
                 const int StartClassId = StartPayload;
                 const int StartMethodArguments = StartClassId + 4;
 
                 int payloadLength = method.WriteArgumentsTo(span.Slice(StartMethodArguments)) + 4;
-                NetworkOrderSerializer.WriteUInt64(span, ((ulong)Constants.FrameMethod << 56) | ((ulong)channel << 40) | ((ulong)payloadLength << 8));
-                NetworkOrderSerializer.WriteUInt32(span.Slice(StartClassId), (uint)method.ProtocolCommandId);
+                NetworkOrderSerializer.WriteUInt64(ref span[0], ((ulong)Constants.FrameMethod << 56) | ((ulong)channel << 40) | ((ulong)payloadLength << 8));
+                NetworkOrderSerializer.WriteUInt32(ref span[StartClassId], (uint)method.ProtocolCommandId);
                 span[payloadLength + StartPayload] = Constants.FrameEnd;
                 return payloadLength + BaseFrameSize;
             }
@@ -88,7 +88,7 @@ namespace RabbitMQ.Client.Impl
              * +----------+----------+-------------------+-----------+ */
             public const int FrameSize = BaseFrameSize + 2 + 2 + 8;
 
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            [MethodImpl(RabbitMQMethodImplOptions.Optimized)]
             public static int WriteTo<T>(Span<byte> span, ushort channel, T header, int bodyLength) where T : ContentHeaderBase
             {
                 const int StartClassId = StartPayload;
@@ -96,9 +96,9 @@ namespace RabbitMQ.Client.Impl
                 const int StartHeaderArguments = StartPayload + 12;
 
                 int payloadLength = 12 + header.WritePropertiesTo(span.Slice(StartHeaderArguments));
-                NetworkOrderSerializer.WriteUInt64(span, ((ulong)Constants.FrameHeader << 56) | ((ulong)channel << 40) | ((ulong)payloadLength << 8));
-                NetworkOrderSerializer.WriteUInt32(span.Slice(StartClassId), (uint)header.ProtocolClassId << 16); // The last 16 bytes (Weight) aren't used
-                NetworkOrderSerializer.WriteUInt64(span.Slice(StartBodyLength), (ulong)bodyLength);
+                NetworkOrderSerializer.WriteUInt64(ref span[0], ((ulong)Constants.FrameHeader << 56) | ((ulong)channel << 40) | ((ulong)payloadLength << 8));
+                NetworkOrderSerializer.WriteUInt32(ref span[StartClassId], (uint)header.ProtocolClassId << 16); // The last 16 bytes (Weight) aren't used
+                NetworkOrderSerializer.WriteUInt64(ref span[StartBodyLength], (ulong)bodyLength);
                 span[payloadLength + StartPayload] = Constants.FrameEnd;
                 return payloadLength + BaseFrameSize;
             }
@@ -113,11 +113,11 @@ namespace RabbitMQ.Client.Impl
              * +--------------+ */
             public const int FrameSize = BaseFrameSize;
 
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            [MethodImpl(RabbitMQMethodImplOptions.Optimized)]
             public static int WriteTo(Span<byte> span, ushort channel, ReadOnlySpan<byte> body)
             {
                 const int StartBodyArgument = StartPayload;
-                NetworkOrderSerializer.WriteUInt64(span, ((ulong)Constants.FrameBody << 56) | ((ulong)channel << 40) | ((ulong)body.Length << 8));
+                NetworkOrderSerializer.WriteUInt64(ref span[0], ((ulong)Constants.FrameBody << 56) | ((ulong)channel << 40) | ((ulong)body.Length << 8));
                 body.CopyTo(span.Slice(StartBodyArgument));
                 span[StartPayload + body.Length] = Constants.FrameEnd;
                 return body.Length + BaseFrameSize;
@@ -227,8 +227,8 @@ namespace RabbitMQ.Client.Impl
             }
 
             FrameType type = (FrameType)firstByte;
-            int channel = NetworkOrderDeserializer.ReadUInt16(new ReadOnlySpan<byte>(frameHeaderBuffer, 1, 2));
-            int payloadSize = NetworkOrderDeserializer.ReadInt32(new ReadOnlySpan<byte>(frameHeaderBuffer, 3, 4)); // FIXME - throw exn on unreasonable value
+            int channel = NetworkOrderDeserializer.ReadUInt16(frameHeaderBuffer, 1);
+            int payloadSize = NetworkOrderDeserializer.ReadInt32(frameHeaderBuffer, 3); // FIXME - throw exn on unreasonable value
 
             const int EndMarkerLength = 1;
             // Is returned by InboundFrame.ReturnPayload in Connection.MainLoopIteration

--- a/projects/RabbitMQ.Client/client/impl/ISession.cs
+++ b/projects/RabbitMQ.Client/client/impl/ISession.cs
@@ -74,7 +74,8 @@ namespace RabbitMQ.Client.Impl
         void Close(ShutdownEventArgs reason, bool notify);
         bool HandleFrame(in InboundFrame frame);
         void Notify();
-        void Transmit<T>(in T cmd) where T : struct, IOutgoingCommand;
-        void Transmit<T>(List<T> cmds) where T : struct, IOutgoingCommand;
+        void Transmit<T>(T cmd) where T : MethodBase;
+        void Transmit<TMethod, THeader>(TMethod cmd, THeader header, ReadOnlyMemory<byte> body) where TMethod : MethodBase where THeader : ContentHeaderBase;
+        void Transmit(List<OutgoingContentCommand> cmds);
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/MainSession.cs
+++ b/projects/RabbitMQ.Client/client/impl/MainSession.cs
@@ -105,18 +105,18 @@ namespace RabbitMQ.Client.Impl
             }
         }
 
-        public override void Transmit<T>(in T cmd)
+        public override void Transmit<T>(T cmd)
         {
             if (_closing && // Are we closing?
-                cmd.Method.ProtocolCommandId != ProtocolCommandId.ConnectionCloseOk && // is this not a close-ok?
-                (_closeServerInitiated || cmd.Method.ProtocolCommandId != ProtocolCommandId.ConnectionClose)) // is this either server initiated or not a close?
+                cmd.ProtocolCommandId != ProtocolCommandId.ConnectionCloseOk && // is this not a close-ok?
+                (_closeServerInitiated || cmd.ProtocolCommandId != ProtocolCommandId.ConnectionClose)) // is this either server initiated or not a close?
             {
                 // We shouldn't do anything since we are closing, not sending a connection-close-ok command
                 // and this is either a server-initiated close or not a connection-close command.
                 return;
             }
 
-            base.Transmit(in cmd);
+            base.Transmit(cmd);
         }
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/MethodBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/MethodBase.cs
@@ -30,6 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+
 using RabbitMQ.Client.client.framing;
 
 namespace RabbitMQ.Client.Impl

--- a/projects/RabbitMQ.Client/client/impl/QuiescingSession.cs
+++ b/projects/RabbitMQ.Client/client/impl/QuiescingSession.cs
@@ -61,7 +61,7 @@ namespace RabbitMQ.Client.Impl
                     case ProtocolCommandId.ChannelClose:
                         // We're already shutting down the channel, so
                         // just send back an ok.
-                        Transmit(new OutgoingCommand(new ConnectionCloseOk()));
+                        Transmit(new ConnectionCloseOk());
                         break;
                 }
             }

--- a/projects/RabbitMQ.Client/util/NetworkOrderDeserializer.cs
+++ b/projects/RabbitMQ.Client/util/NetworkOrderDeserializer.cs
@@ -6,53 +6,65 @@ namespace RabbitMQ.Util
 {
     internal static class NetworkOrderDeserializer
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static double ReadDouble(ReadOnlySpan<byte> span)
+        [MethodImpl(RabbitMQMethodImplOptions.Optimized)]
+        internal static double ReadDouble(ReadOnlySpan<byte> span, int offset)
         {
-            return BitConverter.Int64BitsToDouble(BinaryPrimitives.ReadInt64BigEndian(span));
+            long result = Unsafe.ReadUnaligned<long>(ref Unsafe.AsRef(span[offset]));
+            return BitConverter.Int64BitsToDouble(BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(result) : result);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static short ReadInt16(ReadOnlySpan<byte> span)
+        [MethodImpl(RabbitMQMethodImplOptions.Optimized)]
+        internal static short ReadInt16(ReadOnlySpan<byte> span, int offset)
         {
-            return BinaryPrimitives.ReadInt16BigEndian(span);
+            short result = Unsafe.ReadUnaligned<short>(ref Unsafe.AsRef(span[offset]));
+            return BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(result) : result;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int ReadInt32(ReadOnlySpan<byte> span)
+        [MethodImpl(RabbitMQMethodImplOptions.Optimized)]
+        internal static int ReadInt32(ReadOnlySpan<byte> span, int offset)
         {
-            return BinaryPrimitives.ReadInt32BigEndian(span);
+            int result = Unsafe.ReadUnaligned<int>(ref Unsafe.AsRef(span[offset]));
+            return BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(result) : result;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static long ReadInt64(ReadOnlySpan<byte> span)
+        [MethodImpl(RabbitMQMethodImplOptions.Optimized)]
+        internal static long ReadInt64(ReadOnlySpan<byte> span, int offset)
         {
-            return BinaryPrimitives.ReadInt64BigEndian(span);
+            long result = Unsafe.ReadUnaligned<long>(ref Unsafe.AsRef(span[offset]));
+            return BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(result) : result;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static float ReadSingle(ReadOnlySpan<byte> span)
+        [MethodImpl(RabbitMQMethodImplOptions.Optimized)]
+        internal static float ReadSingle(ReadOnlySpan<byte> span, int offset)
         {
-            uint num = BinaryPrimitives.ReadUInt32BigEndian(span);
-            return Unsafe.As<uint, float>(ref num);
+            uint result = Unsafe.ReadUnaligned<uint>(ref Unsafe.AsRef(span[offset]));
+            if (BitConverter.IsLittleEndian)
+            {
+                result = BinaryPrimitives.ReverseEndianness(result);
+            }
+
+            return Unsafe.As<uint, float>(ref result);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static ushort ReadUInt16(ReadOnlySpan<byte> span)
+        [MethodImpl(RabbitMQMethodImplOptions.Optimized)]
+        internal static ushort ReadUInt16(ReadOnlySpan<byte> span, int offset)
         {
-            return BinaryPrimitives.ReadUInt16BigEndian(span);
+            ushort result = Unsafe.ReadUnaligned<ushort>(ref Unsafe.AsRef(span[offset]));
+            return BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(result) : result;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static uint ReadUInt32(ReadOnlySpan<byte> span)
+        [MethodImpl(RabbitMQMethodImplOptions.Optimized)]
+        internal static uint ReadUInt32(ReadOnlySpan<byte> span, int offset)
         {
-            return BinaryPrimitives.ReadUInt32BigEndian(span);
+            uint result = Unsafe.ReadUnaligned<uint>(ref Unsafe.AsRef(span[offset]));
+            return BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(result) : result;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static ulong ReadUInt64(ReadOnlySpan<byte> span)
+        [MethodImpl(RabbitMQMethodImplOptions.Optimized)]
+        internal static ulong ReadUInt64(ReadOnlySpan<byte> span, int offset)
         {
-            return BinaryPrimitives.ReadUInt64BigEndian(span);
+            ulong result = Unsafe.ReadUnaligned<ulong>(ref Unsafe.AsRef(span[offset]));
+            return BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(result) : result;
         }
     }
 }

--- a/projects/RabbitMQ.Client/util/NetworkOrderSerializer.cs
+++ b/projects/RabbitMQ.Client/util/NetworkOrderSerializer.cs
@@ -6,53 +6,54 @@ namespace RabbitMQ.Util
 {
     internal static class NetworkOrderSerializer
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void WriteDouble(Span<byte> span, double val)
+        [MethodImpl(RabbitMQMethodImplOptions.Optimized)]
+        internal static void WriteDouble(ref byte destination, double val)
         {
-            BinaryPrimitives.WriteInt64BigEndian(span, BitConverter.DoubleToInt64Bits(val));
+            long longVal = BitConverter.DoubleToInt64Bits(val);
+            Unsafe.WriteUnaligned(ref destination, BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(longVal) : longVal);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void WriteInt16(Span<byte> span, short val)
+        [MethodImpl(RabbitMQMethodImplOptions.Optimized)]
+        internal static void WriteInt16(ref byte destination, short val)
         {
-            BinaryPrimitives.WriteInt16BigEndian(span, val);
+            Unsafe.WriteUnaligned(ref destination, BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(val) : val);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void WriteInt32(Span<byte> span, int val)
+        [MethodImpl(RabbitMQMethodImplOptions.Optimized)]
+        internal static void WriteInt32(ref byte destination, int val)
         {
-            BinaryPrimitives.WriteInt32BigEndian(span, val);
+            Unsafe.WriteUnaligned(ref destination, BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(val) : val);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void WriteInt64(Span<byte> span, long val)
+        [MethodImpl(RabbitMQMethodImplOptions.Optimized)]
+        internal static void WriteInt64(ref byte destination, long val)
         {
-            BinaryPrimitives.WriteInt64BigEndian(span, val);
+            Unsafe.WriteUnaligned(ref destination, BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(val) : val);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void WriteSingle(Span<byte> span, float val)
+        [MethodImpl(RabbitMQMethodImplOptions.Optimized)]
+        internal static void WriteSingle(ref byte destination, float val)
         {
             int tempVal = Unsafe.As<float, int>(ref val);
-            BinaryPrimitives.WriteInt32BigEndian(span, tempVal);
+            Unsafe.WriteUnaligned(ref destination, BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(tempVal) : tempVal);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void WriteUInt16(Span<byte> span, ushort val)
+        [MethodImpl(RabbitMQMethodImplOptions.Optimized)]
+        internal static void WriteUInt16(ref byte destination, ushort val)
         {
-            BinaryPrimitives.WriteUInt16BigEndian(span, val);
+            Unsafe.WriteUnaligned(ref destination, BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(val) : val);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void WriteUInt32(Span<byte> span, uint val)
+        [MethodImpl(RabbitMQMethodImplOptions.Optimized)]
+        internal static void WriteUInt32(ref byte destination, uint val)
         {
-            BinaryPrimitives.WriteUInt32BigEndian(span, val);
+            Unsafe.WriteUnaligned(ref destination, BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(val) : val);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void WriteUInt64(Span<byte> span, ulong val)
+        [MethodImpl(RabbitMQMethodImplOptions.Optimized)]
+        internal static void WriteUInt64(ref byte destination, ulong val)
         {
-            BinaryPrimitives.WriteUInt64BigEndian(span, val);
+            Unsafe.WriteUnaligned(ref destination, BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(val) : val);
         }
     }
 }

--- a/projects/RabbitMQ.Client/util/RabbitMQMethodImplOptions.cs
+++ b/projects/RabbitMQ.Client/util/RabbitMQMethodImplOptions.cs
@@ -1,0 +1,13 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace RabbitMQ
+{
+    internal struct RabbitMQMethodImplOptions
+    {
+#if NETCOREAPP
+        public const short Optimized = (short)(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization);
+#else
+        public const short Optimized = (short)MethodImplOptions.AggressiveInlining;
+#endif
+    }
+}

--- a/projects/Unit/TestFieldTableFormatting.cs
+++ b/projects/Unit/TestFieldTableFormatting.cs
@@ -64,8 +64,8 @@ namespace RabbitMQ.Client.Unit
             t["fieldarray"] = array;
             int bytesNeeded = WireFormatting.GetTableByteCount(t);
             byte[] bytes = new byte[bytesNeeded];
-            WireFormatting.WriteTable(bytes, t);
-            int bytesRead = WireFormatting.ReadDictionary(bytes, out var nt);
+            WireFormatting.WriteTable(bytes, 0, t);
+            int bytesRead = WireFormatting.ReadDictionary(bytes, 0, out var nt);
             Assert.AreEqual(bytesNeeded, bytesRead);
             Assert.AreEqual(Encoding.UTF8.GetBytes("Hello"), nt["string"]);
             Assert.AreEqual(1234, nt["int"]);
@@ -88,8 +88,8 @@ namespace RabbitMQ.Client.Unit
             };
             int bytesNeeded = WireFormatting.GetTableByteCount(t);
             byte[] bytes = new byte[bytesNeeded];
-            WireFormatting.WriteTable(bytes, t);
-            int bytesRead = WireFormatting.ReadDictionary(bytes, out _);
+            WireFormatting.WriteTable(bytes, 0, t);
+            int bytesRead = WireFormatting.ReadDictionary(bytes, 0, out _);
             Assert.AreEqual(bytesNeeded, bytesRead);
             Check(bytes, new byte[] {
                     0,0,0,9, // table length
@@ -108,8 +108,8 @@ namespace RabbitMQ.Client.Unit
             };
             int bytesNeeded = WireFormatting.GetTableByteCount(t);
             byte[] bytes = new byte[bytesNeeded];
-            WireFormatting.WriteTable(bytes, t);
-            int bytesRead = WireFormatting.ReadDictionary(bytes, out _);
+            WireFormatting.WriteTable(bytes, 0, t);
+            int bytesRead = WireFormatting.ReadDictionary(bytes, 0, out _);
             Assert.AreEqual(bytesNeeded, bytesRead);
             Check(bytes, new byte[] {
                     0,0,0,9, // table length
@@ -130,7 +130,7 @@ namespace RabbitMQ.Client.Unit
             int bytesNeeded = WireFormatting.GetTableByteCount(t);
             byte[] bytes = new byte[bytesNeeded];
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => WireFormatting.WriteTable(bytes, t));
+            Assert.Throws<ArgumentOutOfRangeException>(() => WireFormatting.WriteTable(bytes, 0, t));
         }
 
         [Test]
@@ -151,8 +151,8 @@ namespace RabbitMQ.Client.Unit
             t["V"] = null; // 2+1
             int bytesNeeded = WireFormatting.GetTableByteCount(t);
             byte[] bytes = new byte[bytesNeeded];
-            WireFormatting.WriteTable(bytes, t);
-            int bytesRead = WireFormatting.ReadDictionary(bytes, out var nt);
+            WireFormatting.WriteTable(bytes, 0, t);
+            int bytesRead = WireFormatting.ReadDictionary(bytes, 0, out var nt);
             Assert.AreEqual(bytesNeeded, bytesRead);
             Assert.AreEqual(typeof(byte), nt["B"].GetType()); Assert.AreEqual((byte)255, nt["B"]);
             Assert.AreEqual(typeof(sbyte), nt["b"].GetType()); Assert.AreEqual((sbyte)-128, nt["b"]);

--- a/projects/Unit/TestFieldTableFormattingGeneric.cs
+++ b/projects/Unit/TestFieldTableFormattingGeneric.cs
@@ -65,8 +65,8 @@ namespace RabbitMQ.Client.Unit
             t["fieldarray"] = array;
             int bytesNeeded = WireFormatting.GetTableByteCount(t);
             byte[] bytes = new byte[bytesNeeded];
-            WireFormatting.WriteTable(bytes, t);
-            int bytesRead = WireFormatting.ReadDictionary(bytes, out var nt);
+            WireFormatting.WriteTable(bytes, 0, t);
+            int bytesRead = WireFormatting.ReadDictionary(bytes, 0, out var nt);
             Assert.AreEqual(bytesNeeded, bytesRead);
             Assert.AreEqual(Encoding.UTF8.GetBytes("Hello"), nt["string"]);
             Assert.AreEqual(1234, nt["int"]);
@@ -89,8 +89,8 @@ namespace RabbitMQ.Client.Unit
             };
             int bytesNeeded = WireFormatting.GetTableByteCount(t);
             byte[] bytes = new byte[bytesNeeded];
-            WireFormatting.WriteTable(bytes, t);
-            int bytesRead = WireFormatting.ReadDictionary(bytes, out _);
+            WireFormatting.WriteTable(bytes, 0, t);
+            int bytesRead = WireFormatting.ReadDictionary(bytes, 0, out _);
             Assert.AreEqual(bytesNeeded, bytesRead);
             Check(bytes, new byte[] {
                     0,0,0,9, // table length
@@ -109,8 +109,8 @@ namespace RabbitMQ.Client.Unit
             };
             int bytesNeeded = WireFormatting.GetTableByteCount(t);
             byte[] bytes = new byte[bytesNeeded];
-            WireFormatting.WriteTable(bytes, t);
-            int bytesRead = WireFormatting.ReadDictionary(bytes, out _);
+            WireFormatting.WriteTable(bytes, 0, t);
+            int bytesRead = WireFormatting.ReadDictionary(bytes, 0, out _);
             Assert.AreEqual(bytesNeeded, bytesRead);
             Check(bytes, new byte[] {
                     0,0,0,9, // table length
@@ -138,8 +138,8 @@ namespace RabbitMQ.Client.Unit
             t["V"] = null;
             int bytesNeeded = WireFormatting.GetTableByteCount(t);
             byte[] bytes = new byte[bytesNeeded];
-            WireFormatting.WriteTable(bytes, t);
-            int bytesRead = WireFormatting.ReadDictionary(bytes, out var nt);
+            WireFormatting.WriteTable(bytes, 0, t);
+            int bytesRead = WireFormatting.ReadDictionary(bytes, 0, out var nt);
             Assert.AreEqual(bytesNeeded, bytesRead);
             Assert.AreEqual(typeof(byte), nt["B"].GetType()); Assert.AreEqual((byte)255, nt["B"]);
             Assert.AreEqual(typeof(sbyte), nt["b"].GetType()); Assert.AreEqual((sbyte)-128, nt["b"]);

--- a/projects/Unit/TestMethodArgumentCodec.cs
+++ b/projects/Unit/TestMethodArgumentCodec.cs
@@ -70,7 +70,7 @@ namespace RabbitMQ.Client.Unit
 
             int bytesNeeded = WireFormatting.GetTableByteCount(t);
             byte[] memory = new byte[bytesNeeded];
-            int offset = WireFormatting.WriteTable(memory.AsSpan(), t);
+            int offset = WireFormatting.WriteTable(memory.AsSpan(), 0, t);
             Assert.AreEqual(bytesNeeded, offset);
             Check(memory, new byte[] { 0x00, 0x00, 0x00, 0x0C,
                                    0x03, 0x61, 0x62, 0x63,
@@ -85,7 +85,7 @@ namespace RabbitMQ.Client.Unit
                 0x00, 0x00, 0x00, 0x0C,
                 0x03, 0x61, 0x62, 0x63,
                 0x53, 0x00, 0x00, 0x00,
-                0x03, 0x64, 0x65, 0x66 }, out var t);
+                0x03, 0x64, 0x65, 0x66 }, 0, out var t);
             Assert.AreEqual(Encoding.UTF8.GetBytes("def"), t["abc"]);
             Assert.AreEqual(1, t.Count);
         }
@@ -101,7 +101,7 @@ namespace RabbitMQ.Client.Unit
             t["x"] = x;
             int bytesNeeded = WireFormatting.GetTableByteCount(t);
             byte[] memory = new byte[bytesNeeded];
-            int offset = WireFormatting.WriteTable(memory.AsSpan(), t);
+            int offset = WireFormatting.WriteTable(memory.AsSpan(), 0, t);
             Assert.AreEqual(bytesNeeded, offset);
             Check(memory, new byte[] { 0x00, 0x00, 0x00, 0x0E,
                                    0x01, 0x78, 0x46, 0x00,

--- a/projects/Unit/TestNetworkByteOrderSerialization.cs
+++ b/projects/Unit/TestNetworkByteOrderSerialization.cs
@@ -40,7 +40,7 @@ namespace RabbitMQ.Client.Unit
     [TestFixture]
     class TestNetworkByteOrderSerialization
     {
-        public void Check(byte[] actual, byte[] expected)
+        public static void Check(byte[] actual, byte[] expected)
         {
             try
             {
@@ -64,28 +64,28 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void TestSingleDecoding()
         {
-            Assert.AreEqual(1.234f, NetworkOrderDeserializer.ReadSingle(_expectedSingleBytes.AsSpan()));
+            Assert.AreEqual(1.234f, NetworkOrderDeserializer.ReadSingle(_expectedSingleBytes.AsSpan(), 0));
         }
 
         [Test]
         public void TestSingleEncoding()
         {
             byte[] bytes = new byte[4];
-            NetworkOrderSerializer.WriteSingle(bytes, 1.234f);
+            NetworkOrderSerializer.WriteSingle(ref bytes[0], 1.234f);
             Check(bytes, _expectedSingleBytes);
         }
 
         [Test]
         public void TestDoubleDecoding()
         {
-            Assert.AreEqual(1.234, NetworkOrderDeserializer.ReadDouble(_expectedDoubleBytes.AsSpan()));
+            Assert.AreEqual(1.234, NetworkOrderDeserializer.ReadDouble(_expectedDoubleBytes.AsSpan(), 0));
         }
 
         [Test]
         public void TestDoubleEncoding()
         {
             byte[] bytes = new byte[8];
-            NetworkOrderSerializer.WriteDouble(bytes, 1.234);
+            NetworkOrderSerializer.WriteDouble(ref bytes[0], 1.234);
             Check(bytes, _expectedDoubleBytes);
         }
 
@@ -93,7 +93,7 @@ namespace RabbitMQ.Client.Unit
         public void TestWriteInt16_positive()
         {
             byte[] bytes = new byte[2];
-            NetworkOrderSerializer.WriteInt16(bytes, 0x1234);
+            NetworkOrderSerializer.WriteInt16(ref bytes[0], 0x1234);
             Check(bytes, new byte[] { 0x12, 0x34 });
         }
 
@@ -101,7 +101,7 @@ namespace RabbitMQ.Client.Unit
         public void TestWriteInt16_negative()
         {
             byte[] bytes = new byte[2];
-            NetworkOrderSerializer.WriteInt16(bytes, -0x1234);
+            NetworkOrderSerializer.WriteInt16(ref bytes[0], -0x1234);
             Check(bytes, new byte[] { 0xED, 0xCC });
         }
 
@@ -109,27 +109,27 @@ namespace RabbitMQ.Client.Unit
         public void TestWriteUInt16()
         {
             byte[] bytes = new byte[2];
-            NetworkOrderSerializer.WriteUInt16(bytes, 0x89AB);
+            NetworkOrderSerializer.WriteUInt16(ref bytes[0], 0x89AB);
             Check(bytes, new byte[] { 0x89, 0xAB });
         }
 
         [Test]
         public void TestReadInt16()
         {
-            Assert.AreEqual(0x1234, NetworkOrderDeserializer.ReadInt16(new byte[] { 0x12, 0x34 }.AsSpan()));
+            Assert.AreEqual(0x1234, NetworkOrderDeserializer.ReadInt16(new byte[] { 0x12, 0x34 }.AsSpan(), 0));
         }
 
         [Test]
         public void TestReadUInt16()
         {
-            Assert.AreEqual(0x89AB, NetworkOrderDeserializer.ReadUInt16(new byte[] { 0x89, 0xAB }.AsSpan()));
+            Assert.AreEqual(0x89AB, NetworkOrderDeserializer.ReadUInt16(new byte[] { 0x89, 0xAB }.AsSpan(), 0));
         }
 
         [Test]
         public void TestWriteInt32_positive()
         {
             byte[] bytes = new byte[4];
-            NetworkOrderSerializer.WriteInt32(bytes, 0x12345678);
+            NetworkOrderSerializer.WriteInt32(ref bytes[0], 0x12345678);
             Check(bytes, new byte[] { 0x12, 0x34, 0x56, 0x78 });
         }
 
@@ -137,7 +137,7 @@ namespace RabbitMQ.Client.Unit
         public void TestWriteInt32_negative()
         {
             byte[] bytes = new byte[4];
-            NetworkOrderSerializer.WriteInt32(bytes, -0x12345678);
+            NetworkOrderSerializer.WriteInt32(ref bytes[0], -0x12345678);
             Check(bytes, new byte[] { 0xED, 0xCB, 0xA9, 0x88 });
         }
 
@@ -145,20 +145,20 @@ namespace RabbitMQ.Client.Unit
         public void TestWriteUInt32()
         {
             byte[] bytes = new byte[4];
-            NetworkOrderSerializer.WriteUInt32(bytes, 0x89ABCDEF);
+            NetworkOrderSerializer.WriteUInt32(ref bytes[0], 0x89ABCDEF);
             Check(bytes, new byte[] { 0x89, 0xAB, 0xCD, 0xEF });
         }
 
         [Test]
         public void TestReadInt32()
         {
-            Assert.AreEqual(0x12345678, NetworkOrderDeserializer.ReadInt32(new byte[] { 0x12, 0x34, 0x56, 0x78 }.AsSpan()));
+            Assert.AreEqual(0x12345678, NetworkOrderDeserializer.ReadInt32(new byte[] { 0x12, 0x34, 0x56, 0x78 }.AsSpan(), 0));
         }
 
         [Test]
         public void TestReadUInt32()
         {
-            Assert.AreEqual(0x89ABCDEF, NetworkOrderDeserializer.ReadUInt32(new byte[] { 0x89, 0xAB, 0xCD, 0xEF }.AsSpan()));
+            Assert.AreEqual(0x89ABCDEF, NetworkOrderDeserializer.ReadUInt32(new byte[] { 0x89, 0xAB, 0xCD, 0xEF }.AsSpan(), 0));
         }
 
 
@@ -166,7 +166,7 @@ namespace RabbitMQ.Client.Unit
         public void TestWriteInt64_positive()
         {
             byte[] bytes = new byte[8];
-            NetworkOrderSerializer.WriteInt64(bytes, 0x123456789ABCDEF0);
+            NetworkOrderSerializer.WriteInt64(ref bytes[0], 0x123456789ABCDEF0);
             Check(bytes, new byte[] { 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0 });
         }
 
@@ -174,7 +174,7 @@ namespace RabbitMQ.Client.Unit
         public void TestWriteInt64_negative()
         {
             byte[] bytes = new byte[8];
-            NetworkOrderSerializer.WriteInt64(bytes, -0x123456789ABCDEF0);
+            NetworkOrderSerializer.WriteInt64(ref bytes[0], -0x123456789ABCDEF0);
             Check(bytes, new byte[] { 0xED, 0xCB, 0xA9, 0x87, 0x65, 0x43, 0x21, 0x10 });
         }
 
@@ -182,20 +182,20 @@ namespace RabbitMQ.Client.Unit
         public void TestWriteUInt64()
         {
             byte[] bytes = new byte[8];
-            NetworkOrderSerializer.WriteUInt64(bytes, 0x89ABCDEF01234567);
+            NetworkOrderSerializer.WriteUInt64(ref bytes[0], 0x89ABCDEF01234567);
             Check(bytes, new byte[] { 0x89, 0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67 });
         }
 
         [Test]
         public void TestReadInt64()
         {
-            Assert.AreEqual(0x123456789ABCDEF0, NetworkOrderDeserializer.ReadInt64(new byte[] { 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0 }.AsSpan()));
+            Assert.AreEqual(0x123456789ABCDEF0, NetworkOrderDeserializer.ReadInt64(new byte[] { 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0 }.AsSpan(), 0));
         }
 
         [Test]
         public void TestReadUInt64()
         {
-            Assert.AreEqual(0x89ABCDEF01234567, NetworkOrderDeserializer.ReadUInt64(new byte[] { 0x89, 0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67 }.AsSpan()));
+            Assert.AreEqual(0x89ABCDEF01234567, NetworkOrderDeserializer.ReadUInt64(new byte[] { 0x89, 0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67 }.AsSpan(), 0));
         }
     }
 }

--- a/projects/Unit/TestWireFormatting.cs
+++ b/projects/Unit/TestWireFormatting.cs
@@ -1,0 +1,39 @@
+﻿
+using NUnit.Framework;
+
+using RabbitMQ.Client.Impl;
+
+namespace RabbitMQ.Client.Unit
+{
+    [TestFixture]
+    public class TestWireFormatting
+    {
+        [TestCase(new byte[] { (byte)'V' }, null)]
+        [TestCase(new byte[] { (byte)'S', 0, 0, 0, 5, (byte)'H', (byte)'E', (byte)'L', (byte)'L', (byte)'O' }, "HELLO")]
+        [TestCase(new byte[] { (byte)'S', 0, 0, 0, 0 }, "")]
+        [TestCase(new byte[] { (byte)'S', 0, 0, 0, 5, (byte)'H', (byte)'E', (byte)'L', (byte)'L', (byte)'O' }, new[] { (byte)'H', (byte)'E', (byte)'L', (byte)'L', (byte)'O' })]
+        [TestCase(new byte[] { (byte)'S', 0, 0, 0, 0 }, new byte[0])]
+        [TestCase(new byte[] { (byte)'t', 1 }, true)]
+        [TestCase(new byte[] { (byte)'t', 0 }, false)]
+        [TestCase(new byte[] { (byte)'I', 0, 0, 0, 123 }, 123)]
+        public void TestFieldWrite(byte[] expected, object value)
+        {
+            var actual = new byte[expected.Length];
+            Assert.AreEqual(expected.Length, WireFormatting.WriteFieldValue(actual, 0, value));
+            TestNetworkByteOrderSerialization.Check(actual, expected);
+        }
+
+        [TestCase(new byte[] { (byte)'V' }, null)]
+        [TestCase(new byte[] { (byte)'S', 0, 0, 0, 5, (byte)'H', (byte)'E', (byte)'L', (byte)'L', (byte)'O' }, new[] { (byte)'H', (byte)'E', (byte)'L', (byte)'L', (byte)'O' })]
+        [TestCase(new byte[] { (byte)'S', 0, 0, 0, 0 }, "")]
+        [TestCase(new byte[] { (byte)'S', 0, 0, 0, 0 }, new byte[0])]
+        [TestCase(new byte[] { (byte)'t', 1 }, true)]
+        [TestCase(new byte[] { (byte)'t', 0 }, false)]
+        [TestCase(new byte[] { (byte)'I', 0, 0, 0, 123 }, 123)]
+        public void TestFieldRead(byte[] actual, object value)
+        {
+            Assert.AreEqual(WireFormatting.ReadFieldValue(actual, 0, out int read), value);
+            Assert.AreEqual(actual.Length, read);
+        }
+    }
+}

--- a/projects/Unit/Unit.csproj
+++ b/projects/Unit/Unit.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyOriginatorKeyFile>../rabbit.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <LangVersion>latest</LangVersion>
     <ReleaseVersion>8.0</ReleaseVersion>
+    <RootNamespace>RabbitMQ.Client.Unit</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Proposed Changes

This PR is not pretty to look at, most of it is ceremony around changes in the WireFormatting class. It does some optimizations to (de)serialization by getting rid of bounds checks and unnecessary arithmetic operations during the serialization phase. There are more improvements that can be made during framing but this results in a hefty net gain for all framing operations I've tested so far.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

This PR is not very pretty to look at, but it does result in hefty improvements to command framing both in the deserialization and serialization phase, so it should benefit all operations made within the client.