### PR TITLE
Add ability to specify maximum message size

### DIFF
--- a/projects/RabbitMQ.Client/client/api/AmqpTcpEndpoint.cs
+++ b/projects/RabbitMQ.Client/client/api/AmqpTcpEndpoint.cs
@@ -61,6 +61,7 @@ namespace RabbitMQ.Client
         public const int UseDefaultPort = -1;
 
         private int _port;
+        private uint _maxMessageSize = Constants.DefaultMaxMessageSizeInBytes;
 
         /// <summary>
         /// Creates a new instance of the <see cref="AmqpTcpEndpoint"/>.
@@ -176,6 +177,25 @@ namespace RabbitMQ.Client
         /// Retrieve the TLS options for this AmqpTcpEndpoint. If not set, null is returned.
         /// </summary>
         public SslOption Ssl { get; set; }
+
+        /// <summary>
+        /// Set the maximum size for a message in bytes. Setting it to 0 reverts to the default of 128MiB
+        /// </summary>
+        public uint MaxMessageSize
+        {
+            get { return _maxMessageSize; }
+            set
+            {
+                if (value == default(uint))
+                {
+                    _maxMessageSize = Constants.DefaultMaxMessageSizeInBytes;
+                }
+                else
+                {
+                    _maxMessageSize = value;
+                }
+            }
+        }
 
         /// <summary>
         /// Construct an instance from a protocol and an address in "hostname:port" format.

--- a/projects/RabbitMQ.Client/client/framing/Constants.cs
+++ b/projects/RabbitMQ.Client/client/framing/Constants.cs
@@ -81,5 +81,8 @@ namespace RabbitMQ.Client
         public const int NotImplemented = 540;
         ///<summary>(= 541)</summary>
         public const int InternalError = 541;
+
+        ///<summary>(= 134217728)</summary>
+        public const uint DefaultMaxMessageSizeInBytes = 134217728;
     }
 }

--- a/projects/Unit/APIApproval.Approve.verified.txt
+++ b/projects/Unit/APIApproval.Approve.verified.txt
@@ -1,4 +1,4 @@
-﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001008d20ec856aeeb8c3153a77faa2d80e6e43b5db93224a20cc7ae384f65f142e89730e2ff0fcc5d578bbe96fa98a7196c77329efdee4579b3814c0789e5a39b51df6edd75b602a33ceabdfcf19a3feb832f31d8254168cd7ba5700dfbca301fbf8db614ba41ba18474de0a5f4c2d51c995bc3636c641c8cbe76f45717bfcb943b5")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001008d20ec856aeeb8c3153a77faa2d80e6e43b5db93224a20cc7ae384f65f142e89730e2ff0fcc5d578bbe96fa98a7196c77329efdee4579b3814c0789e5a39b51df6edd75b602a33ceabdfcf19a3feb832f31d8254168cd7ba5700dfbca301fbf8db614ba41ba18474de0a5f4c2d51c995bc3636c641c8cbe76f45717bfcb943b5")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Unit, PublicKey=00240000048000009400000006020000002400005253413100040000010001008d20ec856aeeb8c3153a77faa2d80e6e43b5db93224a20cc7ae384f65f142e89730e2ff0fcc5d578bbe96fa98a7196c77329efdee4579b3814c0789e5a39b51df6edd75b602a33ceabdfcf19a3feb832f31d8254168cd7ba5700dfbca301fbf8db614ba41ba18474de0a5f4c2d51c995bc3636c641c8cbe76f45717bfcb943b5")]
 namespace RabbitMQ.Client
 {
@@ -13,6 +13,7 @@ namespace RabbitMQ.Client
         public AmqpTcpEndpoint(string hostName, int portOrMinusOne, RabbitMQ.Client.SslOption ssl) { }
         public System.Net.Sockets.AddressFamily AddressFamily { get; set; }
         public string HostName { get; set; }
+        public uint MaxMessageSize { get; set; }
         public int Port { get; set; }
         public RabbitMQ.Client.IProtocol Protocol { get; }
         public RabbitMQ.Client.SslOption Ssl { get; set; }
@@ -207,6 +208,7 @@ namespace RabbitMQ.Client
         public const int CommandInvalid = 503;
         public const int ConnectionForced = 320;
         public const int ContentTooLarge = 311;
+        public const uint DefaultMaxMessageSizeInBytes = 134217728u;
         public const int FrameBody = 3;
         public const int FrameEnd = 206;
         public const int FrameError = 501;


### PR DESCRIPTION
Sets the default max message size to 128MiB to match the RabbitMQ default. There is no way to specify unlimited, either.

Fixes #1217

When I back-port this to 6.x I'll make sure the default is to have no limit, which is different than here.