### PR TITLE
Don't record consumers if topology recovery is off

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recording.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recording.cs
@@ -176,6 +176,11 @@ namespace RabbitMQ.Client.Framing.Impl
 
         internal void RecordConsumer(in RecordedConsumer consumer)
         {
+            if (!_factory.TopologyRecoveryEnabled)
+            {
+                return;
+            }
+
             lock (_recordedEntitiesLock)
             {
                 _recordedConsumers[consumer.ConsumerTag] = consumer;
@@ -184,6 +189,11 @@ namespace RabbitMQ.Client.Framing.Impl
 
         internal void DeleteRecordedConsumer(string consumerTag)
         {
+            if (!_factory.TopologyRecoveryEnabled)
+            {
+                return;
+            }
+
             lock (_recordedEntitiesLock)
             {
                 if (_recordedConsumers.Remove(consumerTag, out var recordedConsumer))


### PR DESCRIPTION
## Proposed Changes

Do not record/delete recorded consumers if a topology recovery is disabled. 

The issue was described [here](https://github.com/EasyNetQ/EasyNetQ/issues/1232) by @vladislav-prishchepa.

Long story short, EasyNetQ does the following during subscription lifecycle:
1. Creates a model for a consumer.
2. Starts a consumer via `BasicConsume`.
3. To stop the consumer, EasyNetQ disposes a model without `BasicCancel` calls. 

In case of frequent subscriptions creations and disposals, a lot of consumers will be recorded and will not be deleted. It wil yield to the memory leak described in the mentioned ^ issue.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

