### PR TITLE
Clean-up the library's project file.

### DIFF
--- a/projects/RabbitMQ.Client/RabbitMQ.Client.csproj
+++ b/projects/RabbitMQ.Client/RabbitMQ.Client.csproj
@@ -12,14 +12,13 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0 OR MPL-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://www.rabbitmq.com/dotnet.html</PackageProjectUrl>
     <PackageTags>rabbitmq, amqp</PackageTags>
     <Product>RabbitMQ</Product>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <AssemblyOriginatorKeyFile>../rabbit.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <MinVerTagPrefix>v</MinVerTagPrefix>
@@ -48,7 +47,6 @@
   <ItemGroup>
     <None Remove="icon.png" />
     <Content Include="icon.png" PackagePath="" />
-    <None Include="..\..\LICENSE" Pack="true" PackagePath="" />
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Unit, PublicKey=00240000048000009400000006020000002400005253413100040000010001008d20ec856aeeb8c3153a77faa2d80e6e43b5db93224a20cc7ae384f65f142e89730e2ff0fcc5d578bbe96fa98a7196c77329efdee4579b3814c0789e5a39b51df6edd75b602a33ceabdfcf19a3feb832f31d8254168cd7ba5700dfbca301fbf8db614ba41ba18474de0a5f4c2d51c995bc3636c641c8cbe76f45717bfcb943b5</_Parameter1>
     </AssemblyAttribute>
@@ -61,9 +59,12 @@
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.4.0" PrivateAssets="All" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Threading.Channels" Version="5.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Proposed Changes

There are a couple of problems with `RabbitMQ.Client.csproj` that this PR fixes:

* The library's license was specified in a file. Since the license is a combination of known open-source licenses, it is now specified as an SPDX license expression, helping readability for both humans and machines.
* The project was publishing its debug symbols both in the main `.nupkg` file, and in a separate `.snupkg` file. There is no reason to do both; the symbols are now included only in the `.snupkg`, saving some tens of kilobytes from the `.nupkg`'s size. If there are compatibility concerns with older IDEs I think we should discontinue the `.snupkg` instead for the sake of reducing duplication.
* The project was publicly referencing two redundant packages; the one contains analyzers that do not need to be public, and the other contains the `Span` type and its friends for frameworks that don't already have it; .NET Core does not need it.

## Types of Changes

- [X] Bug fix (non-breaking change which fixes issue N/A)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable)
- [ ] I have added necessary documentation (if appropriate) (not applicable)
- [ ] Any dependent changes have been merged and published in related repositories (not applicable)

## Further Comments

N/A