### PR TITLE
Fix flaky connection recovery tests.

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recovery.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recovery.cs
@@ -141,10 +141,13 @@ namespace RabbitMQ.Client.Framing.Impl
                             // 2. Recover queues
                             // 3. Recover bindings
                             // 4. Recover consumers
-                            using var recoveryChannel = _innerConnection.CreateModel();
-                            RecoverExchanges(recoveryChannel);
-                            RecoverQueues(recoveryChannel);
-                            RecoverBindings(recoveryChannel);
+                            using (var recoveryChannel = _innerConnection.CreateModel())
+                            {
+                                RecoverExchanges(recoveryChannel);
+                                RecoverQueues(recoveryChannel);
+                                RecoverBindings(recoveryChannel);
+                            }
+                                
                         }
                         RecoverModelsAndItsConsumers();
                     }

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
@@ -166,12 +166,19 @@ namespace RabbitMQ.Client.Impl
                 newChannel.TxSelect();
             }
 
+            /*
+             * https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/1140
+             * If this assignment is not done before recovering consumers, there is a good
+             * chance that an invalid Model will be used to handle a basic.deliver frame,
+             * with the resulting basic.ack never getting sent out.
+             */
+            _innerChannel = newChannel;
+
             if (recoverConsumers)
             {
                 _connection.RecoverConsumers(this, newChannel);
             }
 
-            _innerChannel = newChannel;
             _innerChannel.RunRecoveryEventHandlers(this);
         }
 

--- a/projects/Unit/Fixtures.cs
+++ b/projects/Unit/Fixtures.cs
@@ -382,6 +382,7 @@ namespace RabbitMQ.Client.Unit
         internal void StartRabbitMQ()
         {
             RabbitMQCtl.StartRabbitMQ();
+            RabbitMQCtl.AwaitRabbitMQ();
         }
 
         //

--- a/projects/Unit/RabbitMQCtl.cs
+++ b/projects/Unit/RabbitMQCtl.cs
@@ -228,5 +228,10 @@ namespace RabbitMQ.Client.Unit
         {
             ExecRabbitMQCtl("start_app");
         }
+
+        public static void AwaitRabbitMQ()
+        {
+            ExecRabbitMQCtl("await_startup");
+        }
     }
 }

--- a/projects/Unit/TestConnectionRecovery.cs
+++ b/projects/Unit/TestConnectionRecovery.cs
@@ -90,7 +90,7 @@ namespace RabbitMQ.Client.Unit
 
         }
 
-        [Fact(Skip="TODO flaky")]
+        [Fact]
         public void TestBasicAckAfterChannelRecovery()
         {
             var allMessagesSeenLatch = new ManualResetEventSlim(false);
@@ -112,7 +112,7 @@ namespace RabbitMQ.Client.Unit
             Wait(allMessagesSeenLatch);
         }
 
-        [Fact(Skip="TODO flaky")]
+        [Fact]
         public void TestBasicNackAfterChannelRecovery()
         {
             var allMessagesSeenLatch = new ManualResetEventSlim(false);
@@ -134,7 +134,7 @@ namespace RabbitMQ.Client.Unit
             Wait(allMessagesSeenLatch);
         }
 
-        [Fact(Skip="TODO flaky")]
+        [Fact]
         public void TestBasicRejectAfterChannelRecovery()
         {
             var allMessagesSeenLatch = new ManualResetEventSlim(false);
@@ -858,7 +858,7 @@ namespace RabbitMQ.Client.Unit
                 {
 
                     CloseAndWaitForRecovery();
-                    Thread.Sleep(100);
+                    Thread.Sleep(500);
                 }
                 finally
                 {

--- a/projects/Unit/TestConnectionRecovery.cs
+++ b/projects/Unit/TestConnectionRecovery.cs
@@ -851,22 +851,22 @@ namespace RabbitMQ.Client.Unit
             var properties = new BasicProperties();
             properties.ReplyTo = "amq.rabbitmq.reply-to";
 
-            bool done = false;
+            TimeSpan doneSpan = TimeSpan.FromMilliseconds(100);
+            var done = new ManualResetEventSlim(false);
             Task.Run(() =>
             {
                 try
                 {
 
                     CloseAndWaitForRecovery();
-                    Thread.Sleep(500);
                 }
                 finally
                 {
-                    done = true;
+                    done.Set();
                 }
             });
 
-            while (!done)
+            while (!done.IsSet)
             {
                 try
                 {
@@ -880,7 +880,7 @@ namespace RabbitMQ.Client.Unit
                         Assert.NotEqual(406, a.ShutdownReason.ReplyCode);
                     }
                 }
-                Thread.Sleep(1);
+                done.Wait(doneSpan);
             }
         }
 


### PR DESCRIPTION
Fix #1140 by assigning the new Model to _innerChannel at the correct place. This prevents a race condition during consumer recovery.

cc @michaelklishin @bollhals 