### PR TITLE
Fix XML doc for AmqpTcpEndpoint

### DIFF
--- a/projects/RabbitMQ.Client/client/api/AmqpTcpEndpoint.cs
+++ b/projects/RabbitMQ.Client/client/api/AmqpTcpEndpoint.cs
@@ -38,14 +38,16 @@ namespace RabbitMQ.Client
     /// <summary>
     /// Represents a TCP-addressable AMQP peer: a host name and port number.
     /// </summary>
+    /// <remarks>
     /// <para>
-    /// Some of the constructors take, as a convenience, a System.Uri
+    /// Some of the constructors take, as a convenience, a <see cref="System.Uri"/>
     /// instance representing an AMQP server address. The use of Uri
     /// here is not standardised - Uri is simply a convenient
     /// container for internet-address-like components. In particular,
     /// the Uri "Scheme" property is ignored: only the "Host" and
     /// "Port" properties are extracted.
     /// </para>
+    /// </remarks>
     public class AmqpTcpEndpoint// : ICloneable
     {
         /// <summary>


### PR DESCRIPTION
It was missing `<remarks>`, making it to:
- not appear in [online API doc](https://rabbitmq.github.io/rabbitmq-dotnet-client/api/RabbitMQ.Client.AmqpTcpEndpoint.html)
- not appear in [Visual Studio's Quick Info](https://docs.microsoft.com/en-us/visualstudio/ide/using-intellisense#quick-info)
- get messed up in [JetBrains Rider's Quick Documentation](https://www.jetbrains.com/help/rider/Coding_Assistance__Quick_Documentation.html)

I also added a `<see>` for `System.Uri`.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [x] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
