### PR TITLE
use ref instead of in for generic T + interface

### DIFF
--- a/projects/Benchmarks/WireFormatting/MethodFraming.cs
+++ b/projects/Benchmarks/WireFormatting/MethodFraming.cs
@@ -14,13 +14,13 @@ namespace RabbitMQ.Benchmarks
     [BenchmarkCategory("Framing")]
     public class MethodFramingBasicAck
     {
-        private readonly BasicAck _basicAck = new BasicAck(ulong.MaxValue, true);
+        private BasicAck _basicAck = new BasicAck(ulong.MaxValue, true);
 
         [Params(0)]
         public ushort Channel { get; set; }
 
         [Benchmark]
-        public ReadOnlyMemory<byte> BasicAckWrite() => Framing.SerializeToFrames(_basicAck, Channel);
+        public ReadOnlyMemory<byte> BasicAckWrite() => Framing.SerializeToFrames(ref _basicAck, Channel);
     }
 
     [Config(typeof(Config))]
@@ -28,8 +28,8 @@ namespace RabbitMQ.Benchmarks
     public class MethodFramingBasicPublish
     {
         private const string StringValue = "Exchange_OR_RoutingKey";
-        private readonly BasicPublish _basicPublish = new BasicPublish(StringValue, StringValue, false, false);
-        private readonly BasicPublishMemory _basicPublishMemory = new BasicPublishMemory(Encoding.UTF8.GetBytes(StringValue), Encoding.UTF8.GetBytes(StringValue), false, false);
+        private BasicPublish _basicPublish = new BasicPublish(StringValue, StringValue, false, false);
+        private BasicPublishMemory _basicPublishMemory = new BasicPublishMemory(Encoding.UTF8.GetBytes(StringValue), Encoding.UTF8.GetBytes(StringValue), false, false);
         private readonly BasicProperties _propertiesEmpty = new BasicProperties();
         private readonly BasicProperties _properties = new BasicProperties { AppId = "Application id", MessageId = "Random message id" };
         private readonly ReadOnlyMemory<byte> _bodyEmpty = ReadOnlyMemory<byte>.Empty;
@@ -42,25 +42,25 @@ namespace RabbitMQ.Benchmarks
         public int FrameMax { get; set; }
 
         [Benchmark]
-        public ReadOnlyMemory<byte> BasicPublishWriteNonEmpty() => Framing.SerializeToFrames(_basicPublish, _properties, _body, Channel, FrameMax);
+        public ReadOnlyMemory<byte> BasicPublishWriteNonEmpty() => Framing.SerializeToFrames(ref _basicPublish, _properties, _body, Channel, FrameMax);
 
         [Benchmark]
-        public ReadOnlyMemory<byte> BasicPublishWrite() => Framing.SerializeToFrames(_basicPublish, _propertiesEmpty, _bodyEmpty, Channel, FrameMax);
+        public ReadOnlyMemory<byte> BasicPublishWrite() => Framing.SerializeToFrames(ref _basicPublish, _propertiesEmpty, _bodyEmpty, Channel, FrameMax);
 
         [Benchmark]
-        public ReadOnlyMemory<byte> BasicPublishMemoryWrite() => Framing.SerializeToFrames(_basicPublishMemory, _propertiesEmpty, _bodyEmpty, Channel, FrameMax);
+        public ReadOnlyMemory<byte> BasicPublishMemoryWrite() => Framing.SerializeToFrames(ref _basicPublishMemory, _propertiesEmpty, _bodyEmpty, Channel, FrameMax);
     }
 
     [Config(typeof(Config))]
     [BenchmarkCategory("Framing")]
     public class MethodFramingChannelClose
     {
-        private readonly ChannelClose _channelClose = new ChannelClose(333, string.Empty, 0099, 2999);
+        private ChannelClose _channelClose = new ChannelClose(333, string.Empty, 0099, 2999);
 
         [Params(0)]
         public ushort Channel { get; set; }
 
         [Benchmark]
-        public ReadOnlyMemory<byte> ChannelCloseWrite() => Framing.SerializeToFrames(_channelClose, Channel);
+        public ReadOnlyMemory<byte> ChannelCloseWrite() => Framing.SerializeToFrames(ref _channelClose, Channel);
     }
 }

--- a/projects/RabbitMQ.Client/client/framing/Model.cs
+++ b/projects/RabbitMQ.Client/client/framing/Model.cs
@@ -44,57 +44,68 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override void ConnectionTuneOk(ushort channelMax, uint frameMax, ushort heartbeat)
         {
-            ModelSend(new ConnectionTuneOk(channelMax, frameMax, heartbeat));
+            var cmd = new ConnectionTuneOk(channelMax, frameMax, heartbeat);
+            ModelSend(ref cmd);
         }
 
         public override void _Private_BasicCancel(string consumerTag, bool nowait)
         {
-            ModelSend(new BasicCancel(consumerTag, nowait));
+            var cmd = new BasicCancel(consumerTag, nowait);
+            ModelSend(ref cmd);
         }
 
         public override void _Private_BasicConsume(string queue, string consumerTag, bool noLocal, bool autoAck, bool exclusive, bool nowait, IDictionary<string, object> arguments)
         {
-            ModelSend(new BasicConsume(queue, consumerTag, noLocal, autoAck, exclusive, nowait, arguments));
+            var cmd = new BasicConsume(queue, consumerTag, noLocal, autoAck, exclusive, nowait, arguments);
+            ModelSend(ref cmd);
         }
 
         public override void _Private_BasicGet(string queue, bool autoAck)
         {
-            ModelSend(new BasicGet(queue, autoAck));
+            var cmd = new BasicGet(queue, autoAck);
+            ModelSend(ref cmd);
         }
 
         public override void _Private_BasicPublish(string exchange, string routingKey, bool mandatory, IBasicProperties basicProperties, ReadOnlyMemory<byte> body)
         {
-            ModelSend(new BasicPublish(exchange, routingKey, mandatory, default), (BasicProperties) basicProperties, body);
+            var cmd = new BasicPublish(exchange, routingKey, mandatory, default);
+            ModelSend(ref cmd, (BasicProperties) basicProperties, body);
         }
 
         public override void _Private_BasicPublishMemory(ReadOnlyMemory<byte> exchange, ReadOnlyMemory<byte> routingKey, bool mandatory, IBasicProperties basicProperties, ReadOnlyMemory<byte> body)
         {
-            ModelSend(new BasicPublishMemory(exchange, routingKey, mandatory, default), (BasicProperties) basicProperties, body);
+            var cmd = new BasicPublishMemory(exchange, routingKey, mandatory, default);
+            ModelSend(ref cmd, (BasicProperties) basicProperties, body);
         }
 
         public override void _Private_BasicRecover(bool requeue)
         {
-            ModelSend(new BasicRecover(requeue));
+            var cmd = new BasicRecover(requeue);
+            ModelSend(ref cmd);
         }
 
         public override void _Private_ChannelClose(ushort replyCode, string replyText, ushort classId, ushort methodId)
         {
-            ModelSend(new ChannelClose(replyCode, replyText, classId, methodId));
+            var cmd = new ChannelClose(replyCode, replyText, classId, methodId);
+            ModelSend(ref cmd);
         }
 
         public override void _Private_ChannelCloseOk()
         {
-            ModelSend(new ChannelCloseOk());
+            var cmd = new ChannelCloseOk();
+            ModelSend(ref cmd);
         }
 
         public override void _Private_ChannelFlowOk(bool active)
         {
-            ModelSend(new ChannelFlowOk(active));
+            var cmd = new ChannelFlowOk(active);
+            ModelSend(ref cmd);
         }
 
         public override void _Private_ChannelOpen()
         {
-            ModelRpc(new ChannelOpen(), ProtocolCommandId.ChannelOpenOk);
+            var cmd = new ChannelOpen();
+            ModelRpc(ref cmd, ProtocolCommandId.ChannelOpenOk);
         }
 
         public override void _Private_ConfirmSelect(bool nowait)
@@ -102,37 +113,42 @@ namespace RabbitMQ.Client.Framing.Impl
             var method = new ConfirmSelect(nowait);
             if (nowait)
             {
-                ModelSend(method);
+                ModelSend(ref method);
             }
             else
             {
-                ModelRpc(method, ProtocolCommandId.ConfirmSelectOk);
+                ModelRpc(ref method, ProtocolCommandId.ConfirmSelectOk);
             }
         }
 
         public override void _Private_ConnectionCloseOk()
         {
-            ModelSend(new ConnectionCloseOk());
+            var cmd = new ConnectionCloseOk();
+            ModelSend(ref cmd);
         }
 
         public override void _Private_ConnectionOpen(string virtualHost)
         {
-            ModelSend(new ConnectionOpen(virtualHost));
+            var cmd = new ConnectionOpen(virtualHost);
+            ModelSend(ref cmd);
         }
 
         public override void _Private_ConnectionSecureOk(byte[] response)
         {
-            ModelSend(new ConnectionSecureOk(response));
+            var cmd = new ConnectionSecureOk(response);
+            ModelSend(ref cmd);
         }
 
         public override void _Private_ConnectionStartOk(IDictionary<string, object> clientProperties, string mechanism, byte[] response, string locale)
         {
-            ModelSend(new ConnectionStartOk(clientProperties, mechanism, response, locale));
+            var cmd = new ConnectionStartOk(clientProperties, mechanism, response, locale);
+            ModelSend(ref cmd);
         }
 
         public override void _Private_UpdateSecret(byte[] newSecret, string reason)
         {
-            ModelRpc(new ConnectionUpdateSecret(newSecret, reason), ProtocolCommandId.ConnectionUpdateSecretOk);
+            var cmd = new ConnectionUpdateSecret(newSecret, reason);
+            ModelRpc(ref cmd, ProtocolCommandId.ConnectionUpdateSecretOk);
         }
 
         public override void _Private_ExchangeBind(string destination, string source, string routingKey, bool nowait, IDictionary<string, object> arguments)
@@ -140,11 +156,11 @@ namespace RabbitMQ.Client.Framing.Impl
             ExchangeBind method = new ExchangeBind(destination, source, routingKey, nowait, arguments);
             if (nowait)
             {
-                ModelSend(method);
+                ModelSend(ref method);
             }
             else
             {
-                ModelRpc(method, ProtocolCommandId.ExchangeBindOk);
+                ModelRpc(ref method, ProtocolCommandId.ExchangeBindOk);
             }
         }
 
@@ -153,11 +169,11 @@ namespace RabbitMQ.Client.Framing.Impl
             ExchangeDeclare method = new ExchangeDeclare(exchange, type, passive, durable, autoDelete, @internal, nowait, arguments);
             if (nowait)
             {
-                ModelSend(method);
+                ModelSend(ref method);
             }
             else
             {
-                ModelRpc(method, ProtocolCommandId.ExchangeDeclareOk);
+                ModelRpc(ref method, ProtocolCommandId.ExchangeDeclareOk);
             }
         }
 
@@ -166,11 +182,11 @@ namespace RabbitMQ.Client.Framing.Impl
             ExchangeDelete method = new ExchangeDelete(exchange, ifUnused, nowait);
             if (nowait)
             {
-                ModelSend(method);
+                ModelSend(ref method);
             }
             else
             {
-                ModelRpc(method, ProtocolCommandId.ExchangeDeleteOk);
+                ModelRpc(ref method, ProtocolCommandId.ExchangeDeleteOk);
             }
         }
 
@@ -179,11 +195,11 @@ namespace RabbitMQ.Client.Framing.Impl
             ExchangeUnbind method = new ExchangeUnbind(destination, source, routingKey, nowait, arguments);
             if (nowait)
             {
-                ModelSend(method);
+                ModelSend(ref method);
             }
             else
             {
-                ModelRpc(method, ProtocolCommandId.ExchangeUnbindOk);
+                ModelRpc(ref method, ProtocolCommandId.ExchangeUnbindOk);
             }
         }
 
@@ -192,11 +208,11 @@ namespace RabbitMQ.Client.Framing.Impl
             QueueBind method = new QueueBind(queue, exchange, routingKey, nowait, arguments);
             if (nowait)
             {
-                ModelSend(method);
+                ModelSend(ref method);
             }
             else
             {
-                ModelRpc(method, ProtocolCommandId.QueueBindOk);
+                ModelRpc(ref method, ProtocolCommandId.QueueBindOk);
             }
         }
 
@@ -205,11 +221,11 @@ namespace RabbitMQ.Client.Framing.Impl
             QueueDeclare method = new QueueDeclare(queue, passive, durable, exclusive, autoDelete, nowait, arguments);
             if (nowait)
             {
-                ModelSend(method);
+                ModelSend(ref method);
             }
             else
             {
-                ModelSend(method);
+                ModelSend(ref method);
             }
         }
 
@@ -218,11 +234,11 @@ namespace RabbitMQ.Client.Framing.Impl
             QueueDelete method = new QueueDelete(queue, ifUnused, ifEmpty, nowait);
             if (nowait)
             {
-                ModelSend(method);
+                ModelSend(ref method);
                 return 0xFFFFFFFF;
             }
 
-            return ModelRpc(method, ProtocolCommandId.QueueDeleteOk, memory => new QueueDeleteOk(memory.Span)._messageCount);
+            return ModelRpc(ref method, ProtocolCommandId.QueueDeleteOk, memory => new QueueDeleteOk(memory.Span)._messageCount);
         }
 
         public override uint _Private_QueuePurge(string queue, bool nowait)
@@ -230,36 +246,41 @@ namespace RabbitMQ.Client.Framing.Impl
             QueuePurge method = new QueuePurge(queue, nowait);
             if (nowait)
             {
-                ModelSend(method);
+                ModelSend(ref method);
                 return 0xFFFFFFFF;
             }
 
-            return ModelRpc(method, ProtocolCommandId.QueuePurgeOk, memory => new QueuePurgeOk(memory.Span)._messageCount);
+            return ModelRpc(ref method, ProtocolCommandId.QueuePurgeOk, memory => new QueuePurgeOk(memory.Span)._messageCount);
         }
 
         public override void BasicAck(ulong deliveryTag, bool multiple)
         {
-            ModelSend(new BasicAck(deliveryTag, multiple));
+            var cmd = new BasicAck(deliveryTag, multiple);
+            ModelSend(ref cmd);
         }
 
         public override void BasicNack(ulong deliveryTag, bool multiple, bool requeue)
         {
-            ModelSend(new BasicNack(deliveryTag, multiple, requeue));
+            var cmd = new BasicNack(deliveryTag, multiple, requeue);
+            ModelSend(ref cmd);
         }
 
         public override void BasicQos(uint prefetchSize, ushort prefetchCount, bool global)
         {
-            ModelRpc(new BasicQos(prefetchSize, prefetchCount, global), ProtocolCommandId.BasicQosOk);
+            var cmd = new BasicQos(prefetchSize, prefetchCount, global);
+            ModelRpc(ref cmd, ProtocolCommandId.BasicQosOk);
         }
 
         public override void BasicRecoverAsync(bool requeue)
         {
-            ModelSend(new BasicRecoverAsync(requeue));
+            var cmd = new BasicRecoverAsync(requeue);
+            ModelSend(ref cmd);
         }
 
         public override void BasicReject(ulong deliveryTag, bool requeue)
         {
-            ModelSend(new BasicReject(deliveryTag, requeue));
+            var cmd = new BasicReject(deliveryTag, requeue);
+            ModelSend(ref cmd);
         }
 
         public override IBasicProperties CreateBasicProperties()
@@ -269,22 +290,26 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override void QueueUnbind(string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
         {
-            ModelRpc(new QueueUnbind(queue, exchange, routingKey, arguments), ProtocolCommandId.QueueUnbindOk);
+            var cmd = new QueueUnbind(queue, exchange, routingKey, arguments);
+            ModelRpc(ref cmd, ProtocolCommandId.QueueUnbindOk);
         }
 
         public override void TxCommit()
         {
-            ModelRpc(new TxCommit(), ProtocolCommandId.TxCommitOk);
+            var cmd = new TxCommit();
+            ModelRpc(ref cmd, ProtocolCommandId.TxCommitOk);
         }
 
         public override void TxRollback()
         {
-            ModelRpc(new TxRollback(), ProtocolCommandId.TxRollbackOk);
+            var cmd = new TxRollback();
+            ModelRpc(ref cmd, ProtocolCommandId.TxRollbackOk);
         }
 
         public override void TxSelect()
         {
-            ModelRpc(new TxSelect(), ProtocolCommandId.TxSelectOk);
+            var cmd = new TxSelect();
+            ModelRpc(ref cmd, ProtocolCommandId.TxSelectOk);
         }
 
         protected override bool DispatchAsynchronous(in IncomingCommand cmd)

--- a/projects/RabbitMQ.Client/client/impl/Connection.Receive.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.Receive.cs
@@ -147,7 +147,8 @@ namespace RabbitMQ.Client.Framing.Impl
                 _session0.SetSessionClosing(false);
                 try
                 {
-                    _session0.Transmit(new ConnectionClose(hpe.ShutdownReason.ReplyCode, hpe.ShutdownReason.ReplyText, 0, 0));
+                    var cmd = new ConnectionClose(hpe.ShutdownReason.ReplyCode, hpe.ShutdownReason.ReplyText, 0, 0);
+                    _session0.Transmit(ref cmd);
                     ClosingLoop();
                 }
                 catch (IOException ioe)

--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -270,7 +270,8 @@ namespace RabbitMQ.Client.Framing.Impl
                 try
                 {
                     // Try to send connection.close wait for CloseOk in the MainLoop
-                    _session0.Transmit(new ConnectionClose(reason.ReplyCode, reason.ReplyText, 0, 0));
+                    var cmd = new ConnectionClose(reason.ReplyCode, reason.ReplyText, 0, 0);
+                    _session0.Transmit(ref cmd);
                 }
                 catch (AlreadyClosedException)
                 {

--- a/projects/RabbitMQ.Client/client/impl/ISession.cs
+++ b/projects/RabbitMQ.Client/client/impl/ISession.cs
@@ -72,7 +72,7 @@ namespace RabbitMQ.Client.Impl
         void Close(ShutdownEventArgs reason, bool notify);
         bool HandleFrame(in InboundFrame frame);
         void Notify();
-        void Transmit<T>(in T cmd) where T : struct, IOutgoingAmqpMethod;
-        void Transmit<T>(in T cmd, ContentHeaderBase header, ReadOnlyMemory<byte> body) where T : struct, IOutgoingAmqpMethod;
+        void Transmit<T>(ref T cmd) where T : struct, IOutgoingAmqpMethod;
+        void Transmit<T>(ref T cmd, ContentHeaderBase header, ReadOnlyMemory<byte> body) where T : struct, IOutgoingAmqpMethod;
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/MainSession.cs
+++ b/projects/RabbitMQ.Client/client/impl/MainSession.cs
@@ -99,7 +99,7 @@ namespace RabbitMQ.Client.Impl
             }
         }
 
-        public override void Transmit<T>(in T cmd)
+        public override void Transmit<T>(ref T cmd)
         {
             if (_closing && // Are we closing?
                 cmd.ProtocolCommandId != ProtocolCommandId.ConnectionCloseOk && // is this not a close-ok?
@@ -110,7 +110,7 @@ namespace RabbitMQ.Client.Impl
                 return;
             }
 
-            base.Transmit(in cmd);
+            base.Transmit(ref cmd);
         }
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/ModelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ModelBase.cs
@@ -334,7 +334,7 @@ namespace RabbitMQ.Client.Impl
             }
         }
 
-        protected void ModelRpc<TMethod>(in TMethod method, ProtocolCommandId returnCommandId)
+        protected void ModelRpc<TMethod>(ref  TMethod method, ProtocolCommandId returnCommandId)
             where TMethod : struct, IOutgoingAmqpMethod
         {
             var k = new SimpleBlockingRpcContinuation();
@@ -342,7 +342,7 @@ namespace RabbitMQ.Client.Impl
             lock (_rpcLock)
             {
                 Enqueue(k);
-                Session.Transmit(method);
+                Session.Transmit(ref method);
                 k.GetReply(ContinuationTimeout, out reply);
             }
 
@@ -354,7 +354,7 @@ namespace RabbitMQ.Client.Impl
             }
         }
 
-        protected TReturn ModelRpc<TMethod, TReturn>(in TMethod method, ProtocolCommandId returnCommandId, Func<ReadOnlyMemory<byte>, TReturn> createFunc)
+        protected TReturn ModelRpc<TMethod, TReturn>(ref  TMethod method, ProtocolCommandId returnCommandId, Func<ReadOnlyMemory<byte>, TReturn> createFunc)
             where TMethod : struct, IOutgoingAmqpMethod
         {
             var k = new SimpleBlockingRpcContinuation();
@@ -363,7 +363,7 @@ namespace RabbitMQ.Client.Impl
             lock (_rpcLock)
             {
                 Enqueue(k);
-                Session.Transmit(method);
+                Session.Transmit(ref method);
                 k.GetReply(ContinuationTimeout, out reply);
             }
 
@@ -379,19 +379,19 @@ namespace RabbitMQ.Client.Impl
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected void ModelSend<T>(in T method) where T : struct, IOutgoingAmqpMethod
+        protected void ModelSend<T>(ref  T method) where T : struct, IOutgoingAmqpMethod
         {
-            Session.Transmit(method);
+            Session.Transmit(ref method);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected void ModelSend<T>(in T method, ContentHeaderBase header, ReadOnlyMemory<byte> body) where T : struct, IOutgoingAmqpMethod
+        protected void ModelSend<T>(ref  T method, ContentHeaderBase header, ReadOnlyMemory<byte> body) where T : struct, IOutgoingAmqpMethod
         {
             if (!_flowControlBlock.IsSet)
             {
                 _flowControlBlock.Wait();
             }
-            Session.Transmit(method, header, body);
+            Session.Transmit(ref method, header, body);
         }
 
         internal void OnCallbackException(CallbackExceptionEventArgs args)

--- a/projects/RabbitMQ.Client/client/impl/SessionBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/SessionBase.cs
@@ -129,24 +129,24 @@ namespace RabbitMQ.Client.Impl
             OnSessionShutdown(reason);
         }
 
-        public virtual void Transmit<T>(in T cmd) where T : struct, IOutgoingAmqpMethod
+        public virtual void Transmit<T>(ref T cmd) where T : struct, IOutgoingAmqpMethod
         {
             if (!IsOpen && cmd.ProtocolCommandId != client.framing.ProtocolCommandId.ChannelCloseOk)
             {
                 ThrowAlreadyClosedException();
             }
 
-            Connection.Write(Framing.SerializeToFrames(cmd, ChannelNumber));
+            Connection.Write(Framing.SerializeToFrames(ref cmd, ChannelNumber));
         }
 
-        public void Transmit<T>(in T cmd, ContentHeaderBase header, ReadOnlyMemory<byte> body) where T : struct, IOutgoingAmqpMethod
+        public void Transmit<T>(ref T cmd, ContentHeaderBase header, ReadOnlyMemory<byte> body) where T : struct, IOutgoingAmqpMethod
         {
             if (!IsOpen && cmd.ProtocolCommandId != ProtocolCommandId.ChannelCloseOk)
             {
                 ThrowAlreadyClosedException();
             }
 
-            Connection.Write(Framing.SerializeToFrames(cmd, header, body, ChannelNumber, Connection.MaxPayloadSize));
+            Connection.Write(Framing.SerializeToFrames(ref cmd, header, body, ChannelNumber, Connection.MaxPayloadSize));
         }
 
         private void ThrowAlreadyClosedException()

--- a/projects/Unit/TestFrameFormatting.cs
+++ b/projects/Unit/TestFrameFormatting.cs
@@ -114,7 +114,7 @@ namespace RabbitMQ.Client.Unit
             var method = new BasicPublish("E", "R", true, true);
             int payloadSize = method.GetRequiredBufferSize();
             byte[] frameBytes = new byte[Impl.Framing.Method.FrameSize + payloadSize];
-            Impl.Framing.Method.WriteTo(frameBytes, Channel, method);
+            Impl.Framing.Method.WriteTo(frameBytes, Channel, ref method);
 
             Assert.Equal(12, Impl.Framing.Method.FrameSize);
             Assert.Equal(Constants.FrameMethod, frameBytes[0]);


### PR DESCRIPTION
## Proposed Changes

Figured this out while #1096, as the performance was not what I wanted it to be. While investigating I figured out that when we use `method<T>(in T parameter) where T: struct, Interface` and then call a method on it, the compiler is unable to figure out that they might be readonly. The effect of it is that it does a defensive copy. ([Link to dotnet issue](https://github.com/dotnet/csharplang/issues/3055))

While the structs itself are usually quite small, it still quite noticable. 

The workaround for this is to use ref instead of  in, as this allows calling methods on it without defensive copies.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

After
| Method |        When |       Runtime |       Mean |    Error |   StdDev | Code Size |
-------------------------- |----------- |-------------- |----------:|---------:|---------:|----------:|
| BasicPublishWriteNonEmpty | Before |      .NET 4.8 |  375.61 ns | 2.775 ns | 2.596 ns |    6935 B |
|  BasicPublishWriteNonEmpty | After |      .NET 4.8 |  370.54 ns | 1.648 ns | 1.542 ns |    6831 B |
|         BasicPublishWrite |Before |      .NET 4.8 | 206.93 ns | 0.450 ns | 0.399 ns |    6807 B | 
|          BasicPublishWrite | After |      .NET 4.8 |  203.22 ns | 0.407 ns | 0.361 ns |    6703 B | 
|   BasicPublishMemoryWrite | Before |      .NET 4.8 | 145.62 ns | 0.574 ns | 0.537 ns |    7208 B |
|    BasicPublishMemoryWrite | After |      .NET 4.8 |  138.49 ns | 0.663 ns | 0.620 ns |    7044 B |
| BasicPublishWriteNonEmpty | Before | .NET Core 3.1 |  263.46 ns | 1.574 ns | 1.473 ns |    5776 B |
|  BasicPublishWriteNonEmpty | After | .NET Core 3.1 |  250.61 ns | 1.237 ns | 1.157 ns |    5638 B |
|         BasicPublishWrite | Before | .NET Core 3.1 |  115.68 ns | 0.390 ns | 0.364 ns |    5776 B | 
|          BasicPublishWrite | After | .NET Core 3.1 | 106.93 ns | 0.436 ns | 0.408 ns |    5638 B |
|   BasicPublishMemoryWrite |Before | .NET Core 3.1 |  71.74 ns | 0.274 ns | 0.243 ns |    6318 B | 
|    BasicPublishMemoryWrite | After | .NET Core 3.1 |  60.68 ns | 0.356 ns | 0.333 ns |    6127 B |
