### PR TITLE
Improve error message when async dispatch is misconfigured.

### DIFF
--- a/projects/RabbitMQ.Client/client/api/AsyncDefaultBasicConsumer.cs
+++ b/projects/RabbitMQ.Client/client/api/AsyncDefaultBasicConsumer.cs
@@ -151,33 +151,33 @@ namespace RabbitMQ.Client
 
         event EventHandler<ConsumerEventArgs> IBasicConsumer.ConsumerCancelled
         {
-            add { throw new InvalidOperationException("Should never be called. Enable 'ConsumerDisaptchAsync'."); }
-            remove { throw new InvalidOperationException("Should never be called. Enable 'ConsumerDisaptchAsync'."); }
+            add { throw new InvalidOperationException("Should never be called. Enable 'ConsumerDispatchAsync'."); }
+            remove { throw new InvalidOperationException("Should never be called. Enable 'ConsumerDispatchAsync'."); }
         }
 
         void IBasicConsumer.HandleBasicCancelOk(string consumerTag)
         {
-            throw new InvalidOperationException("Should never be called. Enable 'ConsumerDisaptchAsync'.");
+            throw new InvalidOperationException("Should never be called. Enable 'ConsumerDispatchAsync'.");
         }
 
         void IBasicConsumer.HandleBasicConsumeOk(string consumerTag)
         {
-            throw new InvalidOperationException("Should never be called. Enable 'ConsumerDisaptchAsync'.");
+            throw new InvalidOperationException("Should never be called. Enable 'ConsumerDispatchAsync'.");
         }
 
         void IBasicConsumer.HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, in ReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
         {
-            throw new InvalidOperationException("Should never be called. Enable 'ConsumerDisaptchAsync'.");
+            throw new InvalidOperationException("Should never be called. Enable 'ConsumerDispatchAsync'.");
         }
 
         void IBasicConsumer.HandleModelShutdown(object model, ShutdownEventArgs reason)
         {
-            throw new InvalidOperationException("Should never be called. Enable 'ConsumerDisaptchAsync'.");
+            throw new InvalidOperationException("Should never be called. Enable 'ConsumerDispatchAsync'.");
         }
 
         void IBasicConsumer.HandleBasicCancel(string consumerTag)
         {
-            throw new InvalidOperationException("Should never be called. Enable 'ConsumerDisaptchAsync'.");
+            throw new InvalidOperationException("Should never be called. Enable 'ConsumerDispatchAsync'.");
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

Just emended the error messages thrown by `AsyncDefaultBasicConsumer` in case of misconfigured dispatch.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

None
