### PR TITLE
Use Stream.Read instead of .ReadByte for the first byte

### DIFF
--- a/projects/Unit/TestConnectionRecovery.cs
+++ b/projects/Unit/TestConnectionRecovery.cs
@@ -75,7 +75,7 @@ namespace RabbitMQ.Client.Unit
         }
 
         [Test]
-        [Ignore("TODO flaky")]
+        // [Ignore("TODO flaky")]
         public void TestBasicAckAfterChannelRecovery()
         {
             var allMessagesSeenLatch = new ManualResetEventSlim(false);


### PR DESCRIPTION
It appears that on occasion `Stream.ReadByte` can hang unexpectedly. Maybe `Stream.Read` does not suffer this issue?

Intended to address #1140 