### PR TITLE
Resolve #1039 Confirms Failure should use ShutdownInitiator.Library

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/ModelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ModelBase.cs
@@ -1106,13 +1106,13 @@ namespace RabbitMQ.Client.Impl
                 }
 
                 await CloseAsync(
-                    new ShutdownEventArgs(ShutdownInitiator.Application, Constants.ReplySuccess, "Nacks Received",
+                    new ShutdownEventArgs(ShutdownInitiator.Library, Constants.ReplySuccess, "Nacks Received",
                         new IOException("nack received")),
                     false).ConfigureAwait(false);
             }
             catch (TaskCanceledException exception)
             {
-                await CloseAsync(new ShutdownEventArgs(ShutdownInitiator.Application,
+                await CloseAsync(new ShutdownEventArgs(ShutdownInitiator.Library,
                         Constants.ReplySuccess,
                         "Timed out waiting for acks",
                         exception),


### PR DESCRIPTION
## Proposed Changes

Rather than using `ShutdownInitiator.Application` in `ModelBase.WaitForConfirmsOrDieAsync`, use `ShutdownInitiator.Library` so consumers of the library can react differently based on the source of the Close.  See #1039.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Unfortunately, I cannot determine a mechanism by which I can add unit tests to verify this behavior. While this change can be considered a breaking change, it is binary compatible (no public interface changes), and the change aligns with the documented behavioral expectation of Models that were Closed by the library itself. I do not believe that any user of the library would have relied on the previous behavior.