### PR TITLE
Fix for #1153 - Semaphore disposed before discarded tasks have finished

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/AsyncConsumerWorkService.cs
+++ b/projects/RabbitMQ.Client/client/impl/AsyncConsumerWorkService.cs
@@ -182,7 +182,14 @@ namespace RabbitMQ.Client.Impl
                 finally
                 {
                     work.PostExecute();
-                    limiter.Release();
+
+                    try
+                    {
+                        limiter.Release();
+                    }
+                    catch (ObjectDisposedException) // Prevents Exceptions in the Task's finalizer when the WorkPool is Stopped
+                    {
+                    }
                 }
             }
 


### PR DESCRIPTION
## Proposed Changes

Catch an `ObjectDisposedException` when attempting to Release the `_limiter` Semaphore after the WorkPool has been stopped.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes issue #1153)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories