### PR TITLE
Change recovery process to allow configuration recovery of closed channels

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recovery.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recovery.cs
@@ -146,7 +146,7 @@ namespace RabbitMQ.Client.Framing.Impl
                             RecoverExchanges(model);
                             RecoverQueues(model);
                             RecoverBindings(model);
-                            RecoverConsumers(model);
+                            RecoverConsumers();
                         }
                     }
 
@@ -278,7 +278,7 @@ namespace RabbitMQ.Client.Framing.Impl
             }
         }
 
-        private void RecoverConsumers(IModel model)
+        private void RecoverConsumers()
         {
             Dictionary<string, RecordedConsumer> recordedConsumersCopy;
             lock (_recordedEntitiesLock)
@@ -293,7 +293,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
                 try
                 {
-                    cons.Recover(model);
+                    cons.Recover();
                     string newTag = cons.ConsumerTag;
                     UpdateConsumer(oldTag, newTag, cons);
 

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recovery.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recovery.cs
@@ -135,7 +135,7 @@ namespace RabbitMQ.Client.Framing.Impl
                     RecoverModels();
                     if (_factory.TopologyRecoveryEnabled)
                     {
-                        using (var model = _innerConnection.CreateModel())
+                        using (IModel model = _innerConnection.CreateModel())
                         {
                             // The recovery sequence is the following:
                             //
@@ -143,11 +143,15 @@ namespace RabbitMQ.Client.Framing.Impl
                             // 2. Recover queues
                             // 3. Recover bindings
                             // 4. Recover consumers
+                            //
+                            // New IModel is used to recover the steps 1, 2 and 3 in case the original channel is closed. 
                             RecoverExchanges(model);
                             RecoverQueues(model);
                             RecoverBindings(model);
-                            RecoverConsumers();
                         }
+
+                        // Original IModel is used to recover and take over the original consumers.
+                        RecoverConsumers();
                     }
 
                     ESLog.Info("Connection recovery completed");

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
@@ -264,7 +264,7 @@ namespace RabbitMQ.Client.Impl
         public void ExchangeBind(string destination, string source, string routingKey, IDictionary<string, object> arguments)
         {
             ThrowIfDisposed();
-            RecordedBinding eb = new RecordedExchangeBinding(this, destination, source, routingKey, arguments);
+            RecordedBinding eb = new RecordedExchangeBinding(destination, source, routingKey, arguments);
             _connection.RecordBinding(eb);
             _innerChannel.ExchangeBind(destination, source, routingKey, arguments);
         }
@@ -276,7 +276,7 @@ namespace RabbitMQ.Client.Impl
         {
             ThrowIfDisposed();
             _innerChannel.ExchangeDeclare(exchange, type, durable, autoDelete, arguments);
-            RecordedExchange rx = new RecordedExchange(this, exchange, type, durable, autoDelete, arguments);
+            RecordedExchange rx = new RecordedExchange(exchange, type, durable, autoDelete, arguments);
             _connection.RecordExchange(rx);
         }
 
@@ -284,7 +284,7 @@ namespace RabbitMQ.Client.Impl
         {
             ThrowIfDisposed();
             _innerChannel.ExchangeDeclareNoWait(exchange, type, durable, autoDelete, arguments);
-            RecordedExchange rx = new RecordedExchange(this, exchange, type, durable, autoDelete, arguments);
+            RecordedExchange rx = new RecordedExchange(exchange, type, durable, autoDelete, arguments);
             _connection.RecordExchange(rx);
         }
 
@@ -306,7 +306,7 @@ namespace RabbitMQ.Client.Impl
         public void ExchangeUnbind(string destination, string source, string routingKey, IDictionary<string, object> arguments)
         {
             ThrowIfDisposed();
-            RecordedBinding eb = new RecordedExchangeBinding(this, destination, source, routingKey, arguments);
+            RecordedBinding eb = new RecordedExchangeBinding(destination, source, routingKey, arguments);
             _connection.DeleteRecordedBinding(eb);
             _innerChannel.ExchangeUnbind(destination, source, routingKey, arguments);
             _connection.DeleteAutoDeleteExchange(source);
@@ -318,7 +318,7 @@ namespace RabbitMQ.Client.Impl
         public void QueueBind(string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
         {
             ThrowIfDisposed();
-            RecordedBinding qb = new RecordedQueueBinding(this, queue, exchange, routingKey, arguments);
+            RecordedBinding qb = new RecordedQueueBinding(queue, exchange, routingKey, arguments);
             _connection.RecordBinding(qb);
             _innerChannel.QueueBind(queue, exchange, routingKey, arguments);
         }
@@ -330,7 +330,7 @@ namespace RabbitMQ.Client.Impl
         {
             ThrowIfDisposed();
             QueueDeclareOk result = _innerChannel.QueueDeclare(queue, durable, exclusive, autoDelete, arguments);
-            RecordedQueue rq = new RecordedQueue(this, result.QueueName, queue.Length == 0, durable, exclusive, autoDelete, arguments);
+            RecordedQueue rq = new RecordedQueue(result.QueueName, queue.Length == 0, durable, exclusive, autoDelete, arguments);
             _connection.RecordQueue(rq);
             return result;
         }
@@ -340,7 +340,7 @@ namespace RabbitMQ.Client.Impl
             ThrowIfDisposed();
             _innerChannel.QueueDeclareNoWait(queue, durable, exclusive,
                 autoDelete, arguments);
-            RecordedQueue rq = new RecordedQueue(this, queue, queue.Length == 0, durable, exclusive, autoDelete, arguments);
+            RecordedQueue rq = new RecordedQueue(queue, queue.Length == 0, durable, exclusive, autoDelete, arguments);
             _connection.RecordQueue(rq);
         }
 
@@ -373,7 +373,7 @@ namespace RabbitMQ.Client.Impl
         public void QueueUnbind(string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
         {
             ThrowIfDisposed();
-            RecordedBinding qb = new RecordedQueueBinding(this, queue, exchange, routingKey, arguments);
+            RecordedBinding qb = new RecordedQueueBinding(queue, exchange, routingKey, arguments);
             _connection.DeleteRecordedBinding(qb);
             _innerChannel.QueueUnbind(queue, exchange, routingKey, arguments);
             _connection.DeleteAutoDeleteExchange(exchange);

--- a/projects/RabbitMQ.Client/client/impl/RecordedBinding.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedBinding.cs
@@ -105,9 +105,9 @@ namespace RabbitMQ.Client.Impl
         {
         }
 
-        public override void Recover()
+        public override void Recover(IModel model)
         {
-            ModelDelegate.QueueBind(Destination, Source, RoutingKey, Arguments);
+            model.QueueBind(Destination, Source, RoutingKey, Arguments);
         }
     }
 
@@ -118,9 +118,9 @@ namespace RabbitMQ.Client.Impl
         {
         }
 
-        public override void Recover()
+        public override void Recover(IModel model)
         {
-            ModelDelegate.ExchangeBind(Destination, Source, RoutingKey, Arguments);
+            model.ExchangeBind(Destination, Source, RoutingKey, Arguments);
         }
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/RecordedBinding.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedBinding.cs
@@ -37,8 +37,8 @@ namespace RabbitMQ.Client.Impl
     #nullable enable
     internal abstract class RecordedBinding : RecordedEntity
     {
-        protected RecordedBinding(AutorecoveringModel channel, string destination, string source, string routingKey, IDictionary<string, object>? arguments)
-            : base(channel)
+        protected RecordedBinding(string destination, string source, string routingKey, IDictionary<string, object>? arguments)
+            : base()
         {
             Destination = destination;
             Source = source;
@@ -100,8 +100,8 @@ namespace RabbitMQ.Client.Impl
 
     internal sealed class RecordedQueueBinding : RecordedBinding
     {
-        public RecordedQueueBinding(AutorecoveringModel channel, string destination, string source, string routingKey, IDictionary<string, object>? arguments)
-            : base(channel, destination,  source, routingKey, arguments)
+        public RecordedQueueBinding(string destination, string source, string routingKey, IDictionary<string, object>? arguments)
+            : base(destination,  source, routingKey, arguments)
         {
         }
 
@@ -113,8 +113,8 @@ namespace RabbitMQ.Client.Impl
 
     internal sealed class RecordedExchangeBinding : RecordedBinding
     {
-        public RecordedExchangeBinding(AutorecoveringModel channel, string destination, string source, string routingKey, IDictionary<string, object>? arguments)
-            : base(channel, destination,  source, routingKey, arguments)
+        public RecordedExchangeBinding(string destination, string source, string routingKey, IDictionary<string, object>? arguments)
+            : base(destination,  source, routingKey, arguments)
         {
         }
 

--- a/projects/RabbitMQ.Client/client/impl/RecordedConsumer.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedConsumer.cs
@@ -54,9 +54,9 @@ namespace RabbitMQ.Client.Impl
         public bool Exclusive { get; }
         public IDictionary<string, object>? Arguments { get; }
 
-        public override void Recover()
+        public override void Recover(IModel model)
         {
-            ConsumerTag = ModelDelegate.BasicConsume(Queue, AutoAck, ConsumerTag, false, Exclusive, Arguments, Consumer);
+            ConsumerTag = model.BasicConsume(Queue, AutoAck, ConsumerTag, false, Exclusive, Arguments, Consumer);
         }
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/RecordedConsumer.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedConsumer.cs
@@ -34,7 +34,7 @@ using System.Collections.Generic;
 namespace RabbitMQ.Client.Impl
 {
     #nullable enable
-    internal sealed class RecordedConsumer : RecordedEntity
+    internal sealed class RecordedConsumer : RecordedConsumerEntity
     {
         public RecordedConsumer(AutorecoveringModel channel, IBasicConsumer consumer, string queue, bool autoAck, string consumerTag, bool exclusive, IDictionary<string, object>? arguments)
             : base(channel)
@@ -54,9 +54,9 @@ namespace RabbitMQ.Client.Impl
         public bool Exclusive { get; }
         public IDictionary<string, object>? Arguments { get; }
 
-        public override void Recover(IModel model)
+        public override void Recover()
         {
-            ConsumerTag = model.BasicConsume(Queue, AutoAck, ConsumerTag, false, Exclusive, Arguments, Consumer);
+            ConsumerTag = ModelDelegate.BasicConsume(Queue, AutoAck, ConsumerTag, false, Exclusive, Arguments, Consumer);
         }
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/RecordedConsumerEntity.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedConsumerEntity.cs
@@ -1,4 +1,4 @@
-// This source code is dual-licensed under the Apache License, version
+﻿// This source code is dual-licensed under the Apache License, version
 // 2.0, and the Mozilla Public License, version 2.0.
 //
 // The APL v2.0:
@@ -32,8 +32,20 @@
 namespace RabbitMQ.Client.Impl
 {
     #nullable enable
-    internal abstract class RecordedEntity
+    internal abstract class RecordedConsumerEntity
     {
-        public abstract void Recover(IModel model);
+        private readonly AutorecoveringModel _channel;
+
+        protected RecordedConsumerEntity(AutorecoveringModel channel)
+        {
+            _channel = channel;
+        }
+
+        protected IModel ModelDelegate
+        {
+            get { return _channel.InnerChannel; }
+        }
+
+        public abstract void Recover();
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/RecordedEntity.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedEntity.cs
@@ -48,4 +48,22 @@ namespace RabbitMQ.Client.Impl
 
         public abstract void Recover(IModel model);
     }
+
+    #nullable enable
+    internal abstract class RecordedConsumerEntity
+    {
+        private readonly AutorecoveringModel _channel;
+
+        protected RecordedConsumerEntity(AutorecoveringModel channel)
+        {
+            _channel = channel;
+        }
+
+        protected IModel ModelDelegate
+        {
+            get { return _channel.InnerChannel; }
+        }
+
+        public abstract void Recover();
+    }
 }

--- a/projects/RabbitMQ.Client/client/impl/RecordedEntity.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedEntity.cs
@@ -46,6 +46,6 @@ namespace RabbitMQ.Client.Impl
             get { return _channel.InnerChannel; }
         }
 
-        public abstract void Recover();
+        public abstract void Recover(IModel model);
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/RecordedExchange.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedExchange.cs
@@ -42,8 +42,8 @@ namespace RabbitMQ.Client.Impl
 
         public bool IsAutoDelete { get; }
 
-        public RecordedExchange(AutorecoveringModel channel, string name, string type, bool durable, bool isAutoDelete, IDictionary<string, object>? arguments)
-            : base(channel, name)
+        public RecordedExchange(string name, string type, bool durable, bool isAutoDelete, IDictionary<string, object>? arguments)
+            : base(name)
         {
             _type = type;
             _durable = durable;

--- a/projects/RabbitMQ.Client/client/impl/RecordedExchange.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedExchange.cs
@@ -51,9 +51,9 @@ namespace RabbitMQ.Client.Impl
             _arguments = arguments;
         }
 
-        public override void Recover()
+        public override void Recover(IModel model)
         {
-            ModelDelegate.ExchangeDeclare(Name, _type, _durable, IsAutoDelete, _arguments);
+            model.ExchangeDeclare(Name, _type, _durable, IsAutoDelete, _arguments);
         }
 
         public override string ToString()

--- a/projects/RabbitMQ.Client/client/impl/RecordedNamedEntity.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedNamedEntity.cs
@@ -34,7 +34,7 @@ namespace RabbitMQ.Client.Impl
     #nullable enable
     internal abstract class RecordedNamedEntity : RecordedEntity
     {
-        protected RecordedNamedEntity(AutorecoveringModel channel, string name) : base(channel)
+        protected RecordedNamedEntity(string name) : base()
         {
             Name = name;
         }

--- a/projects/RabbitMQ.Client/client/impl/RecordedQueue.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedQueue.cs
@@ -43,8 +43,8 @@ namespace RabbitMQ.Client.Impl
         public bool IsAutoDelete { get; }
         public bool IsServerNamed { get; }
 
-        public RecordedQueue(AutorecoveringModel channel, string name, bool isServerNamed, bool durable, bool exclusive, bool autoDelete, IDictionary<string, object>? arguments)
-            : base(channel, name)
+        public RecordedQueue(string name, bool isServerNamed, bool durable, bool exclusive, bool autoDelete, IDictionary<string, object>? arguments)
+            : base(name)
         {
             _arguments = arguments;
             _durable = durable;

--- a/projects/RabbitMQ.Client/client/impl/RecordedQueue.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedQueue.cs
@@ -53,10 +53,10 @@ namespace RabbitMQ.Client.Impl
             IsServerNamed = isServerNamed;
         }
 
-        public override void Recover()
+        public override void Recover(IModel model)
         {
             var queueName = IsServerNamed ? string.Empty : Name;
-            var result = ModelDelegate.QueueDeclare(queueName, _durable, _exclusive, IsAutoDelete, _arguments);
+            var result = model.QueueDeclare(queueName, _durable, _exclusive, IsAutoDelete, _arguments);
             Name = result.QueueName;
         }
 


### PR DESCRIPTION
## Proposed Changes

I figured out that a channel that is closed at the point where it is tying to recover is giving problems while recovering. The issue occurring "Not able to recover binding" is blocking the completion of the full recovery. Stopping before getting to recover the Consumers. All Connections and Channels are recovered at this point. (this results in a repeat every 5 seconds and creating new connection and channels every time)

While looking into it i thought how can it be this class(old channel) still exists? I used it within a constructor. It should be disposed. Trying to resolve this i created an using statement around this code for the channel. Which results in a correctly disposed channel. This results in the continuation of the recovery in case of the consumers. (And not repeating the recover process every 5 seconds)

Which brings me to the following exception within the recovery process. Where it is trying to recover bindings from the IModel that now is disposed. Because this is an unknown error for the recovery process it ignores this state and continues. This makes the recovery complete. 
```
it's not a known problem with connectivty, ignoring it
```

This still results in an uncomplete recovery because the binding was not able to recover. Reasons:
- Channel = Closed
- Channel = Disposed

Both of them result in the effect that the binding is not recovered. 
- Where as Closed results in failing of recovery at all with 5 secondsrepeat
- Where as Disposed results in full recovery except the bindings

```
Informational: Performing automatic recovery
Informational: Connection recovery completed
Error: Topology recovery exception
Error: Exception: RabbitMQ.Client.Exceptions.TopologyRecoveryException
Caught an exception while recovering binding between HTMLPDFDirect and HTMLPDFQueue: Cannot access a disposed object.
Object name: 'RabbitMQ.Client.Impl.AutorecoveringModel'.

InnerException:
System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'RabbitMQ.Client.Impl.AutorecoveringModel'.
   at RabbitMQ.Client.Impl.AutorecoveringModel.get_Delegate()
   at RabbitMQ.Client.Impl.RecordedEntity.get_ModelDelegate()
   at RabbitMQ.Client.Impl.RecordedQueueBinding.Recover()
   at RabbitMQ.Client.Framing.Impl.AutorecoveringConnection.RecoverBindings()
Informational: Will not retry recovery because of System.ObjectDisposedException: it's not a known problem with connectivty, ignoring it
Informational: Connection recovery completed
```

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #1061)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

I chose a simple solution to kick of a discussion. This would fix the problem on hand and would not create any issues for existing code so far as i can imagine. But this is probably not the correct way to do make this solution. This will trigger some kind of refactoring if this is correct