### PR TITLE
improve basic properties read / write

### DIFF
--- a/projects/Benchmarks/WireFormatting/PrimitivesSerialization.cs
+++ b/projects/Benchmarks/WireFormatting/PrimitivesSerialization.cs
@@ -11,7 +11,7 @@ namespace RabbitMQ.Benchmarks
     [BenchmarkCategory("Primitives")]
     public class PrimitivesBase
     {
-        protected Memory<byte> _buffer = new byte[16];
+        protected readonly Memory<byte> _buffer = new byte[16];
 
         [GlobalSetup]
         public virtual void Setup() { }
@@ -22,10 +22,18 @@ namespace RabbitMQ.Benchmarks
         public override void Setup() => WireFormatting.WriteBits(ref _buffer.Span.GetStart(), true, false, true, false, true);
 
         [Benchmark]
-        public int BoolRead2() => WireFormatting.ReadBits(_buffer.Span, out bool _, out bool _);
+        public (bool, bool) BoolRead2()
+        {
+            WireFormatting.ReadBits(_buffer.Span, out bool v1, out bool v2);
+            return (v1, v2);
+        }
 
         [Benchmark]
-        public int BoolRead5() => WireFormatting.ReadBits(_buffer.Span, out bool _, out bool _, out bool _, out bool _, out bool _);
+        public (bool, bool, bool, bool, bool) BoolRead5()
+        {
+            WireFormatting.ReadBits(_buffer.Span, out bool v1, out bool v2, out bool v3, out bool v4, out bool v5);
+            return (v1, v2, v3, v4, v5);
+        }
 
         [Benchmark]
         [Arguments(true, false)]
@@ -52,7 +60,11 @@ namespace RabbitMQ.Benchmarks
         public override void Setup() => WireFormatting.WriteLong(ref _buffer.Span.GetStart(), 12345u);
 
         [Benchmark]
-        public int LongRead() => WireFormatting.ReadLong(_buffer.Span, out _);
+        public uint LongRead()
+        {
+            WireFormatting.ReadLong(_buffer.Span, out uint v1);
+            return v1;
+        }
 
         [Benchmark]
         [Arguments(12345u)]
@@ -64,7 +76,11 @@ namespace RabbitMQ.Benchmarks
         public override void Setup() => WireFormatting.WriteLonglong(ref _buffer.Span.GetStart(), 12345ul);
 
         [Benchmark]
-        public int LonglongRead() => WireFormatting.ReadLonglong(_buffer.Span, out _);
+        public ulong LonglongRead()
+        {
+            WireFormatting.ReadLonglong(_buffer.Span, out ulong v1);
+            return v1;
+        }
 
         [Benchmark]
         [Arguments(12345ul)]
@@ -76,7 +92,11 @@ namespace RabbitMQ.Benchmarks
         public override void Setup() => WireFormatting.WriteShort(ref _buffer.Span.GetStart(), 12345);
 
         [Benchmark]
-        public int ShortRead() => WireFormatting.ReadShort(_buffer.Span, out _);
+        public ushort ShortRead()
+        {
+            WireFormatting.ReadShort(_buffer.Span, out ushort v1);
+            return v1;
+        }
 
         [Benchmark]
         [Arguments(12345)]
@@ -85,12 +105,16 @@ namespace RabbitMQ.Benchmarks
 
     public class PrimitivesTimestamp : PrimitivesBase
     {
-        AmqpTimestamp _timestamp = new AmqpTimestamp(DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+        private AmqpTimestamp _timestamp = new AmqpTimestamp(DateTimeOffset.UtcNow.ToUnixTimeSeconds());
 
         public override void Setup() => WireFormatting.WriteTimestamp(ref _buffer.Span.GetStart(), _timestamp);
 
         [Benchmark]
-        public int TimestampRead() => WireFormatting.ReadTimestamp(_buffer.Span, out _);
+        public AmqpTimestamp TimestampRead()
+        {
+            WireFormatting.ReadTimestamp(_buffer.Span, out AmqpTimestamp v1);
+            return v1;
+        }
 
         [Benchmark]
         public int TimestampWrite() => WireFormatting.WriteTimestamp(ref _buffer.Span.GetStart(), _timestamp);

--- a/projects/RabbitMQ.Client/client/impl/WireFormatting.Read.cs
+++ b/projects/RabbitMQ.Client/client/impl/WireFormatting.Read.cs
@@ -239,31 +239,6 @@ namespace RabbitMQ.Client.Impl
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int ReadBits(ReadOnlySpan<byte> span,
-            out bool val1, out bool val2, out bool val3, out bool val4, out bool val5,
-            out bool val6, out bool val7, out bool val8, out bool val9, out bool val10,
-            out bool val11, out bool val12, out bool val13, out bool val14)
-        {
-            byte bits = span[0];
-            val1 = (bits & 0b1000_0000) != 0;
-            val2 = (bits & 0b0100_0000) != 0;
-            val3 = (bits & 0b0010_0000) != 0;
-            val4 = (bits & 0b0001_0000) != 0;
-            val5 = (bits & 0b0000_1000) != 0;
-            val6 = (bits & 0b0000_0100) != 0;
-            val7 = (bits & 0b0000_0010) != 0;
-            val8 = (bits & 0b0000_0001) != 0;
-            bits = span[1];
-            val9 = (bits & 0b1000_0000) != 0;
-            val10 = (bits & 0b0100_0000) != 0;
-            val11 = (bits & 0b0010_0000) != 0;
-            val12 = (bits & 0b0001_0000) != 0;
-            val13 = (bits & 0b0000_1000) != 0;
-            val14 = (bits & 0b0000_0100) != 0;
-            return 2;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int ReadShort(ReadOnlySpan<byte> span, out ushort value)
         {
             value = NetworkOrderDeserializer.ReadUInt16(span);
@@ -328,7 +303,7 @@ namespace RabbitMQ.Client.Impl
         private static int ThrowInvalidTableValue(char type)
             => throw new SyntaxErrorException($"Unrecognised type in table: {type}");
 
-        private static decimal ThrowInvalidDecimalScale(int scale)
-                    => throw new SyntaxErrorException($"Unrepresentable AMQP decimal table field: scale={scale}");
+        private static void ThrowInvalidDecimalScale(int scale)
+            => throw new SyntaxErrorException($"Unrepresentable AMQP decimal table field: scale={scale}");
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/WireFormatting.Write.cs
+++ b/projects/RabbitMQ.Client/client/impl/WireFormatting.Write.cs
@@ -303,23 +303,6 @@ namespace RabbitMQ.Client.Impl
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int WriteBits(ref byte destination,
-            bool val1, bool val2, bool val3, bool val4, bool val5,
-            bool val6, bool val7, bool val8, bool val9, bool val10,
-            bool val11, bool val12, bool val13, bool val14)
-        {
-            int a = val8.ToByte() + val7.ToByte() * 2 + val6.ToByte() * 4 + val5.ToByte() * 8;
-            int b = val4.ToByte() + val3.ToByte() * 2 + val2.ToByte() * 4 + val1.ToByte() * 8;
-            destination = (byte)(a | (b << 4));
-
-            a = val14.ToByte() * 4 + val13.ToByte() * 8;
-            b = val12.ToByte() + val11.ToByte() * 2 + val10.ToByte() * 4 + val9.ToByte() * 8;
-
-            destination.GetOffset(1) = (byte)(a | (b << 4));
-            return 2;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int WriteLongstr(ref byte destination, ReadOnlySpan<byte> val)
         {
             WriteLong(ref destination, (uint)val.Length);
@@ -499,9 +482,6 @@ namespace RabbitMQ.Client.Impl
 
         public static int ThrowArgumentOutOfRangeException(int orig, int expected)
             => throw new ArgumentOutOfRangeException("span", $"Span has not enough space ({orig} instead of {expected})");
-
-        public static int ThrowArgumentOutOfRangeException(string val, int maxLength)
-            => throw new ArgumentOutOfRangeException(nameof(val), val, $"Value exceeds the maximum allowed length of {maxLength} bytes.");
 
         private static int ThrowWireFormattingException(decimal value)
             => throw new WireFormattingException("Decimal overflow in AMQP encoding", value);

--- a/projects/RabbitMQ.Client/util/TypeExtensions.cs
+++ b/projects/RabbitMQ.Client/util/TypeExtensions.cs
@@ -43,6 +43,18 @@ namespace RabbitMQ
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsBitSet(this in byte value, byte bitPosition)
+        {
+            return (value & (1 << bitPosition)) != 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SetBit(this ref byte value, byte bitPosition)
+        {
+            value |= (byte)(1 << bitPosition);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte ToByte(this ref bool source)
         {
             return Unsafe.As<bool, byte>(ref source);


### PR DESCRIPTION
## Proposed Changes

Improves the read / write of basic properties performance by changing when to read / write the presence bits.

|               Method |        When|            Runtime |      Mean |    Error |   StdDev |  Gen 0 | Code Size | Allocated |
|--------------------- |----------- |------------------- |----------:|---------:|---------:|-------:|----------:|----------:|
|  BasicPropertiesRead | Before |      .NET Core 3.1 |  66.39 ns | 0.428 ns | 0.400 ns | 0.0408 |   3,085 B |     192 B |
|  BasicPropertiesRead | After |      .NET Core 3.1 |  63.28 ns | 0.485 ns | 0.453 ns | 0.0408 |   2,588 B |     192 B |
| BasicPropertiesWrite | Before |      .NET Core 3.1 |  40.23 ns | 0.044 ns | 0.039 ns |      - |   2,200 B |         - |
| BasicPropertiesWrite | After |      .NET Core 3.1 |  34.88 ns | 0.089 ns | 0.084 ns |      - |   1,881 B |         - |
|  BasicPropertiesRead | Before | .NET Framework 4.8 | 116.48 ns | 0.490 ns | 0.458 ns | 0.0424 |   6,750 B |     201 B |
|  BasicPropertiesRead | After | .NET Framework 4.8 | 111.27 ns | 0.227 ns | 0.213 ns | 0.0424 |   6,118 B |     201 B |
| BasicPropertiesWrite | Before | .NET Framework 4.8 |  62.54 ns | 0.155 ns | 0.145 ns |      - |   3,333 B |         - |
| BasicPropertiesWrite | After | .NET Framework 4.8 |  59.23 ns | 0.155 ns | 0.145 ns |      - |   2,960 B |         - |

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
