### PR TITLE
Add TimeOut to Abort call in dispose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ TestResult.xml
 /NuGet
 .vscode/
 *.lock.json
-api/
 
 test.sh
 *.VisualState.xml

--- a/projects/RabbitMQ.Client/client/api/IConnectionExtensions.cs
+++ b/projects/RabbitMQ.Client/client/api/IConnectionExtensions.cs
@@ -19,7 +19,7 @@ namespace RabbitMQ.Client
         /// </remarks>
         public static void Close(this IConnection connection)
         {
-            connection.Close(Constants.ReplySuccess, "Goodbye", TimeSpan.FromSeconds(30), false);
+            connection.Close(Constants.ReplySuccess, "Goodbye", InternalConstants.DefaultConnectionCloseTimeout, false);
         }
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace RabbitMQ.Client
         /// </remarks>
         public static void Close(this IConnection connection, ushort reasonCode, string reasonText)
         {
-            connection.Close(reasonCode, reasonText, TimeSpan.FromSeconds(30), false);
+            connection.Close(reasonCode, reasonText, InternalConstants.DefaultConnectionCloseTimeout, false);
         }
 
         /// <summary>
@@ -93,7 +93,7 @@ namespace RabbitMQ.Client
         /// </remarks>
         public static void Abort(this IConnection connection)
         {
-            connection.Close(Constants.ReplySuccess, "Connection close forced", TimeSpan.FromSeconds(5), true);
+            connection.Close(Constants.ReplySuccess, "Connection close forced", InternalConstants.DefaultConnectionAbortTimeout, true);
         }
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace RabbitMQ.Client
         /// </remarks>
         public static void Abort(this IConnection connection, ushort reasonCode, string reasonText)
         {
-            connection.Close(reasonCode, reasonText, TimeSpan.FromSeconds(5), true);
+            connection.Close(reasonCode, reasonText, InternalConstants.DefaultConnectionAbortTimeout, true);
         }
 
         /// <summary>

--- a/projects/RabbitMQ.Client/client/api/InternalConstants.cs
+++ b/projects/RabbitMQ.Client/client/api/InternalConstants.cs
@@ -1,4 +1,4 @@
-﻿// This source code is dual-licensed under the Apache License, version
+// This source code is dual-licensed under the Apache License, version
 // 2.0, and the Mozilla Public License, version 2.0.
 //
 // The APL v2.0:
@@ -30,36 +30,12 @@
 //---------------------------------------------------------------------------
 
 using System;
-using System.Threading;
 
-using RabbitMQ.Client.Impl;
-
-using Xunit;
-using Xunit.Abstractions;
-
-namespace RabbitMQ.Client.Unit
+namespace RabbitMQ.Client
 {
-
-    public class TestModelShutdown : IntegrationFixture
+    internal static class InternalConstants
     {
-        public TestModelShutdown(ITestOutputHelper output) : base(output)
-        {
-        }
-
-        [Fact]
-        public void TestConsumerDispatcherShutdown()
-        {
-            var m = (AutorecoveringModel)_model;
-            var latch = new ManualResetEventSlim(false);
-
-            _model.ModelShutdown += (model, args) =>
-            {
-                latch.Set();
-            };
-            Assert.False(m.ConsumerDispatcher.IsShutdown, "dispatcher should NOT be shut down before Close");
-            _model.Close();
-            Wait(latch, TimeSpan.FromSeconds(3));
-            Assert.True(m.ConsumerDispatcher.IsShutdown, "dispatcher should be shut down after Close");
-        }
+        internal static readonly TimeSpan DefaultConnectionAbortTimeout = TimeSpan.FromSeconds(5);
+        internal static readonly TimeSpan DefaultConnectionCloseTimeout = TimeSpan.FromSeconds(30);
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.cs
@@ -216,7 +216,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
             try
             {
-                this.Abort();
+                this.Abort(InternalConstants.DefaultConnectionAbortTimeout);
             }
             catch (Exception)
             {

--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -42,7 +42,7 @@ using RabbitMQ.Client.Logging;
 
 namespace RabbitMQ.Client.Framing.Impl
 {
-    #nullable enable
+#nullable enable
     internal sealed partial class Connection : IConnection
     {
         private bool _disposed;
@@ -410,7 +410,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
             try
             {
-                this.Abort();
+                this.Abort(InternalConstants.DefaultConnectionAbortTimeout);
                 _mainLoopTask.Wait();
             }
             catch (OperationInterruptedException)

--- a/projects/RabbitMQ.Client/client/impl/ModelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ModelBase.cs
@@ -742,7 +742,7 @@ namespace RabbitMQ.Client.Impl
             if (m_connectionStartCell is null)
             {
                 var reason = new ShutdownEventArgs(ShutdownInitiator.Library, Constants.CommandInvalid, "Unexpected Connection.Start");
-                Session.Connection.Close(reason, false, TimeSpan.FromSeconds(30));
+                Session.Connection.Close(reason, false, InternalConstants.DefaultConnectionCloseTimeout);
             }
 
             var method = new ConnectionStart(cmd.MethodBytes.Span);

--- a/projects/Unit/APIApproval.cs
+++ b/projects/Unit/APIApproval.cs
@@ -29,6 +29,7 @@
 //  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
+using System.Reflection;
 using System.Threading.Tasks;
 
 using PublicApiGenerator;

--- a/projects/Unit/RabbitMQCtl.cs
+++ b/projects/Unit/RabbitMQCtl.cs
@@ -217,6 +217,7 @@ namespace RabbitMQ.Client.Unit
             StopRabbitMQ();
             Thread.Sleep(500);
             StartRabbitMQ();
+            AwaitRabbitMQ();
         }
 
         public static void StopRabbitMQ()

--- a/projects/Unit/TestAsyncConsumerExceptions.cs
+++ b/projects/Unit/TestAsyncConsumerExceptions.cs
@@ -36,13 +36,17 @@ using System.Threading.Tasks;
 using RabbitMQ.Client.Events;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestAsyncConsumerExceptions : IntegrationFixture
     {
         private static readonly Exception TestException = new Exception("oops");
+
+        public TestAsyncConsumerExceptions(ITestOutputHelper output) : base(output)
+        {
+        }
 
         protected void TestExceptionHandlingWith(IBasicConsumer consumer,
             Action<IModel, string, IBasicConsumer, string> action)

--- a/projects/Unit/TestBasicGet.cs
+++ b/projects/Unit/TestBasicGet.cs
@@ -32,12 +32,16 @@
 using RabbitMQ.Client.Exceptions;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestBasicGet : IntegrationFixture
     {
+        public TestBasicGet(ITestOutputHelper output) : base(output)
+        {
+        }
+
         [Fact]
         public void TestBasicGetWithClosedChannel()
         {

--- a/projects/Unit/TestBlockingCell.cs
+++ b/projects/Unit/TestBlockingCell.cs
@@ -38,7 +38,6 @@ using Xunit;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestBlockingCell : TimingFixture
     {
         internal class DelayedSetter<T>

--- a/projects/Unit/TestChannelSoftErrors.cs
+++ b/projects/Unit/TestChannelSoftErrors.cs
@@ -33,12 +33,16 @@ using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Exceptions;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestChannelSoftErrors : IntegrationFixture
     {
+        public TestChannelSoftErrors(ITestOutputHelper output) : base(output)
+        {
+        }
+
         [Fact]
         public void TestBindOnNonExistingQueue()
         {

--- a/projects/Unit/TestConcurrentAccessWithSharedConnection.cs
+++ b/projects/Unit/TestConcurrentAccessWithSharedConnection.cs
@@ -35,6 +35,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
@@ -44,6 +45,10 @@ namespace RabbitMQ.Client.Unit
         internal const int Threads = 32;
         internal CountdownEvent _latch;
         internal TimeSpan _completionTimeout = TimeSpan.FromSeconds(90);
+
+        public TestConcurrentAccessWithSharedConnection(ITestOutputHelper output) : base(output)
+        {
+        }
 
         protected override void SetUp()
         {

--- a/projects/Unit/TestConfirmSelect.cs
+++ b/projects/Unit/TestConfirmSelect.cs
@@ -30,12 +30,15 @@
 //---------------------------------------------------------------------------
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestConfirmSelect : IntegrationFixture
     {
+        public TestConfirmSelect(ITestOutputHelper output) : base(output)
+        {
+        }
 
         [Fact]
         public void TestConfirmSelectIdempotency()

--- a/projects/Unit/TestConnectionFactoryContinuationTimeout.cs
+++ b/projects/Unit/TestConnectionFactoryContinuationTimeout.cs
@@ -32,12 +32,16 @@
 using System;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestConnectionFactoryContinuationTimeout : IntegrationFixture
     {
+        public TestConnectionFactoryContinuationTimeout(ITestOutputHelper output) : base(output)
+        {
+        }
+
         [Fact]
         public void TestConnectionFactoryContinuationTimeoutOnRecoveringConnection()
         {

--- a/projects/Unit/TestConnectionShutdown.cs
+++ b/projects/Unit/TestConnectionShutdown.cs
@@ -36,12 +36,17 @@ using RabbitMQ.Client.Impl;
 using RabbitMQ.Client.Framing.Impl;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
 
     public class TestConnectionShutdown : IntegrationFixture
     {
+        public TestConnectionShutdown(ITestOutputHelper output) : base(output)
+        {
+        }
+
         [Fact]
         public void TestCleanClosureWithSocketClosedOutOfBand()
         {

--- a/projects/Unit/TestConsumerCancelNotify.cs
+++ b/projects/Unit/TestConsumerCancelNotify.cs
@@ -35,6 +35,7 @@ using System.Threading;
 using RabbitMQ.Client.Events;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
@@ -45,6 +46,10 @@ namespace RabbitMQ.Client.Unit
         protected bool notifiedCallback;
         protected bool notifiedEvent;
         protected string consumerTag;
+
+        public TestConsumerCancelNotify(ITestOutputHelper output) : base(output)
+        {
+        }
 
         [Fact]
         public void TestConsumerCancelNotification()

--- a/projects/Unit/TestConsumerCount.cs
+++ b/projects/Unit/TestConsumerCount.cs
@@ -32,11 +32,16 @@
 using RabbitMQ.Client.Events;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
     public class TestConsumerCount : IntegrationFixture
     {
+        public TestConsumerCount(ITestOutputHelper output) : base(output)
+        {
+        }
+
         [Fact]
         public void TestConsumerCountMethod()
         {

--- a/projects/Unit/TestConsumerExceptions.cs
+++ b/projects/Unit/TestConsumerExceptions.cs
@@ -33,6 +33,7 @@ using System;
 using System.Threading;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
@@ -124,6 +125,10 @@ namespace RabbitMQ.Client.Unit
             WaitOn(o);
 
             Assert.True(notified);
+        }
+
+        public TestConsumerExceptions(ITestOutputHelper output) : base(output)
+        {
         }
 
         [Fact]

--- a/projects/Unit/TestConsumerOperationDispatch.cs
+++ b/projects/Unit/TestConsumerOperationDispatch.cs
@@ -34,15 +34,19 @@ using System.Collections.Generic;
 using System.Threading;
 
 using RabbitMQ.Client.Events;
-using RabbitMQ.Client.Framing;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
 
     public class TestConsumerOperationDispatch : IntegrationFixture
     {
+        public TestConsumerOperationDispatch(ITestOutputHelper output) : base(output)
+        {
+        }
+
         private readonly string _x = "dotnet.tests.consumer-operation-dispatch.fanout";
         private readonly List<IModel> _channels = new List<IModel>();
         private readonly List<string> _queues = new List<string>();

--- a/projects/Unit/TestEventingConsumer.cs
+++ b/projects/Unit/TestEventingConsumer.cs
@@ -34,11 +34,16 @@ using System.Threading;
 using RabbitMQ.Client.Events;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
 
-    public class TestEventingConsumer : IntegrationFixture {
+    public class TestEventingConsumer : IntegrationFixture
+    {
+        public TestEventingConsumer(ITestOutputHelper output) : base(output)
+        {
+        }
 
         [Fact]
         public void TestEventingConsumerRegistrationEvents()

--- a/projects/Unit/TestExceptionMessages.cs
+++ b/projects/Unit/TestExceptionMessages.cs
@@ -34,12 +34,17 @@ using System;
 using RabbitMQ.Client.Exceptions;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
 
     public class TestExceptionMessages : IntegrationFixture
     {
+        public TestExceptionMessages(ITestOutputHelper output) : base(output)
+        {
+        }
+
         [Fact]
         public void TestAlreadyClosedExceptionMessage()
         {

--- a/projects/Unit/TestExchangeDeclare.cs
+++ b/projects/Unit/TestExchangeDeclare.cs
@@ -34,11 +34,16 @@ using System.Collections.Generic;
 using System.Threading;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
 
-    public class TestExchangeDeclare : IntegrationFixture {
+    public class TestExchangeDeclare : IntegrationFixture
+    {
+        public TestExchangeDeclare(ITestOutputHelper output) : base(output)
+        {
+        }
 
         [Fact]
         public void TestConcurrentExchangeDeclare()

--- a/projects/Unit/TestExtensions.cs
+++ b/projects/Unit/TestExtensions.cs
@@ -33,12 +33,17 @@ using System;
 using System.Threading.Tasks;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
 
     public class TestExtensions : IntegrationFixture
     {
+        public TestExtensions(ITestOutputHelper output) : base(output)
+        {
+        }
+
         [Fact]
         public async Task TestConfirmBarrier()
         {

--- a/projects/Unit/TestHeartbeats.cs
+++ b/projects/Unit/TestHeartbeats.cs
@@ -34,11 +34,16 @@ using System.Collections.Generic;
 using System.Threading;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
     public class TestHeartbeats : IntegrationFixture
     {
+        public TestHeartbeats(ITestOutputHelper output) : base(output)
+        {
+        }
+
         private readonly TimeSpan _heartbeatTimeout = TimeSpan.FromSeconds(2);
 
         [Fact(Timeout = 35000)]

--- a/projects/Unit/TestInitialConnection.cs
+++ b/projects/Unit/TestInitialConnection.cs
@@ -34,12 +34,17 @@ using System.Collections.Generic;
 using RabbitMQ.Client.Exceptions;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
 
     public class TestInitialConnection : IntegrationFixture
     {
+        public TestInitialConnection(ITestOutputHelper output) : base(output)
+        {
+        }
+
         [Fact]
         public void TestBasicConnectionRecoveryWithHostnameList()
         {

--- a/projects/Unit/TestInvalidAck.cs
+++ b/projects/Unit/TestInvalidAck.cs
@@ -32,11 +32,16 @@
 using System.Threading;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
 
-    public class TestInvalidAck : IntegrationFixture {
+    public class TestInvalidAck : IntegrationFixture
+    {
+        public TestInvalidAck(ITestOutputHelper output) : base(output)
+        {
+        }
 
         [Fact]
         public void TestAckWithUnknownConsumerTagAndMultipleFalse()

--- a/projects/Unit/TestMainLoop.cs
+++ b/projects/Unit/TestMainLoop.cs
@@ -35,11 +35,16 @@ using System.Threading;
 using RabbitMQ.Client.Events;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
 
-    public class TestMainLoop : IntegrationFixture {
+    public class TestMainLoop : IntegrationFixture
+    {
+        public TestMainLoop(ITestOutputHelper output) : base(output)
+        {
+        }
 
         private sealed class FaultyConsumer : DefaultBasicConsumer
         {

--- a/projects/Unit/TestMessageCount.cs
+++ b/projects/Unit/TestMessageCount.cs
@@ -32,11 +32,16 @@
 using System.Threading.Tasks;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
     public class TestMessageCount : IntegrationFixture
     {
+        public TestMessageCount(ITestOutputHelper output) : base(output)
+        {
+        }
+
         [Fact]
         public async Task TestMessageCountMethod()
         {

--- a/projects/Unit/TestNowait.cs
+++ b/projects/Unit/TestNowait.cs
@@ -30,11 +30,17 @@
 //---------------------------------------------------------------------------
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
 
-    public class TestNoWait : IntegrationFixture {
+    public class TestNoWait : IntegrationFixture
+    {
+        public TestNoWait(ITestOutputHelper output) : base(output)
+        {
+        }
+
         [Fact]
         public void TestQueueDeclareNoWait()
         {

--- a/projects/Unit/TestPassiveDeclare.cs
+++ b/projects/Unit/TestPassiveDeclare.cs
@@ -34,12 +34,17 @@ using System;
 using RabbitMQ.Client.Exceptions;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
 
     public class TestPassiveDeclare : IntegrationFixture
     {
+        public TestPassiveDeclare(ITestOutputHelper output) : base(output)
+        {
+        }
+
         [Fact]
         public void TestPassiveExchangeDeclareWhenExchangeDoesNotExist()
         {

--- a/projects/Unit/TestPublisherConfirms.cs
+++ b/projects/Unit/TestPublisherConfirms.cs
@@ -37,6 +37,7 @@ using System.Threading.Tasks;
 using RabbitMQ.Client.Impl;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
@@ -44,6 +45,10 @@ namespace RabbitMQ.Client.Unit
     public class TestPublisherConfirms : IntegrationFixture
     {
         private const string QueueName = "RabbitMQ.Client.Unit.TestPublisherConfirms";
+
+        public TestPublisherConfirms(ITestOutputHelper output) : base(output)
+        {
+        }
 
         [Fact]
         public void TestWaitForConfirmsWithoutTimeout()

--- a/projects/Unit/TestQueueDeclare.cs
+++ b/projects/Unit/TestQueueDeclare.cs
@@ -34,12 +34,15 @@ using System.Collections.Generic;
 using System.Threading;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestQueueDeclare : IntegrationFixture
     {
+        public TestQueueDeclare(ITestOutputHelper output) : base(output)
+        {
+        }
 
         [Fact]
         [Trait("Category", "RequireSMP")]

--- a/projects/Unit/TestUpdateSecret.cs
+++ b/projects/Unit/TestUpdateSecret.cs
@@ -33,11 +33,16 @@ using System;
 using System.Text;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
 
-    public class TestUpdateSecret : IntegrationFixture {
+    public class TestUpdateSecret : IntegrationFixture
+    {
+        public TestUpdateSecret(ITestOutputHelper output) : base(output)
+        {
+        }
 
         [Fact]
         public void TestUpdatingConnectionSecret()


### PR DESCRIPTION
Supersedes #1075

Fixes #938 

cc @CeesKass

Note: this also modifies integration tests to add the test suite name to the connection name. This makes it _much_ easier to know which tests may be having issues by looking at the RabbitMQ logs.

## Proposed Changes

While testing my usage of the RabbitMQ.Client library against a blocked RabbitMQ server I encountered an infinitely hanging dispose of my publisher see #938 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #938)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

I'm not sure if this is a breaking change or not, I did not dive deep enough into the Abort procedure to know if anything can break when calling with a timeout

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
