### PR TITLE
change ref to in and use Unsafe.AsRef

### DIFF
--- a/projects/RabbitMQ.Client/client/api/IModel.cs
+++ b/projects/RabbitMQ.Client/client/api/IModel.cs
@@ -188,7 +188,7 @@ namespace RabbitMQ.Client
         ///     Routing key must be shorter than 255 bytes.
         ///   </para>
         /// </remarks>
-        void BasicPublish<TProperties>(string exchange, string routingKey, ref TProperties basicProperties, ReadOnlyMemory<byte> body = default, bool mandatory = false)
+        void BasicPublish<TProperties>(string exchange, string routingKey, in TProperties basicProperties, ReadOnlyMemory<byte> body = default, bool mandatory = false)
             where TProperties : IReadOnlyBasicProperties, IAmqpHeader;
         /// <summary>
         /// Publishes a message.
@@ -198,7 +198,7 @@ namespace RabbitMQ.Client
         ///     Routing key must be shorter than 255 bytes.
         ///   </para>
         /// </remarks>
-        void BasicPublish<TProperties>(CachedString exchange, CachedString routingKey, ref TProperties basicProperties, ReadOnlyMemory<byte> body = default, bool mandatory = false)
+        void BasicPublish<TProperties>(CachedString exchange, CachedString routingKey, in TProperties basicProperties, ReadOnlyMemory<byte> body = default, bool mandatory = false)
             where TProperties : IReadOnlyBasicProperties, IAmqpHeader;
 #nullable disable
 

--- a/projects/RabbitMQ.Client/client/api/IModelExtensions.cs
+++ b/projects/RabbitMQ.Client/client/api/IModelExtensions.cs
@@ -82,17 +82,17 @@ namespace RabbitMQ.Client
         /// <remarks>
         /// The publication occurs with mandatory=false and immediate=false.
         /// </remarks>
-        public static void BasicPublish<T>(this IModel model, PublicationAddress addr, ref T basicProperties, ReadOnlyMemory<byte> body)
+        public static void BasicPublish<T>(this IModel model, PublicationAddress addr, in T basicProperties, ReadOnlyMemory<byte> body)
             where T : IReadOnlyBasicProperties, IAmqpHeader
         {
-            model.BasicPublish(addr.ExchangeName, addr.RoutingKey, ref basicProperties, body);
+            model.BasicPublish(addr.ExchangeName, addr.RoutingKey, in basicProperties, body);
         }
 
         public static void BasicPublish(this IModel model, string exchange, string routingKey, ReadOnlyMemory<byte> body = default, bool mandatory = false)
-            => model.BasicPublish(exchange, routingKey, ref EmptyBasicProperty.Empty, body, mandatory);
+            => model.BasicPublish(exchange, routingKey, in EmptyBasicProperty.Empty, body, mandatory);
 
         public static void BasicPublish(this IModel model, CachedString exchange, CachedString routingKey, ReadOnlyMemory<byte> body = default, bool mandatory = false)
-            => model.BasicPublish(exchange, routingKey, ref EmptyBasicProperty.Empty, body, mandatory);
+            => model.BasicPublish(exchange, routingKey, in EmptyBasicProperty.Empty, body, mandatory);
 #nullable disable
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace RabbitMQ.Client
         }
 
         /// <summary>
-        /// (Extension method) Like exchange bind but sets nowait to true. 
+        /// (Extension method) Like exchange bind but sets nowait to true.
         /// </summary>
         public static void ExchangeBindNoWait(this IModel model, string destination, string source, string routingKey, IDictionary<string, object> arguments = null)
         {
@@ -130,7 +130,7 @@ namespace RabbitMQ.Client
         }
 
         /// <summary>
-        /// (Extension method) Like ExchangeDeclare but sets nowait to true. 
+        /// (Extension method) Like ExchangeDeclare but sets nowait to true.
         /// </summary>
         public static void ExchangeDeclareNoWait(this IModel model, string exchange, string type, bool durable = false, bool autoDelete = false,
             IDictionary<string, object> arguments = null)

--- a/projects/RabbitMQ.Client/client/framing/Model.cs
+++ b/projects/RabbitMQ.Client/client/framing/Model.cs
@@ -44,56 +44,47 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public override void ConnectionTuneOk(ushort channelMax, uint frameMax, ushort heartbeat)
         {
-            var cmd = new ConnectionTuneOk(channelMax, frameMax, heartbeat);
-            ModelSend(ref cmd);
+            ModelSend(new ConnectionTuneOk(channelMax, frameMax, heartbeat));
         }
 
         public override void _Private_BasicCancel(string consumerTag, bool nowait)
         {
-            var cmd = new BasicCancel(consumerTag, nowait);
-            ModelSend(ref cmd);
+            ModelSend(new BasicCancel(consumerTag, nowait));
         }
 
         public override void _Private_BasicConsume(string queue, string consumerTag, bool noLocal, bool autoAck, bool exclusive, bool nowait, IDictionary<string, object> arguments)
         {
-            var cmd = new BasicConsume(queue, consumerTag, noLocal, autoAck, exclusive, nowait, arguments);
-            ModelSend(ref cmd);
+            ModelSend(new BasicConsume(queue, consumerTag, noLocal, autoAck, exclusive, nowait, arguments));
         }
 
         public override void _Private_BasicGet(string queue, bool autoAck)
         {
-            var cmd = new BasicGet(queue, autoAck);
-            ModelSend(ref cmd);
+            ModelSend(new BasicGet(queue, autoAck));
         }
 
         public override void _Private_BasicRecover(bool requeue)
         {
-            var cmd = new BasicRecover(requeue);
-            ModelSend(ref cmd);
+            ModelSend(new BasicRecover(requeue));
         }
 
         public override void _Private_ChannelClose(ushort replyCode, string replyText, ushort classId, ushort methodId)
         {
-            var cmd = new ChannelClose(replyCode, replyText, classId, methodId);
-            ModelSend(ref cmd);
+            ModelSend(new ChannelClose(replyCode, replyText, classId, methodId));
         }
 
         public override void _Private_ChannelCloseOk()
         {
-            var cmd = new ChannelCloseOk();
-            ModelSend(ref cmd);
+            ModelSend(new ChannelCloseOk());
         }
 
         public override void _Private_ChannelFlowOk(bool active)
         {
-            var cmd = new ChannelFlowOk(active);
-            ModelSend(ref cmd);
+            ModelSend(new ChannelFlowOk(active));
         }
 
         public override void _Private_ChannelOpen()
         {
-            var cmd = new ChannelOpen();
-            ModelRpc(ref cmd, ProtocolCommandId.ChannelOpenOk);
+            ModelRpc(new ChannelOpen(), ProtocolCommandId.ChannelOpenOk);
         }
 
         public override void _Private_ConfirmSelect(bool nowait)
@@ -101,198 +92,184 @@ namespace RabbitMQ.Client.Framing.Impl
             var method = new ConfirmSelect(nowait);
             if (nowait)
             {
-                ModelSend(ref method);
+                ModelSend(method);
             }
             else
             {
-                ModelRpc(ref method, ProtocolCommandId.ConfirmSelectOk);
+                ModelRpc(method, ProtocolCommandId.ConfirmSelectOk);
             }
         }
 
         public override void _Private_ConnectionCloseOk()
         {
-            var cmd = new ConnectionCloseOk();
-            ModelSend(ref cmd);
+            ModelSend(new ConnectionCloseOk());
         }
 
         public override void _Private_ConnectionOpen(string virtualHost)
         {
-            var cmd = new ConnectionOpen(virtualHost);
-            ModelSend(ref cmd);
+            ModelSend(new ConnectionOpen(virtualHost));
         }
 
         public override void _Private_ConnectionSecureOk(byte[] response)
         {
-            var cmd = new ConnectionSecureOk(response);
-            ModelSend(ref cmd);
+            ModelSend(new ConnectionSecureOk(response));
         }
 
         public override void _Private_ConnectionStartOk(IDictionary<string, object> clientProperties, string mechanism, byte[] response, string locale)
         {
-            var cmd = new ConnectionStartOk(clientProperties, mechanism, response, locale);
-            ModelSend(ref cmd);
+            ModelSend(new ConnectionStartOk(clientProperties, mechanism, response, locale));
         }
 
         public override void _Private_UpdateSecret(byte[] newSecret, string reason)
         {
-            var cmd = new ConnectionUpdateSecret(newSecret, reason);
-            ModelRpc(ref cmd, ProtocolCommandId.ConnectionUpdateSecretOk);
+            ModelRpc(new ConnectionUpdateSecret(newSecret, reason), ProtocolCommandId.ConnectionUpdateSecretOk);
         }
 
         public override void _Private_ExchangeBind(string destination, string source, string routingKey, bool nowait, IDictionary<string, object> arguments)
         {
-            ExchangeBind method = new ExchangeBind(destination, source, routingKey, nowait, arguments);
+            var method = new ExchangeBind(destination, source, routingKey, nowait, arguments);
             if (nowait)
             {
-                ModelSend(ref method);
+                ModelSend(method);
             }
             else
             {
-                ModelRpc(ref method, ProtocolCommandId.ExchangeBindOk);
+                ModelRpc(method, ProtocolCommandId.ExchangeBindOk);
             }
         }
 
         public override void _Private_ExchangeDeclare(string exchange, string type, bool passive, bool durable, bool autoDelete, bool @internal, bool nowait, IDictionary<string, object> arguments)
         {
-            ExchangeDeclare method = new ExchangeDeclare(exchange, type, passive, durable, autoDelete, @internal, nowait, arguments);
+            var method = new ExchangeDeclare(exchange, type, passive, durable, autoDelete, @internal, nowait, arguments);
             if (nowait)
             {
-                ModelSend(ref method);
+                ModelSend(method);
             }
             else
             {
-                ModelRpc(ref method, ProtocolCommandId.ExchangeDeclareOk);
+                ModelRpc(method, ProtocolCommandId.ExchangeDeclareOk);
             }
         }
 
         public override void _Private_ExchangeDelete(string exchange, bool ifUnused, bool nowait)
         {
-            ExchangeDelete method = new ExchangeDelete(exchange, ifUnused, nowait);
+            var method = new ExchangeDelete(exchange, ifUnused, nowait);
             if (nowait)
             {
-                ModelSend(ref method);
+                ModelSend(method);
             }
             else
             {
-                ModelRpc(ref method, ProtocolCommandId.ExchangeDeleteOk);
+                ModelRpc(method, ProtocolCommandId.ExchangeDeleteOk);
             }
         }
 
         public override void _Private_ExchangeUnbind(string destination, string source, string routingKey, bool nowait, IDictionary<string, object> arguments)
         {
-            ExchangeUnbind method = new ExchangeUnbind(destination, source, routingKey, nowait, arguments);
+            var method = new ExchangeUnbind(destination, source, routingKey, nowait, arguments);
             if (nowait)
             {
-                ModelSend(ref method);
+                ModelSend(method);
             }
             else
             {
-                ModelRpc(ref method, ProtocolCommandId.ExchangeUnbindOk);
+                ModelRpc(method, ProtocolCommandId.ExchangeUnbindOk);
             }
         }
 
         public override void _Private_QueueBind(string queue, string exchange, string routingKey, bool nowait, IDictionary<string, object> arguments)
         {
-            QueueBind method = new QueueBind(queue, exchange, routingKey, nowait, arguments);
+            var method = new QueueBind(queue, exchange, routingKey, nowait, arguments);
             if (nowait)
             {
-                ModelSend(ref method);
+                ModelSend(method);
             }
             else
             {
-                ModelRpc(ref method, ProtocolCommandId.QueueBindOk);
+                ModelRpc(method, ProtocolCommandId.QueueBindOk);
             }
         }
 
         public override void _Private_QueueDeclare(string queue, bool passive, bool durable, bool exclusive, bool autoDelete, bool nowait, IDictionary<string, object> arguments)
         {
-            QueueDeclare method = new QueueDeclare(queue, passive, durable, exclusive, autoDelete, nowait, arguments);
+            var method = new QueueDeclare(queue, passive, durable, exclusive, autoDelete, nowait, arguments);
             if (nowait)
             {
-                ModelSend(ref method);
+                ModelSend(method);
             }
             else
             {
-                ModelSend(ref method);
+                ModelSend(method);
             }
         }
 
         public override uint _Private_QueueDelete(string queue, bool ifUnused, bool ifEmpty, bool nowait)
         {
-            QueueDelete method = new QueueDelete(queue, ifUnused, ifEmpty, nowait);
+            var method = new QueueDelete(queue, ifUnused, ifEmpty, nowait);
             if (nowait)
             {
-                ModelSend(ref method);
+                ModelSend(method);
                 return 0xFFFFFFFF;
             }
 
-            return ModelRpc(ref method, ProtocolCommandId.QueueDeleteOk, memory => new QueueDeleteOk(memory.Span)._messageCount);
+            return ModelRpc(method, ProtocolCommandId.QueueDeleteOk, memory => new QueueDeleteOk(memory.Span)._messageCount);
         }
 
         public override uint _Private_QueuePurge(string queue, bool nowait)
         {
-            QueuePurge method = new QueuePurge(queue, nowait);
+            var method = new QueuePurge(queue, nowait);
             if (nowait)
             {
-                ModelSend(ref method);
+                ModelSend(method);
                 return 0xFFFFFFFF;
             }
 
-            return ModelRpc(ref method, ProtocolCommandId.QueuePurgeOk, memory => new QueuePurgeOk(memory.Span)._messageCount);
+            return ModelRpc(method, ProtocolCommandId.QueuePurgeOk, memory => new QueuePurgeOk(memory.Span)._messageCount);
         }
 
         public override void BasicAck(ulong deliveryTag, bool multiple)
         {
-            var cmd = new BasicAck(deliveryTag, multiple);
-            ModelSend(ref cmd);
+            ModelSend(new BasicAck(deliveryTag, multiple));
         }
 
         public override void BasicNack(ulong deliveryTag, bool multiple, bool requeue)
         {
-            var cmd = new BasicNack(deliveryTag, multiple, requeue);
-            ModelSend(ref cmd);
+            ModelSend(new BasicNack(deliveryTag, multiple, requeue));
         }
 
         public override void BasicQos(uint prefetchSize, ushort prefetchCount, bool global)
         {
-            var cmd = new BasicQos(prefetchSize, prefetchCount, global);
-            ModelRpc(ref cmd, ProtocolCommandId.BasicQosOk);
+            ModelRpc(new BasicQos(prefetchSize, prefetchCount, global), ProtocolCommandId.BasicQosOk);
         }
 
         public override void BasicRecoverAsync(bool requeue)
         {
-            var cmd = new BasicRecoverAsync(requeue);
-            ModelSend(ref cmd);
+            ModelSend(new BasicRecoverAsync(requeue));
         }
 
         public override void BasicReject(ulong deliveryTag, bool requeue)
         {
-            var cmd = new BasicReject(deliveryTag, requeue);
-            ModelSend(ref cmd);
+            ModelSend(new BasicReject(deliveryTag, requeue));
         }
 
         public override void QueueUnbind(string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
         {
-            var cmd = new QueueUnbind(queue, exchange, routingKey, arguments);
-            ModelRpc(ref cmd, ProtocolCommandId.QueueUnbindOk);
+            ModelRpc(new QueueUnbind(queue, exchange, routingKey, arguments), ProtocolCommandId.QueueUnbindOk);
         }
 
         public override void TxCommit()
         {
-            var cmd = new TxCommit();
-            ModelRpc(ref cmd, ProtocolCommandId.TxCommitOk);
+            ModelRpc(new TxCommit(), ProtocolCommandId.TxCommitOk);
         }
 
         public override void TxRollback()
         {
-            var cmd = new TxRollback();
-            ModelRpc(ref cmd, ProtocolCommandId.TxRollbackOk);
+            ModelRpc(new TxRollback(), ProtocolCommandId.TxRollbackOk);
         }
 
         public override void TxSelect()
         {
-            var cmd = new TxSelect();
-            ModelRpc(ref cmd, ProtocolCommandId.TxSelectOk);
+            ModelRpc(new TxSelect(), ProtocolCommandId.TxSelectOk);
         }
 
         protected override bool DispatchAsynchronous(in IncomingCommand cmd)

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
@@ -249,13 +249,13 @@ namespace RabbitMQ.Client.Impl
         public void BasicNack(ulong deliveryTag, bool multiple, bool requeue)
             => InnerChannel.BasicNack(deliveryTag, multiple, requeue);
 
-        public void BasicPublish<TProperties>(string exchange, string routingKey, ref TProperties basicProperties, ReadOnlyMemory<byte> body, bool mandatory)
+        public void BasicPublish<TProperties>(string exchange, string routingKey, in TProperties basicProperties, ReadOnlyMemory<byte> body, bool mandatory)
             where TProperties : IReadOnlyBasicProperties, IAmqpHeader
-            => InnerChannel.BasicPublish(exchange, routingKey, ref basicProperties, body, mandatory);
+            => InnerChannel.BasicPublish(exchange, routingKey, in basicProperties, body, mandatory);
 
-        public void BasicPublish<TProperties>(CachedString exchange, CachedString routingKey, ref TProperties basicProperties, ReadOnlyMemory<byte> body, bool mandatory)
+        public void BasicPublish<TProperties>(CachedString exchange, CachedString routingKey, in TProperties basicProperties, ReadOnlyMemory<byte> body, bool mandatory)
             where TProperties : IReadOnlyBasicProperties, IAmqpHeader
-            => InnerChannel.BasicPublish(exchange, routingKey, ref basicProperties, body, mandatory);
+            => InnerChannel.BasicPublish(exchange, routingKey, in basicProperties, body, mandatory);
 
         public void BasicQos(uint prefetchSize, ushort prefetchCount, bool global)
         {

--- a/projects/RabbitMQ.Client/client/impl/Connection.Receive.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.Receive.cs
@@ -148,7 +148,7 @@ namespace RabbitMQ.Client.Framing.Impl
                 try
                 {
                     var cmd = new ConnectionClose(hpe.ShutdownReason.ReplyCode, hpe.ShutdownReason.ReplyText, 0, 0);
-                    _session0.Transmit(ref cmd);
+                    _session0.Transmit(in cmd);
                     if (hpe.CanShutdownCleanly)
                     {
                         ClosingLoop();

--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -284,8 +284,7 @@ namespace RabbitMQ.Client.Framing.Impl
                     // Try to send connection.close wait for CloseOk in the MainLoop
                     if (!_closed)
                     {
-                        var cmd = new ConnectionClose(reason.ReplyCode, reason.ReplyText, 0, 0);
-                        _session0.Transmit(ref cmd);
+                        _session0.Transmit(new ConnectionClose(reason.ReplyCode, reason.ReplyText, 0, 0));
                     }
                 }
                 catch (AlreadyClosedException)

--- a/projects/RabbitMQ.Client/client/impl/EmptyBasicProperty.cs
+++ b/projects/RabbitMQ.Client/client/impl/EmptyBasicProperty.cs
@@ -8,7 +8,7 @@ namespace RabbitMQ.Client.client.impl
 #nullable enable
     internal readonly struct EmptyBasicProperty : IReadOnlyBasicProperties, IAmqpHeader
     {
-        internal static EmptyBasicProperty Empty;
+        internal static readonly EmptyBasicProperty Empty;
 
         ushort IAmqpHeader.ProtocolClassId => ClassConstants.Basic;
 

--- a/projects/RabbitMQ.Client/client/impl/ISession.cs
+++ b/projects/RabbitMQ.Client/client/impl/ISession.cs
@@ -72,8 +72,8 @@ namespace RabbitMQ.Client.Impl
         void Close(ShutdownEventArgs reason, bool notify);
         bool HandleFrame(in InboundFrame frame);
         void Notify();
-        void Transmit<T>(ref T cmd) where T : struct, IOutgoingAmqpMethod;
-        void Transmit<TMethod, THeader>(ref TMethod cmd, ref THeader header, ReadOnlyMemory<byte> body)
+        void Transmit<T>(in T cmd) where T : struct, IOutgoingAmqpMethod;
+        void Transmit<TMethod, THeader>(in TMethod cmd, in THeader header, ReadOnlyMemory<byte> body)
             where TMethod : struct, IOutgoingAmqpMethod
             where THeader : IAmqpHeader;
     }

--- a/projects/RabbitMQ.Client/client/impl/MainSession.cs
+++ b/projects/RabbitMQ.Client/client/impl/MainSession.cs
@@ -99,7 +99,7 @@ namespace RabbitMQ.Client.Impl
             }
         }
 
-        public override void Transmit<T>(ref T cmd)
+        public override void Transmit<T>(in T cmd)
         {
             if (_closing && // Are we closing?
                 cmd.ProtocolCommandId != ProtocolCommandId.ConnectionCloseOk && // is this not a close-ok?
@@ -110,7 +110,7 @@ namespace RabbitMQ.Client.Impl
                 return;
             }
 
-            base.Transmit(ref cmd);
+            base.Transmit(in cmd);
         }
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/ModelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ModelBase.cs
@@ -333,7 +333,7 @@ namespace RabbitMQ.Client.Impl
             }
         }
 
-        protected void ModelRpc<TMethod>(ref TMethod method, ProtocolCommandId returnCommandId)
+        protected void ModelRpc<TMethod>(in TMethod method, ProtocolCommandId returnCommandId)
             where TMethod : struct, IOutgoingAmqpMethod
         {
             var k = new SimpleBlockingRpcContinuation();
@@ -341,7 +341,7 @@ namespace RabbitMQ.Client.Impl
             lock (_rpcLock)
             {
                 Enqueue(k);
-                Session.Transmit(ref method);
+                Session.Transmit(in method);
                 k.GetReply(ContinuationTimeout, out reply);
             }
 
@@ -353,7 +353,7 @@ namespace RabbitMQ.Client.Impl
             }
         }
 
-        protected TReturn ModelRpc<TMethod, TReturn>(ref TMethod method, ProtocolCommandId returnCommandId, Func<ReadOnlyMemory<byte>, TReturn> createFunc)
+        protected TReturn ModelRpc<TMethod, TReturn>(in TMethod method, ProtocolCommandId returnCommandId, Func<ReadOnlyMemory<byte>, TReturn> createFunc)
             where TMethod : struct, IOutgoingAmqpMethod
         {
             var k = new SimpleBlockingRpcContinuation();
@@ -362,7 +362,7 @@ namespace RabbitMQ.Client.Impl
             lock (_rpcLock)
             {
                 Enqueue(k);
-                Session.Transmit(ref method);
+                Session.Transmit(in method);
                 k.GetReply(ContinuationTimeout, out reply);
             }
 
@@ -378,13 +378,13 @@ namespace RabbitMQ.Client.Impl
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected void ModelSend<T>(ref T method) where T : struct, IOutgoingAmqpMethod
+        protected void ModelSend<T>(in T method) where T : struct, IOutgoingAmqpMethod
         {
-            Session.Transmit(ref method);
+            Session.Transmit(in method);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected void ModelSend<TMethod, THeader>(ref TMethod method, ref THeader header, ReadOnlyMemory<byte> body)
+        protected void ModelSend<TMethod, THeader>(in TMethod method, in THeader header, ReadOnlyMemory<byte> body)
             where TMethod : struct, IOutgoingAmqpMethod
             where THeader : IAmqpHeader
         {
@@ -392,7 +392,7 @@ namespace RabbitMQ.Client.Impl
             {
                 _flowControlBlock.Wait();
             }
-            Session.Transmit(ref method, ref header, body);
+            Session.Transmit(in method, in header, body);
         }
 
         internal void OnCallbackException(CallbackExceptionEventArgs args)
@@ -898,7 +898,7 @@ namespace RabbitMQ.Client.Impl
 
         public abstract void BasicNack(ulong deliveryTag, bool multiple, bool requeue);
 
-        public void BasicPublish<TProperties>(string exchange, string routingKey, ref TProperties basicProperties, ReadOnlyMemory<byte> body, bool mandatory)
+        public void BasicPublish<TProperties>(string exchange, string routingKey, in TProperties basicProperties, ReadOnlyMemory<byte> body, bool mandatory)
             where TProperties : IReadOnlyBasicProperties, IAmqpHeader
         {
             if (NextPublishSeqNo > 0)
@@ -910,10 +910,10 @@ namespace RabbitMQ.Client.Impl
             }
 
             var cmd = new BasicPublish(exchange, routingKey, mandatory, default);
-            ModelSend(ref cmd, ref basicProperties, body);
+            ModelSend(in cmd, in basicProperties, body);
         }
 
-        public void BasicPublish<TProperties>(CachedString exchange, CachedString routingKey, ref TProperties basicProperties, ReadOnlyMemory<byte> body, bool mandatory)
+        public void BasicPublish<TProperties>(CachedString exchange, CachedString routingKey, in TProperties basicProperties, ReadOnlyMemory<byte> body, bool mandatory)
             where TProperties : IReadOnlyBasicProperties, IAmqpHeader
         {
             if (NextPublishSeqNo > 0)
@@ -925,7 +925,7 @@ namespace RabbitMQ.Client.Impl
             }
 
             var cmd = new BasicPublishMemory(exchange.Bytes, routingKey.Bytes, mandatory, default);
-            ModelSend(ref cmd, ref basicProperties, body);
+            ModelSend(in cmd, in basicProperties, body);
         }
 
         public void UpdateSecret(string newSecret, string reason)

--- a/projects/TestApplications/MassPublish/Program.cs
+++ b/projects/TestApplications/MassPublish/Program.cs
@@ -48,7 +48,7 @@ namespace MassPublish
                         {
                             AppId = "testapp",
                         };
-                        publisher.BasicPublish("test", "myawesome.routing.key", ref properties, payload);
+                        publisher.BasicPublish("test", "myawesome.routing.key", properties, payload);
                     }
                     messagesSent += ItemsPerBatch;
                     await publisher.WaitForConfirmsOrDieAsync().ConfigureAwait(false);

--- a/projects/Unit/APIApproval.Approve.verified.txt
+++ b/projects/Unit/APIApproval.Approve.verified.txt
@@ -456,9 +456,9 @@ namespace RabbitMQ.Client
         string BasicConsume(string queue, bool autoAck, string consumerTag, bool noLocal, bool exclusive, System.Collections.Generic.IDictionary<string, object> arguments, RabbitMQ.Client.IBasicConsumer consumer);
         RabbitMQ.Client.BasicGetResult BasicGet(string queue, bool autoAck);
         void BasicNack(ulong deliveryTag, bool multiple, bool requeue);
-        void BasicPublish<TProperties>(RabbitMQ.Client.CachedString exchange, RabbitMQ.Client.CachedString routingKey, ref TProperties basicProperties, System.ReadOnlyMemory<byte> body = default, bool mandatory = false)
+        void BasicPublish<TProperties>(RabbitMQ.Client.CachedString exchange, RabbitMQ.Client.CachedString routingKey, in TProperties basicProperties, System.ReadOnlyMemory<byte> body = default, bool mandatory = false)
             where TProperties : RabbitMQ.Client.IReadOnlyBasicProperties, RabbitMQ.Client.IAmqpHeader;
-        void BasicPublish<TProperties>(string exchange, string routingKey, ref TProperties basicProperties, System.ReadOnlyMemory<byte> body = default, bool mandatory = false)
+        void BasicPublish<TProperties>(string exchange, string routingKey, in TProperties basicProperties, System.ReadOnlyMemory<byte> body = default, bool mandatory = false)
             where TProperties : RabbitMQ.Client.IReadOnlyBasicProperties, RabbitMQ.Client.IAmqpHeader;
         void BasicQos(uint prefetchSize, ushort prefetchCount, bool global);
         void BasicRecover(bool requeue);
@@ -502,7 +502,7 @@ namespace RabbitMQ.Client
         public static string BasicConsume(this RabbitMQ.Client.IModel model, RabbitMQ.Client.IBasicConsumer consumer, string queue, bool autoAck = false, string consumerTag = "", bool noLocal = false, bool exclusive = false, System.Collections.Generic.IDictionary<string, object> arguments = null) { }
         public static void BasicPublish(this RabbitMQ.Client.IModel model, RabbitMQ.Client.CachedString exchange, RabbitMQ.Client.CachedString routingKey, System.ReadOnlyMemory<byte> body = default, bool mandatory = false) { }
         public static void BasicPublish(this RabbitMQ.Client.IModel model, string exchange, string routingKey, System.ReadOnlyMemory<byte> body = default, bool mandatory = false) { }
-        public static void BasicPublish<T>(this RabbitMQ.Client.IModel model, RabbitMQ.Client.PublicationAddress addr, ref T basicProperties, System.ReadOnlyMemory<byte> body)
+        public static void BasicPublish<T>(this RabbitMQ.Client.IModel model, RabbitMQ.Client.PublicationAddress addr, in T basicProperties, System.ReadOnlyMemory<byte> body)
             where T : RabbitMQ.Client.IReadOnlyBasicProperties, RabbitMQ.Client.IAmqpHeader { }
         public static void Close(this RabbitMQ.Client.IModel model) { }
         public static void Close(this RabbitMQ.Client.IModel model, ushort replyCode, string replyText) { }

--- a/projects/Unit/TestBasicPublish.cs
+++ b/projects/Unit/TestBasicPublish.cs
@@ -32,7 +32,7 @@ namespace RabbitMQ.Client.Unit
                 };
                 string tag = m.BasicConsume(q.QueueName, true, consumer);
 
-                m.BasicPublish("", q.QueueName, ref bp, sendBody);
+                m.BasicPublish("", q.QueueName, bp, sendBody);
                 bool waitResFalse = are.WaitOne(5000);
                 m.BasicCancel(tag);
 

--- a/projects/Unit/TestConnectionRecovery.cs
+++ b/projects/Unit/TestConnectionRecovery.cs
@@ -877,7 +877,7 @@ namespace RabbitMQ.Client.Unit
             {
                 try
                 {
-                    _model.BasicPublish(string.Empty, testQueueName, ref properties, _messageBody);
+                    _model.BasicPublish(string.Empty, testQueueName, properties, _messageBody);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
## Proposed Changes

This change avoids having to expose the `ref BasicProperties` parameter we have introduced when switching over to the struct BasicProperties.

Ref has 2 downsides, 
- 1) it's not readonly, so the user could think we're editing the struct, which we do not want to do.
- 2) you have to put ref infront of it everywhere

This PR changes it to be `in`, and in the lowest possible place use Unsafe.AsRef to cheat our way to be able to use ref for the SerializeToFrames method.
(Which requires it, as the generic method  creates defensive copies of the struct if it is `n` for each method call, as it is not aware that the method itself is readonly due to the interface description not allowing to mark a method as readonly. (This is a dotnet limitation))

So with this we get the best for the user and an acceptable workaround within the library.

Undos commit af8c0721d8c7d7c1ed631a490c33596da3e0a580 of #1096 

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories