### PR TITLE
Fix incorrect RemotePort

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
+++ b/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
@@ -165,7 +165,7 @@ namespace RabbitMQ.Client.Impl
 
         public int RemotePort
         {
-            get { return ((IPEndPoint)LocalEndPoint).Port; }
+            get { return ((IPEndPoint)RemoteEndPoint).Port; }
         }
 
         public TimeSpan ReadTimeout


### PR DESCRIPTION
Fix bug:
`SocketFrameHandler.RemotePort` was wrong.

Expected:
`RemotePort` = port of `RemoteEndPoint`.

Actual:
`RemotePort` = port of `LocalEndPoint`.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
