### PR TITLE
fix a typo in comments of WaitForConfirmsOrDieAsync

### DIFF
--- a/projects/RabbitMQ.Client/client/api/IModel.cs
+++ b/projects/RabbitMQ.Client/client/api/IModel.cs
@@ -435,7 +435,7 @@ namespace RabbitMQ.Client
         /// <remarks>
         /// Waits until all messages published since the last call have
         /// been ack'd by the broker.  If a nack is received or the timeout
-        /// elapses, throws an OperationInterruptedException exception immediately.
+        /// elapses, throws an IOException exception immediately.
         /// </remarks>
         Task WaitForConfirmsOrDieAsync(CancellationToken token = default);
 


### PR DESCRIPTION
these days we want to migrate our projects from ZeroMQ to RabbitMQ and I found a typo in comments that related to Publisher Confirms feature.

WaitOrConfirmsDie in version 6.2.2 and latter we have this comment 

" Waits until all messages published since the last call have been ack'd by the
        //     broker. If a nack is received or the timeout elapses, throws an OperationInterruptedException
        //     exception immediately.
"

but this method throws an System.IO.IOException

lets reproduce this problem.
![image](https://user-images.githubusercontent.com/68565441/135770896-ebef3b6e-c330-4b44-89db-137c26802cd4.png)

thank you in advance.