### PR TITLE
Added ability to specify custom ArrayPool

### DIFF
--- a/projects/RabbitMQ.Client/client/api/ConnectionFactory.cs
+++ b/projects/RabbitMQ.Client/client/api/ConnectionFactory.cs
@@ -189,7 +189,7 @@ namespace RabbitMQ.Client
 
         // just here to hold the value that was set through the setter
         private Uri _uri;
-        private ArrayPool<byte> _memoryPool;
+        private ArrayPool<byte> _memoryPool = ArrayPool<byte>.Shared;
 
         /// <summary>
         /// The memory pool used for allocating buffers. Default is <see cref="MemoryPool{T}.Shared"/>.

--- a/projects/RabbitMQ.Client/client/api/ConnectionFactory.cs
+++ b/projects/RabbitMQ.Client/client/api/ConnectionFactory.cs
@@ -189,14 +189,15 @@ namespace RabbitMQ.Client
 
         // just here to hold the value that was set through the setter
         private Uri _uri;
-        private readonly ArrayPool<byte> _memoryPool;
+        private ArrayPool<byte> _memoryPool;
 
         /// <summary>
         /// The memory pool used for allocating buffers. Default is <see cref="MemoryPool{T}.Shared"/>.
         /// </summary>
         public ArrayPool<byte> MemoryPool
         {
-            get => _memoryPool;
+            get { return _memoryPool; }
+            set { _memoryPool = value ?? ArrayPool<byte>.Shared; }
         }
 
         /// <summary>
@@ -268,18 +269,6 @@ namespace RabbitMQ.Client
         public ConnectionFactory()
         {
             ClientProperties = Connection.DefaultClientProperties();
-            _memoryPool = ArrayPool<byte>.Shared;
-        }
-
-        /// <summary>
-        /// Construct a fresh instance, with all fields set to their respective defaults,
-        /// using your own memory pool.
-        /// <param name="memoryPool">Memory pool to use with all Connections</param>
-        /// </summary>
-        public ConnectionFactory(ArrayPool<byte> memoryPool)
-        {
-            ClientProperties = Connection.DefaultClientProperties();
-            _memoryPool = memoryPool;
         }
 
         /// <summary>

--- a/projects/RabbitMQ.Client/client/impl/AsyncConsumerDispatcher.cs
+++ b/projects/RabbitMQ.Client/client/impl/AsyncConsumerDispatcher.cs
@@ -47,10 +47,11 @@ namespace RabbitMQ.Client.Impl
             IBasicProperties basicProperties,
             ReadOnlySpan<byte> body)
         {
-            byte[] bodyBytes = ArrayPool<byte>.Shared.Rent(body.Length);
+            var pool = _model.Session.Connection.MemoryPool;
+            byte[] bodyBytes = pool.Rent(body.Length);
             Memory<byte> bodyCopy = new Memory<byte>(bodyBytes, 0, body.Length);
             body.CopyTo(bodyCopy.Span);
-            ScheduleUnlessShuttingDown(new BasicDeliver(consumer, consumerTag, deliveryTag, redelivered, exchange, routingKey, basicProperties, bodyCopy));
+            ScheduleUnlessShuttingDown(new BasicDeliver(consumer, consumerTag, deliveryTag, redelivered, exchange, routingKey, basicProperties, bodyCopy, pool));
         }
 
         public void HandleBasicCancelOk(IBasicConsumer consumer, string consumerTag)

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.cs
@@ -683,8 +683,7 @@ namespace RabbitMQ.Client.Framing.Impl
                 throw new ObjectDisposedException(GetType().FullName);
             }
 
-            _delegate = new Connection(_factory, false,
-                fh, ClientProvidedName);
+            _delegate = new Connection(_factory, false, fh, _factory.MemoryPool, ClientProvidedName);
 
             _recoveryTask = Task.Run(MainRecoveryLoop);
 
@@ -1017,7 +1016,7 @@ namespace RabbitMQ.Client.Framing.Impl
             try
             {
                 IFrameHandler fh = _endpoints.SelectOne(_factory.CreateFrameHandler);
-                _delegate = new Connection(_factory, false, fh, ClientProvidedName);
+                _delegate = new Connection(_factory, false, fh, _factory.MemoryPool, ClientProvidedName);
                 return true;
             }
             catch (Exception e)

--- a/projects/RabbitMQ.Client/client/impl/CommandAssembler.cs
+++ b/projects/RabbitMQ.Client/client/impl/CommandAssembler.cs
@@ -88,7 +88,7 @@ namespace RabbitMQ.Client.Impl
                 return IncomingCommand.Empty;
             }
 
-            var result = new IncomingCommand(_method, _header, _body, _bodyBytes);
+            var result = new IncomingCommand(_method, _header, _body, _bodyBytes, _protocol.MemoryPool);
             Reset();
             return result;
         }
@@ -123,7 +123,7 @@ namespace RabbitMQ.Client.Impl
             _remainingBodyBytes = (int) totalBodyBytes;
 
             // Is returned by IncomingCommand.Dispose in Session.HandleFrame
-            _bodyBytes = ArrayPool<byte>.Shared.Rent(_remainingBodyBytes);
+            _bodyBytes = _protocol.MemoryPool.Rent(_remainingBodyBytes);
             _body = new Memory<byte>(_bodyBytes, 0, _remainingBodyBytes);
             UpdateContentBodyState();
         }

--- a/projects/RabbitMQ.Client/client/impl/ConcurrentConsumerDispatcher.cs
+++ b/projects/RabbitMQ.Client/client/impl/ConcurrentConsumerDispatcher.cs
@@ -64,7 +64,8 @@ namespace RabbitMQ.Client.Impl
                                        IBasicProperties basicProperties,
                                        ReadOnlySpan<byte> body)
         {
-            byte[] memoryCopyArray = ArrayPool<byte>.Shared.Rent(body.Length);
+            var pool = _model.Session.Connection.MemoryPool;
+            byte[] memoryCopyArray = pool.Rent(body.Length);
             Memory<byte> memoryCopy = new Memory<byte>(memoryCopyArray, 0, body.Length);
             body.CopyTo(memoryCopy.Span);
             UnlessShuttingDown(() =>
@@ -90,7 +91,7 @@ namespace RabbitMQ.Client.Impl
                 }
                 finally
                 {
-                    ArrayPool<byte>.Shared.Return(memoryCopyArray);
+                    pool.Return(memoryCopyArray);
                 }
             });
         }

--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -132,6 +132,10 @@ namespace RabbitMQ.Client.Framing.Impl
                 string clientProvidedName = null)
             : this(factory, insist, frameHandler, clientProvidedName)
         {
+            if (memoryPool == null)
+            {
+                throw new ArgumentNullException(nameof(memoryPool));
+            }
             _memoryPool = memoryPool;
         }
 

--- a/projects/RabbitMQ.Client/client/impl/IFrameHandler.cs
+++ b/projects/RabbitMQ.Client/client/impl/IFrameHandler.cs
@@ -61,6 +61,6 @@ namespace RabbitMQ.Client.Impl
 
         void SendHeader();
 
-        void Write(Memory<byte> memory);
+        void Write(ReadOnlyMemory<byte> memory);
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/IProtocolExtensions.cs
+++ b/projects/RabbitMQ.Client/client/impl/IProtocolExtensions.cs
@@ -30,9 +30,8 @@
 //---------------------------------------------------------------------------
 
 using System;
-
+using System.Buffers;
 using System.Net.Sockets;
-
 using RabbitMQ.Client.Impl;
 
 namespace RabbitMQ.Client.Framing.Impl
@@ -42,12 +41,16 @@ namespace RabbitMQ.Client.Framing.Impl
         public static IFrameHandler CreateFrameHandler(
             this IProtocol protocol,
             AmqpTcpEndpoint endpoint,
+            ArrayPool<byte> pool,
             Func<AddressFamily, ITcpClient> socketFactory,
             TimeSpan connectionTimeout,
             TimeSpan readTimeout,
             TimeSpan writeTimeout)
         {
-            return new SocketFrameHandler(endpoint, socketFactory, connectionTimeout, readTimeout, writeTimeout);
+            return new SocketFrameHandler(endpoint, socketFactory, connectionTimeout, readTimeout, writeTimeout)
+            {
+                MemoryPool = pool
+            };
         }
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/IncomingCommand.cs
+++ b/projects/RabbitMQ.Client/client/impl/IncomingCommand.cs
@@ -11,22 +11,24 @@ namespace RabbitMQ.Client.Impl
         public readonly ContentHeaderBase Header;
         public readonly ReadOnlyMemory<byte> Body;
         private readonly byte[] _rentedArray;
+        private readonly ArrayPool<byte> _rentedArrayOwner;
 
         public bool IsEmpty => Method is null;
 
-        public IncomingCommand(MethodBase method, ContentHeaderBase header, ReadOnlyMemory<byte> body, byte[] rentedArray)
+        public IncomingCommand(MethodBase method, ContentHeaderBase header, ReadOnlyMemory<byte> body, byte[] rentedArray, ArrayPool<byte> rentedArrayOwner)
         {
             Method = method;
             Header = header;
             Body = body;
             _rentedArray = rentedArray;
+            _rentedArrayOwner = rentedArrayOwner;
         }
 
         public void Dispose()
         {
             if (_rentedArray != null)
             {
-                ArrayPool<byte>.Shared.Return(_rentedArray);
+                _rentedArrayOwner.Return(_rentedArray);
             }
         }
 

--- a/projects/RabbitMQ.Client/client/impl/ModelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ModelBase.cs
@@ -68,7 +68,7 @@ namespace RabbitMQ.Client.Impl
 
         private bool _onlyAcksReceived = true;
 
-        public IConsumerDispatcher ConsumerDispatcher { get; private set; }
+        public IConsumerDispatcher ConsumerDispatcher { get; }
 
         public ModelBase(ISession session) : this(session, session.Connection.ConsumerWorkService)
         { }

--- a/projects/RabbitMQ.Client/client/impl/OutgoingCommand.cs
+++ b/projects/RabbitMQ.Client/client/impl/OutgoingCommand.cs
@@ -65,8 +65,8 @@ namespace RabbitMQ.Client.Impl
             int maxBodyPayloadBytes = (int)(connection.FrameMax == 0 ? int.MaxValue : connection.FrameMax - EmptyFrameSize);
             var size = GetMaxSize(maxBodyPayloadBytes);
 
-            // Will be returned by SocketFrameWriter.WriteLoop
-            var memory = new Memory<byte>(ArrayPool<byte>.Shared.Rent(size), 0, size);
+            // Will be returned by SocketFrameHandler.WriteLoop
+            var memory = new Memory<byte>(connection.MemoryPool.Rent(size), 0, size);
             var span = memory.Span;
 
             var offset = Framing.Method.WriteTo(span, channelNumber, Method);

--- a/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
+++ b/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
@@ -70,12 +70,13 @@ namespace RabbitMQ.Client.Impl
         private readonly ITcpClient _socket;
         private readonly Stream _reader;
         private readonly Stream _writer;
-        private readonly ChannelWriter<Memory<byte>> _channelWriter;
-        private readonly ChannelReader<Memory<byte>> _channelReader;
+        private readonly ChannelWriter<ReadOnlyMemory<byte>> _channelWriter;
+        private readonly ChannelReader<ReadOnlyMemory<byte>> _channelReader;
         private readonly Task _writerTask;
         private readonly object _semaphore = new object();
         private readonly byte[] _frameHeaderBuffer;
         private bool _closed;
+        private ArrayPool<byte> _pool = ArrayPool<byte>.Shared;
 
         public SocketFrameHandler(AmqpTcpEndpoint endpoint,
             Func<AddressFamily, ITcpClient> socketFactory,
@@ -83,7 +84,7 @@ namespace RabbitMQ.Client.Impl
         {
             Endpoint = endpoint;
             _frameHeaderBuffer = new byte[6];
-            var channel = Channel.CreateUnbounded<Memory<byte>>(
+            var channel = Channel.CreateUnbounded<ReadOnlyMemory<byte>>(
                 new UnboundedChannelOptions
                 {
                     AllowSynchronousContinuations = false,
@@ -135,6 +136,12 @@ namespace RabbitMQ.Client.Impl
             _writerTask = Task.Run(WriteLoop, CancellationToken.None);
         }
         public AmqpTcpEndpoint Endpoint { get; set; }
+
+        internal ArrayPool<byte> MemoryPool
+        {
+            get => _pool;
+            set => _pool = value ?? ArrayPool<byte>.Shared; // TODO: Change to init accessor
+        }
 
         public EndPoint LocalEndPoint
         {
@@ -222,7 +229,7 @@ namespace RabbitMQ.Client.Impl
 
         public InboundFrame ReadFrame()
         {
-            return InboundFrame.ReadFrom(_reader, _frameHeaderBuffer);
+            return InboundFrame.ReadFrom(_reader, _frameHeaderBuffer, MemoryPool);
         }
 
         public void SendHeader()
@@ -248,7 +255,7 @@ namespace RabbitMQ.Client.Impl
             _writer.Flush();
         }
 
-        public void Write(Memory<byte> memory)
+        public void Write(ReadOnlyMemory<byte> memory)
         {
             _channelWriter.TryWrite(memory);
         }
@@ -262,7 +269,7 @@ namespace RabbitMQ.Client.Impl
                 {
                     MemoryMarshal.TryGetArray(memory, out ArraySegment<byte> segment);
                     await _writer.WriteAsync(segment.Array, segment.Offset, segment.Count).ConfigureAwait(false);
-                    ArrayPool<byte>.Shared.Return(segment.Array);
+                    MemoryPool.Return(segment.Array);
                 }
 
                 await _writer.FlushAsync().ConfigureAwait(false);

--- a/projects/Unit/APIApproval.Approve.verified.txt
+++ b/projects/Unit/APIApproval.Approve.verified.txt
@@ -78,7 +78,6 @@ namespace RabbitMQ.Client
         public static readonly System.TimeSpan DefaultConnectionTimeout;
         public static readonly System.TimeSpan DefaultHeartbeat;
         public ConnectionFactory() { }
-        public ConnectionFactory(System.Buffers.ArrayPool<byte> memoryPool) { }
         public System.Security.Authentication.SslProtocols AmqpUriSslProtocols { get; set; }
         public System.Collections.Generic.IList<RabbitMQ.Client.IAuthMechanismFactory> AuthMechanisms { get; set; }
         public bool AutomaticRecoveryEnabled { get; set; }
@@ -91,7 +90,7 @@ namespace RabbitMQ.Client
         public System.Func<System.Collections.Generic.IEnumerable<RabbitMQ.Client.AmqpTcpEndpoint>, RabbitMQ.Client.IEndpointResolver> EndpointResolverFactory { get; set; }
         public System.TimeSpan HandshakeContinuationTimeout { get; set; }
         public string HostName { get; set; }
-        public System.Buffers.ArrayPool<byte> MemoryPool { get; }
+        public System.Buffers.ArrayPool<byte> MemoryPool { get; set; }
         public System.TimeSpan NetworkRecoveryInterval { get; set; }
         public string Password { get; set; }
         public int Port { get; set; }

--- a/projects/Unit/APIApproval.Approve.verified.txt
+++ b/projects/Unit/APIApproval.Approve.verified.txt
@@ -78,6 +78,7 @@ namespace RabbitMQ.Client
         public static readonly System.TimeSpan DefaultConnectionTimeout;
         public static readonly System.TimeSpan DefaultHeartbeat;
         public ConnectionFactory() { }
+        public ConnectionFactory(System.Buffers.ArrayPool<byte> memoryPool) { }
         public System.Security.Authentication.SslProtocols AmqpUriSslProtocols { get; set; }
         public System.Collections.Generic.IList<RabbitMQ.Client.IAuthMechanismFactory> AuthMechanisms { get; set; }
         public bool AutomaticRecoveryEnabled { get; set; }
@@ -90,6 +91,7 @@ namespace RabbitMQ.Client
         public System.Func<System.Collections.Generic.IEnumerable<RabbitMQ.Client.AmqpTcpEndpoint>, RabbitMQ.Client.IEndpointResolver> EndpointResolverFactory { get; set; }
         public System.TimeSpan HandshakeContinuationTimeout { get; set; }
         public string HostName { get; set; }
+        public System.Buffers.ArrayPool<byte> MemoryPool { get; }
         public System.TimeSpan NetworkRecoveryInterval { get; set; }
         public string Password { get; set; }
         public int Port { get; set; }

--- a/projects/Unit/TestFrameFormatting.cs
+++ b/projects/Unit/TestFrameFormatting.cs
@@ -43,7 +43,7 @@ namespace RabbitMQ.Client.Unit
         [Test]
         public void HeartbeatFrame()
         {
-            var memory = Impl.Framing.Heartbeat.GetHeartbeatFrame();
+            var memory = Impl.Framing.Heartbeat.GetHeartbeatFrame(ArrayPool<byte>.Shared);
             var frameSpan = memory.Span;
 
             try


### PR DESCRIPTION
## Proposed Changes

This change is aimed to fix inefficient memory pooling as described and discussed in #1184. It allows to specify custom `ArrayPool<byte>` through `ConnectionFactory` instead of `ArrayPool<byte>.Shared`.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Unfortunately, 6.x branch is based on .NET Standard 2.0. This target framework doesn't support `ReadAsync`/`WriteAsync` stream overloads supporting `ReadOnlyMemory<byte>` type. Thus, `MemoryPool<byte>` is not applicable here.