### PR TITLE
Add OpenTelemetry support via ActivitySource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.orig
 *.log
 _site/
 
@@ -28,6 +29,11 @@ test.sh
 test-output.log
 InternalTrace*
 nunit-agent*
+#################
+## JetBrains Rider
+#################
+.idea/
+
 #################
 ## Visual Studio
 #################

--- a/RabbitMQDotNetClient.sln
+++ b/RabbitMQDotNetClient.sln
@@ -5,6 +5,7 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{34486CC0-D61E-46BA-9E5E-6E8EFA7C34B5}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		.gitignore = .gitignore
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RabbitMQ.Client", "projects\RabbitMQ.Client\RabbitMQ.Client.csproj", "{8C554257-5ECC-45DB-873D-560BFBB74EC8}"

--- a/projects/RabbitMQ.Client/PublicAPI.Unshipped.txt
+++ b/projects/RabbitMQ.Client/PublicAPI.Unshipped.txt
@@ -481,8 +481,8 @@ RabbitMQ.Client.IChannel.BasicAcks -> System.EventHandler<RabbitMQ.Client.Events
 RabbitMQ.Client.IChannel.BasicGetAsync(string queue, bool autoAck) -> System.Threading.Tasks.ValueTask<RabbitMQ.Client.BasicGetResult>
 RabbitMQ.Client.IChannel.BasicNackAsync(ulong deliveryTag, bool multiple, bool requeue) -> System.Threading.Tasks.ValueTask
 RabbitMQ.Client.IChannel.BasicNacks -> System.EventHandler<RabbitMQ.Client.Events.BasicNackEventArgs>
-RabbitMQ.Client.IChannel.BasicPublishAsync<TProperties>(RabbitMQ.Client.CachedString exchange, RabbitMQ.Client.CachedString routingKey, in TProperties basicProperties, System.ReadOnlyMemory<byte> body = default(System.ReadOnlyMemory<byte>), bool mandatory = false) -> System.Threading.Tasks.ValueTask
-RabbitMQ.Client.IChannel.BasicPublishAsync<TProperties>(string exchange, string routingKey, in TProperties basicProperties, System.ReadOnlyMemory<byte> body = default(System.ReadOnlyMemory<byte>), bool mandatory = false) -> System.Threading.Tasks.ValueTask
+RabbitMQ.Client.IChannel.BasicPublishAsync<TProperties>(RabbitMQ.Client.CachedString exchange, RabbitMQ.Client.CachedString routingKey, TProperties basicProperties, System.ReadOnlyMemory<byte> body = default(System.ReadOnlyMemory<byte>), bool mandatory = false) -> System.Threading.Tasks.ValueTask
+RabbitMQ.Client.IChannel.BasicPublishAsync<TProperties>(string exchange, string routingKey, TProperties basicProperties, System.ReadOnlyMemory<byte> body = default(System.ReadOnlyMemory<byte>), bool mandatory = false) -> System.Threading.Tasks.ValueTask
 RabbitMQ.Client.IChannel.BasicReturn -> System.EventHandler<RabbitMQ.Client.Events.BasicReturnEventArgs>
 RabbitMQ.Client.IChannel.CallbackException -> System.EventHandler<RabbitMQ.Client.Events.CallbackExceptionEventArgs>
 RabbitMQ.Client.IChannel.ChannelNumber.get -> int
@@ -658,6 +658,7 @@ RabbitMQ.Client.PublicationAddress
 RabbitMQ.Client.PublicationAddress.PublicationAddress(string exchangeType, string exchangeName, string routingKey) -> void
 RabbitMQ.Client.QueueDeclareOk
 RabbitMQ.Client.QueueDeclareOk.QueueDeclareOk(string queueName, uint messageCount, uint consumerCount) -> void
+RabbitMQ.Client.RabbitMQActivitySource
 RabbitMQ.Client.ReadOnlyBasicProperties
 RabbitMQ.Client.ReadOnlyBasicProperties.AppId.get -> string
 RabbitMQ.Client.ReadOnlyBasicProperties.ClusterId.get -> string
@@ -851,6 +852,8 @@ static RabbitMQ.Client.IChannelExtensions.BasicPublishAsync<T>(this RabbitMQ.Cli
 static RabbitMQ.Client.PublicationAddress.Parse(string uriLikeString) -> RabbitMQ.Client.PublicationAddress
 static RabbitMQ.Client.PublicationAddress.TryParse(string uriLikeString, out RabbitMQ.Client.PublicationAddress result) -> bool
 static RabbitMQ.Client.QueueDeclareOk.implicit operator string(RabbitMQ.Client.QueueDeclareOk declareOk) -> string
+static RabbitMQ.Client.RabbitMQActivitySource.UseRoutingKeyAsOperationName.get -> bool
+static RabbitMQ.Client.RabbitMQActivitySource.UseRoutingKeyAsOperationName.set -> void
 static RabbitMQ.Client.TcpClientAdapter.GetMatchingHost(System.Collections.Generic.IReadOnlyCollection<System.Net.IPAddress> addresses, System.Net.Sockets.AddressFamily addressFamily) -> System.Net.IPAddress
 static RabbitMQ.Client.TimerBasedCredentialRefresherEventSource.Log.get -> RabbitMQ.Client.TimerBasedCredentialRefresherEventSource
 static readonly RabbitMQ.Client.CachedString.Empty -> RabbitMQ.Client.CachedString
@@ -881,6 +884,8 @@ virtual RabbitMQ.Client.TcpClientAdapter.Dispose(bool disposing) -> void
 virtual RabbitMQ.Client.TcpClientAdapter.GetStream() -> System.Net.Sockets.NetworkStream
 virtual RabbitMQ.Client.TcpClientAdapter.ReceiveTimeout.get -> System.TimeSpan
 virtual RabbitMQ.Client.TcpClientAdapter.ReceiveTimeout.set -> void
+~const RabbitMQ.Client.RabbitMQActivitySource.PublisherSourceName = "RabbitMQ.Client.Publisher" -> string
+~const RabbitMQ.Client.RabbitMQActivitySource.SubscriberSourceName = "RabbitMQ.Client.Subscriber" -> string
 ~override RabbitMQ.Client.Events.EventingBasicConsumer.HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, RabbitMQ.Client.ReadOnlyBasicProperties properties, System.ReadOnlyMemory<byte> body) -> System.Threading.Tasks.Task
 ~RabbitMQ.Client.ConnectionFactory.CreateConnectionAsync(RabbitMQ.Client.IEndpointResolver endpointResolver, string clientProvidedName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<RabbitMQ.Client.IConnection>
 ~RabbitMQ.Client.ConnectionFactory.CreateConnectionAsync(string clientProvidedName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<RabbitMQ.Client.IConnection>

--- a/projects/RabbitMQ.Client/RabbitMQ.Client.csproj
+++ b/projects/RabbitMQ.Client/RabbitMQ.Client.csproj
@@ -80,4 +80,7 @@
     <PackageReference Include="System.IO.Pipelines" Version="8.0.0" />
   </ItemGroup>
 
+  <ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
+  </ItemGroup>
 </Project>

--- a/projects/RabbitMQ.Client/client/api/IChannel.cs
+++ b/projects/RabbitMQ.Client/client/api/IChannel.cs
@@ -192,7 +192,7 @@ namespace RabbitMQ.Client
         ///     Routing key must be shorter than 255 bytes.
         ///   </para>
         /// </remarks>
-        ValueTask BasicPublishAsync<TProperties>(string exchange, string routingKey, in TProperties basicProperties, ReadOnlyMemory<byte> body = default, bool mandatory = false)
+        ValueTask BasicPublishAsync<TProperties>(string exchange, string routingKey, TProperties basicProperties, ReadOnlyMemory<byte> body = default, bool mandatory = false)
             where TProperties : IReadOnlyBasicProperties, IAmqpHeader;
 
         /// <summary>
@@ -203,7 +203,7 @@ namespace RabbitMQ.Client
         ///     Routing key must be shorter than 255 bytes.
         ///   </para>
         /// </remarks>
-        ValueTask BasicPublishAsync<TProperties>(CachedString exchange, CachedString routingKey, in TProperties basicProperties, ReadOnlyMemory<byte> body = default, bool mandatory = false)
+        ValueTask BasicPublishAsync<TProperties>(CachedString exchange, CachedString routingKey, TProperties basicProperties, ReadOnlyMemory<byte> body = default, bool mandatory = false)
             where TProperties : IReadOnlyBasicProperties, IAmqpHeader;
 
 #nullable disable

--- a/projects/RabbitMQ.Client/client/api/IChannelExtensions.cs
+++ b/projects/RabbitMQ.Client/client/api/IChannelExtensions.cs
@@ -89,14 +89,14 @@ namespace RabbitMQ.Client
         public static ValueTask BasicPublishAsync<T>(this IChannel channel, PublicationAddress addr, in T basicProperties, ReadOnlyMemory<byte> body)
             where T : IReadOnlyBasicProperties, IAmqpHeader
         {
-            return channel.BasicPublishAsync(addr.ExchangeName, addr.RoutingKey, in basicProperties, body);
+            return channel.BasicPublishAsync(addr.ExchangeName, addr.RoutingKey, basicProperties, body);
         }
 
         public static ValueTask BasicPublishAsync(this IChannel channel, string exchange, string routingKey, ReadOnlyMemory<byte> body = default, bool mandatory = false)
-            => channel.BasicPublishAsync(exchange, routingKey, in EmptyBasicProperty.Empty, body, mandatory);
+            => channel.BasicPublishAsync(exchange, routingKey, EmptyBasicProperty.Empty, body, mandatory);
 
         public static ValueTask BasicPublishAsync(this IChannel channel, CachedString exchange, CachedString routingKey, ReadOnlyMemory<byte> body = default, bool mandatory = false)
-            => channel.BasicPublishAsync(exchange, routingKey, in EmptyBasicProperty.Empty, body, mandatory);
+            => channel.BasicPublishAsync(exchange, routingKey, EmptyBasicProperty.Empty, body, mandatory);
 
 #nullable disable
 

--- a/projects/RabbitMQ.Client/client/impl/AsyncRpcContinuations.cs
+++ b/projects/RabbitMQ.Client/client/impl/AsyncRpcContinuations.cs
@@ -72,6 +72,8 @@ namespace RabbitMQ.Client.Impl
             _tcsConfiguredTaskAwaitable = _tcs.Task.ConfigureAwait(false);
         }
 
+        internal DateTime StartTime { get; } = DateTime.UtcNow;
+
         public ConfiguredTaskAwaitable<T>.ConfiguredTaskAwaiter GetAwaiter()
         {
             return _tcsConfiguredTaskAwaitable.GetAwaiter();

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringChannel.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringChannel.cs
@@ -290,13 +290,13 @@ namespace RabbitMQ.Client.Impl
         public ValueTask BasicNackAsync(ulong deliveryTag, bool multiple, bool requeue)
             => InnerChannel.BasicNackAsync(deliveryTag, multiple, requeue);
 
-        public ValueTask BasicPublishAsync<TProperties>(string exchange, string routingKey, in TProperties basicProperties, ReadOnlyMemory<byte> body, bool mandatory)
+        public ValueTask BasicPublishAsync<TProperties>(string exchange, string routingKey, TProperties basicProperties, ReadOnlyMemory<byte> body, bool mandatory)
             where TProperties : IReadOnlyBasicProperties, IAmqpHeader
-            => InnerChannel.BasicPublishAsync(exchange, routingKey, in basicProperties, body, mandatory);
+            => InnerChannel.BasicPublishAsync(exchange, routingKey, basicProperties, body, mandatory);
 
-        public ValueTask BasicPublishAsync<TProperties>(CachedString exchange, CachedString routingKey, in TProperties basicProperties, ReadOnlyMemory<byte> body, bool mandatory)
+        public ValueTask BasicPublishAsync<TProperties>(CachedString exchange, CachedString routingKey, TProperties basicProperties, ReadOnlyMemory<byte> body, bool mandatory)
             where TProperties : IReadOnlyBasicProperties, IAmqpHeader
-            => InnerChannel.BasicPublishAsync(exchange, routingKey, in basicProperties, body, mandatory);
+            => InnerChannel.BasicPublishAsync(exchange, routingKey, basicProperties, body, mandatory);
 
         public Task BasicQosAsync(uint prefetchSize, ushort prefetchCount, bool global)
         {

--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -31,7 +31,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using System.Net;
+using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -445,6 +448,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         internal void Write(RentedMemory frames)
         {
+            Activity.Current.SetNetworkTags(_frameHandler);
             ValueTask task = _frameHandler.WriteAsync(frames);
             if (!task.IsCompletedSuccessfully)
             {
@@ -454,6 +458,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         internal ValueTask WriteAsync(RentedMemory frames)
         {
+            Activity.Current.SetNetworkTags(_frameHandler);
             return _frameHandler.WriteAsync(frames);
         }
 

--- a/projects/RabbitMQ.Client/client/impl/RabbitMQActivitySource.cs
+++ b/projects/RabbitMQ.Client/client/impl/RabbitMQActivitySource.cs
@@ -1,0 +1,290 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Text;
+using RabbitMQ.Client.Events;
+using RabbitMQ.Client.Impl;
+
+namespace RabbitMQ.Client
+{
+    public static class RabbitMQActivitySource
+    {
+        // These constants are defined in the OpenTelemetry specification:
+        // https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/#messaging-attributes
+        internal const string MessageId = "messaging.message.id";
+        internal const string MessageConversationId = "messaging.message.conversation_id";
+        internal const string MessagingOperation = "messaging.operation";
+        internal const string MessagingSystem = "messaging.system";
+        internal const string MessagingDestination = "messaging.destination.name";
+        internal const string MessagingDestinationRoutingKey = "messaging.rabbitmq.destination.routing_key";
+        internal const string MessagingBodySize = "messaging.message.body.size";
+        internal const string MessagingEnvelopeSize = "messaging.message.envelope.size";
+        internal const string ProtocolName = "network.protocol.name";
+        internal const string ProtocolVersion = "network.protocol.version";
+        internal const string RabbitMQDeliveryTag = "messaging.rabbitmq.delivery_tag";
+
+        private static readonly string AssemblyVersion = typeof(RabbitMQActivitySource).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion ?? "";
+
+        private static readonly ActivitySource s_publisherSource = new ActivitySource(PublisherSourceName, AssemblyVersion);
+        private static readonly ActivitySource s_subscriberSource = new ActivitySource(SubscriberSourceName, AssemblyVersion);
+
+        public const string PublisherSourceName = "RabbitMQ.Client.Publisher";
+        public const string SubscriberSourceName = "RabbitMQ.Client.Subscriber";
+
+        public static bool UseRoutingKeyAsOperationName { get; set; } = true;
+        internal static bool PublisherHasListeners => s_publisherSource.HasListeners();
+        internal static bool SubscriberHasListeners => s_subscriberSource.HasListeners();
+
+        internal static readonly IEnumerable<KeyValuePair<string, object>> CreationTags = new[]
+        {
+            new KeyValuePair<string, object>(MessagingSystem, "rabbitmq"),
+            new KeyValuePair<string, object>(ProtocolName, "amqp"),
+            new KeyValuePair<string, object>(ProtocolVersion, "0.9.1")
+        };
+
+        internal static Activity Send(string routingKey, string exchange, int bodySize,
+            ActivityContext linkedContext = default)
+        {
+            if (s_publisherSource.HasListeners())
+            {
+                Activity activity = linkedContext == default
+                    ? s_publisherSource.StartRabbitMQActivity(UseRoutingKeyAsOperationName ? $"{routingKey} publish" : "publish",
+                        ActivityKind.Producer)
+                    : s_publisherSource.StartLinkedRabbitMQActivity(UseRoutingKeyAsOperationName ? $"{routingKey} publish" : "publish",
+                        ActivityKind.Producer, linkedContext);
+                if (activity?.IsAllDataRequested == true)
+                {
+                    PopulateMessagingTags("publish", routingKey, exchange, 0, bodySize, activity);
+                }
+
+                return activity;
+            }
+
+            return null;
+        }
+
+        internal static Activity ReceiveEmpty(string queue)
+        {
+            if (!s_subscriberSource.HasListeners())
+            {
+                return null;
+            }
+
+            Activity activity = s_subscriberSource.StartRabbitMQActivity(UseRoutingKeyAsOperationName ? $"{queue} receive" : "receive",
+                ActivityKind.Consumer);
+            if (activity.IsAllDataRequested)
+            {
+                activity
+                    .SetTag(MessagingOperation, "receive")
+                    .SetTag(MessagingDestination, "amq.default");
+            }
+
+            return activity;
+        }
+
+        internal static Activity Receive(string routingKey, string exchange, ulong deliveryTag,
+            in ReadOnlyBasicProperties readOnlyBasicProperties, int bodySize)
+        {
+            if (!s_subscriberSource.HasListeners())
+            {
+                return null;
+            }
+
+            // Extract the PropagationContext of the upstream parent from the message headers.
+            DistributedContextPropagator.Current.ExtractTraceIdAndState(readOnlyBasicProperties.Headers,
+                ExtractTraceIdAndState, out string traceParent, out string traceState);
+            ActivityContext.TryParse(traceParent, traceState, out ActivityContext linkedContext);
+            Activity activity = s_subscriberSource.StartLinkedRabbitMQActivity(
+                UseRoutingKeyAsOperationName ? $"{routingKey} receive" : "receive", ActivityKind.Consumer,
+                linkedContext);
+            if (activity.IsAllDataRequested)
+            {
+                PopulateMessagingTags("receive", routingKey, exchange, deliveryTag, readOnlyBasicProperties,
+                    bodySize, activity);
+            }
+
+            return activity;
+        }
+
+        internal static Activity Deliver(BasicDeliverEventArgs deliverEventArgs)
+        {
+            if (!s_subscriberSource.HasListeners())
+            {
+                return null;
+            }
+
+            // Extract the PropagationContext of the upstream parent from the message headers.
+            DistributedContextPropagator.Current.ExtractTraceIdAndState(deliverEventArgs.BasicProperties.Headers,
+                ExtractTraceIdAndState, out string traceparent, out string traceState);
+            ActivityContext.TryParse(traceparent, traceState, out ActivityContext parentContext);
+            Activity activity = s_subscriberSource.StartLinkedRabbitMQActivity(
+                UseRoutingKeyAsOperationName ? $"{deliverEventArgs.RoutingKey} deliver" : "deliver",
+                ActivityKind.Consumer, parentContext);
+            if (activity != null && activity.IsAllDataRequested)
+            {
+                PopulateMessagingTags("deliver", deliverEventArgs.RoutingKey, deliverEventArgs.Exchange,
+                    deliverEventArgs.DeliveryTag, deliverEventArgs.BasicProperties, deliverEventArgs.Body.Length,
+                    activity);
+            }
+
+            return activity;
+
+        }
+
+        private static Activity StartRabbitMQActivity(this ActivitySource source, string name, ActivityKind kind,
+            ActivityContext parentContext = default)
+        {
+            Activity activity = source
+                .CreateActivity(name, kind, parentContext, idFormat: ActivityIdFormat.W3C, tags: CreationTags)?.Start();
+            return activity;
+        }
+
+        private static Activity StartLinkedRabbitMQActivity(this ActivitySource source, string name, ActivityKind kind,
+            ActivityContext linkedContext = default, ActivityContext parentContext = default)
+        {
+            Activity activity = source.CreateActivity(name, kind, parentContext: parentContext,
+                    links: new[] { new ActivityLink(linkedContext) }, idFormat: ActivityIdFormat.W3C,
+                    tags: CreationTags)
+                ?.Start();
+            return activity;
+        }
+
+        private static void PopulateMessagingTags(string operation, string routingKey, string exchange,
+            ulong deliveryTag, in ReadOnlyBasicProperties readOnlyBasicProperties, int bodySize, Activity activity)
+        {
+            PopulateMessagingTags(operation, routingKey, exchange, deliveryTag, bodySize, activity);
+
+            if (!string.IsNullOrEmpty(readOnlyBasicProperties.CorrelationId))
+            {
+                activity.SetTag(MessageConversationId, readOnlyBasicProperties.CorrelationId);
+            }
+
+            if (!string.IsNullOrEmpty(readOnlyBasicProperties.MessageId))
+            {
+                activity.SetTag(MessageId, readOnlyBasicProperties.MessageId);
+            }
+        }
+
+        private static void PopulateMessagingTags(string operation, string routingKey, string exchange,
+            ulong deliveryTag, int bodySize, Activity activity)
+        {
+            activity
+                .SetTag(MessagingOperation, operation)
+                .SetTag(MessagingDestination, string.IsNullOrEmpty(exchange) ? "amq.default" : exchange)
+                .SetTag(MessagingDestinationRoutingKey, routingKey)
+                .SetTag(MessagingBodySize, bodySize);
+
+            if (deliveryTag > 0)
+            {
+                activity.SetTag(RabbitMQDeliveryTag, deliveryTag);
+            }
+        }
+
+        internal static void PopulateMessageEnvelopeSize(Activity activity, int size)
+        {
+            if (activity != null && activity.IsAllDataRequested && PublisherHasListeners)
+            {
+                activity.SetTag(MessagingEnvelopeSize, size);
+            }
+        }
+
+        internal static bool TryGetExistingContext<T>(T props, out ActivityContext context)
+            where T : IReadOnlyBasicProperties
+        {
+            if (props.Headers == null)
+            {
+                context = default;
+                return false;
+            }
+
+            bool hasHeaders = false;
+            foreach (string header in DistributedContextPropagator.Current.Fields)
+            {
+                if (props.Headers.ContainsKey(header))
+                {
+                    hasHeaders = true;
+                    break;
+                }
+            }
+
+            if (hasHeaders)
+            {
+                DistributedContextPropagator.Current.ExtractTraceIdAndState(props.Headers, ExtractTraceIdAndState,
+                    out string traceParent, out string traceState);
+                return ActivityContext.TryParse(traceParent, traceState, out context);
+            }
+
+            context = default;
+            return false;
+        }
+
+        private static void ExtractTraceIdAndState(object props, string name, out string value,
+            out IEnumerable<string> values)
+        {
+            if (props is Dictionary<string, object> headers && headers.TryGetValue(name, out object propsVal) &&
+                propsVal is byte[] bytes)
+            {
+                value = Encoding.UTF8.GetString(bytes);
+                values = default;
+            }
+            else
+            {
+                value = default;
+                values = default;
+            }
+        }
+
+        internal static void SetNetworkTags(this Activity activity, IFrameHandler frameHandler)
+        {
+            if (PublisherHasListeners && activity != null && activity.IsAllDataRequested)
+            {
+                switch (frameHandler.RemoteEndPoint.AddressFamily)
+                {
+                    case AddressFamily.InterNetworkV6:
+                        activity.SetTag("network.type", "ipv6");
+                        break;
+                    case AddressFamily.InterNetwork:
+                        activity.SetTag("network.type", "ipv4");
+                        break;
+                }
+
+                if (!string.IsNullOrEmpty(frameHandler.Endpoint.HostName))
+                {
+                    activity
+                        .SetTag("server.address", frameHandler.Endpoint.HostName);
+                }
+
+                activity
+                    .SetTag("server.port", frameHandler.Endpoint.Port);
+
+                if (frameHandler.RemoteEndPoint is IPEndPoint ipEndpoint)
+                {
+                    string remoteAddress = ipEndpoint.Address.ToString();
+                    if (activity.GetTagItem("server.address") == null)
+                    {
+                        activity
+                            .SetTag("server.address", remoteAddress);
+                    }
+
+                    activity
+                        .SetTag("network.peer.address", remoteAddress)
+                        .SetTag("network.peer.port", ipEndpoint.Port);
+                }
+
+                if (frameHandler.LocalEndPoint is IPEndPoint localEndpoint)
+                {
+                    string localAddress = localEndpoint.Address.ToString();
+                    activity
+                        .SetTag("client.address", localAddress)
+                        .SetTag("client.port", localEndpoint.Port)
+                        .SetTag("network.local.address", localAddress)
+                        .SetTag("network.local.port", localEndpoint.Port);
+                }
+            }
+        }
+    }
+}

--- a/projects/RabbitMQ.Client/client/impl/RpcContinuations.cs
+++ b/projects/RabbitMQ.Client/client/impl/RpcContinuations.cs
@@ -38,6 +38,7 @@ namespace RabbitMQ.Client.Impl
     internal class SimpleBlockingRpcContinuation : IRpcContinuation
     {
         private readonly BlockingCell<Either<IncomingCommand, ShutdownEventArgs>> m_cell = new BlockingCell<Either<IncomingCommand, ShutdownEventArgs>>();
+        internal DateTime StartTime { get; } = DateTime.UtcNow;
 
         public void GetReply(TimeSpan timeout)
         {

--- a/projects/Test/Common/ProcessUtil.cs
+++ b/projects/Test/Common/ProcessUtil.cs
@@ -32,7 +32,7 @@ namespace Test
                 var processTasks = new List<Task>();
 
                 // === EXITED Event handling ===
-                var processExitEvent = new TaskCompletionSource<bool>();
+                var processExitEvent = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 process.Exited += (sender, args) =>
                 {
@@ -46,7 +46,7 @@ namespace Test
 
                 if (process.StartInfo.RedirectStandardOutput)
                 {
-                    var stdOutCloseEvent = new TaskCompletionSource<bool>();
+                    var stdOutCloseEvent = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                     process.OutputDataReceived += (s, e) =>
                     {
@@ -72,7 +72,7 @@ namespace Test
 
                 if (process.StartInfo.RedirectStandardError)
                 {
-                    var stdErrCloseEvent = new TaskCompletionSource<bool>();
+                    var stdErrCloseEvent = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                     process.ErrorDataReceived += (s, e) =>
                     {

--- a/projects/Test/Integration/TestChannelShutdown.cs
+++ b/projects/Test/Integration/TestChannelShutdown.cs
@@ -48,7 +48,7 @@ namespace Test.Integration
         public async Task TestConsumerDispatcherShutdown()
         {
             var autorecoveringChannel = (AutorecoveringChannel)_channel;
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             _channel.ChannelShutdown += (channel, args) =>
             {

--- a/projects/Test/Integration/TestConcurrentAccessWithSharedConnection.cs
+++ b/projects/Test/Integration/TestConcurrentAccessWithSharedConnection.cs
@@ -102,7 +102,7 @@ namespace Test.Integration
         {
             return TestConcurrentChannelOperationsAsync(async (conn) =>
             {
-                var tcs = new TaskCompletionSource<bool>();
+                var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 // publishing on a shared channel is not supported
                 // and would missing the point of this test anyway

--- a/projects/Test/Integration/TestConfirmSelect.cs
+++ b/projects/Test/Integration/TestConfirmSelect.cs
@@ -79,7 +79,7 @@ namespace Test.Integration
 
             var properties = new BasicProperties();
             // _output.WriteLine("Client delivery tag {0}", _channel.NextPublishSeqNo);
-            await _channel.BasicPublishAsync(exchange: "sample", routingKey: string.Empty, in properties, body);
+            await _channel.BasicPublishAsync(exchange: "sample", routingKey: string.Empty, properties, body);
             await _channel.WaitForConfirmsOrDieAsync();
 
             try
@@ -89,7 +89,7 @@ namespace Test.Integration
                     CorrelationId = new string('o', correlationIdLength)
                 };
                 // _output.WriteLine("Client delivery tag {0}", _channel.NextPublishSeqNo);
-                await _channel.BasicPublishAsync("sample", string.Empty, in properties, body);
+                await _channel.BasicPublishAsync("sample", string.Empty, properties, body);
                 await _channel.WaitForConfirmsOrDieAsync();
             }
             catch
@@ -99,7 +99,7 @@ namespace Test.Integration
 
             properties = new BasicProperties();
             // _output.WriteLine("Client delivery tag {0}", _channel.NextPublishSeqNo);
-            await _channel.BasicPublishAsync("sample", string.Empty, in properties, body);
+            await _channel.BasicPublishAsync("sample", string.Empty, properties, body);
             await _channel.WaitForConfirmsOrDieAsync();
             // _output.WriteLine("I'm done...");
         }

--- a/projects/Test/Integration/TestConnectionShutdown.cs
+++ b/projects/Test/Integration/TestConnectionShutdown.cs
@@ -48,7 +48,7 @@ namespace Test.Integration
         [Fact]
         public async Task TestCleanClosureWithSocketClosedOutOfBand()
         {
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             _channel.ChannelShutdown += (channel, args) =>
             {
                 tcs.SetResult(true);
@@ -64,7 +64,7 @@ namespace Test.Integration
         [Fact]
         public async Task TestAbortWithSocketClosedOutOfBand()
         {
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             _channel.ChannelShutdown += (channel, args) =>
             {
                 tcs.SetResult(true);
@@ -82,7 +82,7 @@ namespace Test.Integration
         [Fact]
         public async Task TestDisposedWithSocketClosedOutOfBand()
         {
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             _channel.ChannelShutdown += (channel, args) =>
             {
@@ -103,7 +103,7 @@ namespace Test.Integration
         [Fact]
         public async Task TestShutdownSignalPropagationToChannels()
         {
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             _channel.ChannelShutdown += (channel, args) =>
             {
@@ -119,7 +119,7 @@ namespace Test.Integration
         public async Task TestConsumerDispatcherShutdown()
         {
             var m = (AutorecoveringChannel)_channel;
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             _channel.ChannelShutdown += (channel, args) =>
             {

--- a/projects/Test/Integration/TestConsumer.cs
+++ b/projects/Test/Integration/TestConsumer.cs
@@ -133,7 +133,7 @@ namespace Test.Integration
             countdownEvent.Wait();
 
             // Add last receiver
-            var lastConsumerReceivedTcs = new TaskCompletionSource<bool>();
+            var lastConsumerReceivedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             consumer.Received += (o, a) =>
             {
                 lastConsumerReceivedTcs.SetResult(true);

--- a/projects/Test/Integration/TestConsumerCancelNotify.cs
+++ b/projects/Test/Integration/TestConsumerCancelNotify.cs
@@ -40,7 +40,7 @@ namespace Test.Integration
 {
     public class TestConsumerCancelNotify : IntegrationFixture
     {
-        private readonly TaskCompletionSource<bool> _tcs = new TaskCompletionSource<bool>();
+        private readonly TaskCompletionSource<bool> _tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         private string _consumerTag;
 
         public TestConsumerCancelNotify(ITestOutputHelper output) : base(output)

--- a/projects/Test/Integration/TestConsumerExceptions.cs
+++ b/projects/Test/Integration/TestConsumerExceptions.cs
@@ -108,7 +108,7 @@ namespace Test.Integration
         protected async Task TestExceptionHandlingWithAsync(IBasicConsumer consumer,
             Func<IChannel, string, IBasicConsumer, string, Task> action)
         {
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             bool notified = false;
             string q = await _channel.QueueDeclareAsync();
 

--- a/projects/Test/Integration/TestConsumerOperationDispatch.cs
+++ b/projects/Test/Integration/TestConsumerOperationDispatch.cs
@@ -164,7 +164,7 @@ namespace Test.Integration
             string q2 = (await ch2.QueueDeclareAsync()).QueueName;
             await ch2.QueueBindAsync(queue: q2, exchange: _x, routingKey: "");
 
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             await ch1.BasicConsumeAsync(q1, true, new EventingBasicConsumer(ch1));
             var c2 = new EventingBasicConsumer(ch2);
             c2.Received += (object sender, BasicDeliverEventArgs e) =>
@@ -183,8 +183,8 @@ namespace Test.Integration
         {
             public ShutdownLatchConsumer()
             {
-                Latch = new TaskCompletionSource<bool>();
-                DuplicateLatch = new TaskCompletionSource<bool>();
+                Latch = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                DuplicateLatch = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             }
 
             public readonly TaskCompletionSource<bool> Latch;

--- a/projects/Test/Integration/TestEventingConsumer.cs
+++ b/projects/Test/Integration/TestEventingConsumer.cs
@@ -48,10 +48,10 @@ namespace Test.Integration
         {
             string q = await _channel.QueueDeclareAsync();
 
-            var registeredTcs = new TaskCompletionSource<bool>();
+            var registeredTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             object registeredSender = null;
 
-            var unregisteredTcs = new TaskCompletionSource<bool>();
+            var unregisteredTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             object unregisteredSender = null;
 
             EventingBasicConsumer ec = new EventingBasicConsumer(_channel);
@@ -85,7 +85,7 @@ namespace Test.Integration
         [Fact]
         public async Task TestEventingConsumerDeliveryEvents()
         {
-            var tcs0 = new TaskCompletionSource<bool>();
+            var tcs0 = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             string q = await _channel.QueueDeclareAsync();
 
             bool receivedInvoked = false;
@@ -103,7 +103,7 @@ namespace Test.Integration
             await _channel.BasicPublishAsync("", q, _encoding.GetBytes("msg"));
 
             await WaitAsync(tcs0, "received event");
-            var tcs1 = new TaskCompletionSource<bool>();
+            var tcs1 = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             Assert.True(receivedInvoked);
             Assert.NotNull(receivedSender);

--- a/projects/Test/Integration/TestInvalidAck.cs
+++ b/projects/Test/Integration/TestInvalidAck.cs
@@ -45,7 +45,7 @@ namespace Test.Integration
         [Fact]
         public async Task TestAckWithUnknownConsumerTagAndMultipleFalse()
         {
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             bool shutdownFired = false;
             ShutdownEventArgs shutdownArgs = null;
             _channel.ChannelShutdown += (s, args) =>

--- a/projects/Test/Integration/TestMainLoop.cs
+++ b/projects/Test/Integration/TestMainLoop.cs
@@ -63,7 +63,7 @@ namespace Test.Integration
         [Fact]
         public async Task TestCloseWithFaultyConsumer()
         {
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             QueueDeclareOk q = await _channel.QueueDeclareAsync(string.Empty, false, false, false);
 
             CallbackExceptionEventArgs ea = null;

--- a/projects/Test/SequentialIntegration/TestActivitySource.cs
+++ b/projects/Test/SequentialIntegration/TestActivitySource.cs
@@ -1,0 +1,247 @@
+﻿// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2020 VMware, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       https://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v2.0:
+//
+//---------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
+//---------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Test.SequentialIntegration
+{
+    public class TestActivitySource : SequentialIntegrationFixture
+    {
+        public TestActivitySource(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        void AssertStringTagEquals(Activity activity, string name, string expected)
+        {
+            string tag = activity.GetTagItem(name) as string;
+            Assert.NotNull(tag);
+            Assert.Equal(expected, tag);
+        }
+
+        void AssertStringTagStartsWith(Activity activity, string name, string expected)
+        {
+            string tag = activity.GetTagItem(name) as string;
+            Assert.NotNull(tag);
+            Assert.StartsWith(expected, tag);
+        }
+
+        void AssertStringTagNotNullOrEmpty(Activity activity, string name)
+        {
+            string tag = activity.GetTagItem(name) as string;
+            Assert.NotNull(tag);
+            Assert.False(string.IsNullOrEmpty(tag));
+        }
+
+        void AssertIntTagGreaterThanZero(Activity activity, string name)
+        {
+            Assert.True(activity.GetTagItem(name) is int result && result > 0);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task TestPublisherAndConsumerActivityTags(bool useRoutingKeyAsOperationName)
+        {
+            await _channel.ConfirmSelectAsync();
+
+            RabbitMQActivitySource.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
+            var _activities = new List<Activity>();
+            using (ActivityListener activityListener = StartActivityListener(_activities))
+            {
+                await Task.Delay(500);
+                string queueName = $"{Guid.NewGuid()}";
+                QueueDeclareOk q = await _channel.QueueDeclareAsync(queueName);
+                byte[] sendBody = Encoding.UTF8.GetBytes("hi");
+                byte[] consumeBody = null;
+                var consumer = new EventingBasicConsumer(_channel);
+                var consumerReceivedTcs =
+                    new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                consumer.Received += (o, a) =>
+                {
+                    consumeBody = a.Body.ToArray();
+                    consumerReceivedTcs.SetResult(true);
+                };
+
+                string consumerTag = await _channel.BasicConsumeAsync(queueName, autoAck: true, consumer: consumer);
+                await _channel.BasicPublishAsync("", q.QueueName, sendBody, mandatory: true);
+                await _channel.WaitForConfirmsOrDieAsync();
+
+                await consumerReceivedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+                Assert.True(await consumerReceivedTcs.Task);
+
+                await _channel.BasicCancelAsync(consumerTag);
+                await Task.Delay(500);
+                AssertActivityData(useRoutingKeyAsOperationName, queueName, _activities, true);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task TestPublisherAndConsumerActivityTagsAsync(bool useRoutingKeyAsOperationName)
+        {
+            await _channel.ConfirmSelectAsync();
+
+            RabbitMQActivitySource.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
+            var activities = new List<Activity>();
+            using (ActivityListener activityListener = StartActivityListener(activities))
+            {
+                await Task.Delay(500);
+
+                string queueName = $"{Guid.NewGuid()}";
+                QueueDeclareOk q = await _channel.QueueDeclareAsync(queueName);
+                byte[] sendBody = Encoding.UTF8.GetBytes("hi");
+                byte[] consumeBody = null;
+                var consumer = new EventingBasicConsumer(_channel);
+                var consumerReceivedTcs =
+                    new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                consumer.Received += (o, a) =>
+                {
+                    consumeBody = a.Body.ToArray();
+                    consumerReceivedTcs.SetResult(true);
+                };
+
+                string consumerTag = await _channel.BasicConsumeAsync(queueName, autoAck: true, consumer: consumer);
+                await _channel.BasicPublishAsync("", q.QueueName, sendBody, mandatory: true);
+                await _channel.WaitForConfirmsOrDieAsync();
+
+                await consumerReceivedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+                Assert.True(await consumerReceivedTcs.Task);
+
+                await _channel.BasicCancelAsync(consumerTag);
+                await Task.Delay(500);
+                AssertActivityData(useRoutingKeyAsOperationName, queueName, activities, true);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task TestPublisherAndBasicGetActivityTags(bool useRoutingKeyAsOperationName)
+        {
+            await _channel.ConfirmSelectAsync();
+            RabbitMQActivitySource.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
+            var activities = new List<Activity>();
+            using (ActivityListener activityListener = StartActivityListener(activities))
+            {
+                await Task.Delay(500);
+                string queue = $"queue-{Guid.NewGuid()}";
+                const string msg = "for basic.get";
+
+                try
+                {
+                    await _channel.QueueDeclareAsync(queue, false, false, false, null);
+                    await _channel.BasicPublishAsync("", queue, Encoding.UTF8.GetBytes(msg), mandatory: true);
+                    await _channel.WaitForConfirmsOrDieAsync();
+                    QueueDeclareOk ok = await _channel.QueueDeclarePassiveAsync(queue);
+                    Assert.Equal(1u, ok.MessageCount);
+                    BasicGetResult res = await _channel.BasicGetAsync(queue, true);
+                    Assert.Equal(msg, Encoding.UTF8.GetString(res.Body.ToArray()));
+                    ok = await _channel.QueueDeclarePassiveAsync(queue);
+                    Assert.Equal(0u, ok.MessageCount);
+                    await Task.Delay(500);
+                    AssertActivityData(useRoutingKeyAsOperationName, queue, activities, false);
+                }
+                finally
+                {
+                    await _channel.QueueDeleteAsync(queue);
+                }
+            }
+        }
+
+        private static ActivityListener StartActivityListener(List<Activity> activities)
+        {
+            ActivityListener activityListener = new ActivityListener();
+            activityListener.Sample = (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded;
+            activityListener.SampleUsingParentId = (ref ActivityCreationOptions<string> _) =>
+                ActivitySamplingResult.AllDataAndRecorded;
+            activityListener.ShouldListenTo =
+                activitySource => activitySource.Name.StartsWith("RabbitMQ.Client.");
+            activityListener.ActivityStarted = activities.Add;
+            ActivitySource.AddActivityListener(activityListener);
+            return activityListener;
+        }
+
+        private void AssertActivityData(bool useRoutingKeyAsOperationName, string queueName,
+            List<Activity> activityList, bool isDeliver = false)
+        {
+            string childName = isDeliver ? "deliver" : "receive";
+            Activity[] activities = activityList.ToArray();
+            Assert.NotEmpty(activities);
+            foreach (var item in activities)
+            {
+                _output.WriteLine(
+                    $"{item.Context.TraceId}: {item.OperationName}");
+                _output.WriteLine($"  Tags: {string.Join(", ", item.Tags.Select(x => $"{x.Key}: {x.Value}"))}");
+                _output.WriteLine($"  Links: {string.Join(", ", item.Links.Select(x => $"{x.Context.TraceId}"))}");
+            }
+
+            Activity sendActivity = activities.First(x =>
+                x.OperationName == (useRoutingKeyAsOperationName ? $"{queueName} publish" : "publish") &&
+                x.GetTagItem(RabbitMQActivitySource.MessagingDestinationRoutingKey) is string routingKeyTag &&
+                routingKeyTag == $"{queueName}");
+            Activity receiveActivity = activities.Single(x =>
+                x.OperationName == (useRoutingKeyAsOperationName ? $"{queueName} {childName}" : $"{childName}") &&
+                x.Links.First().Context.TraceId == sendActivity.TraceId);
+            Assert.Equal(ActivityKind.Producer, sendActivity.Kind);
+            Assert.Equal(ActivityKind.Consumer, receiveActivity.Kind);
+            Assert.Null(receiveActivity.ParentId);
+            AssertStringTagNotNullOrEmpty(sendActivity, "network.peer.address");
+            AssertStringTagNotNullOrEmpty(sendActivity, "network.local.address");
+            AssertStringTagNotNullOrEmpty(sendActivity, "server.address");
+            AssertStringTagNotNullOrEmpty(sendActivity, "client.address");
+            AssertIntTagGreaterThanZero(sendActivity, "network.peer.port");
+            AssertIntTagGreaterThanZero(sendActivity, "network.local.port");
+            AssertIntTagGreaterThanZero(sendActivity, "server.port");
+            AssertIntTagGreaterThanZero(sendActivity, "client.port");
+            AssertStringTagStartsWith(sendActivity, "network.type", "ipv");
+            AssertStringTagEquals(sendActivity, RabbitMQActivitySource.MessagingSystem, "rabbitmq");
+            AssertStringTagEquals(sendActivity, RabbitMQActivitySource.ProtocolName, "amqp");
+            AssertStringTagEquals(sendActivity, RabbitMQActivitySource.ProtocolVersion, "0.9.1");
+            AssertStringTagEquals(sendActivity, RabbitMQActivitySource.MessagingDestination, "amq.default");
+            AssertStringTagEquals(sendActivity, RabbitMQActivitySource.MessagingDestinationRoutingKey, queueName);
+            AssertIntTagGreaterThanZero(sendActivity, RabbitMQActivitySource.MessagingEnvelopeSize);
+            AssertIntTagGreaterThanZero(sendActivity, RabbitMQActivitySource.MessagingBodySize);
+            AssertIntTagGreaterThanZero(receiveActivity, RabbitMQActivitySource.MessagingBodySize);
+        }
+    }
+}

--- a/projects/Test/SequentialIntegration/TestConnectionBlocked.cs
+++ b/projects/Test/SequentialIntegration/TestConnectionBlocked.cs
@@ -53,7 +53,7 @@ namespace Test.SequentialIntegration
         [Fact]
         public async Task TestConnectionBlockedNotification()
         {
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             _conn.ConnectionBlocked += (object sender, ConnectionBlockedEventArgs args) =>
             {
                 UnblockAsync();
@@ -72,7 +72,7 @@ namespace Test.SequentialIntegration
         [Fact]
         public async Task TestDisposeOnBlockedConnectionDoesNotHang()
         {
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await BlockAsync(_channel);
 

--- a/projects/Test/SequentialIntegration/TestConnectionRecovery.cs
+++ b/projects/Test/SequentialIntegration/TestConnectionRecovery.cs
@@ -73,7 +73,7 @@ namespace Test.SequentialIntegration
         [Fact]
         public async Task TestBasicAckAfterChannelRecovery()
         {
-            var allMessagesSeenTcs = new TaskCompletionSource<bool>();
+            var allMessagesSeenTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var cons = new AckingBasicConsumer(_channel, _totalMessageCount, allMessagesSeenTcs);
 
             QueueDeclareOk q = await _channel.QueueDeclareAsync(_queueName, false, false, false);
@@ -96,7 +96,7 @@ namespace Test.SequentialIntegration
         [Fact]
         public async Task TestBasicNackAfterChannelRecovery()
         {
-            var allMessagesSeenTcs = new TaskCompletionSource<bool>();
+            var allMessagesSeenTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var cons = new NackingBasicConsumer(_channel, _totalMessageCount, allMessagesSeenTcs);
 
             QueueDeclareOk q = await _channel.QueueDeclareAsync(_queueName, false, false, false);
@@ -119,7 +119,7 @@ namespace Test.SequentialIntegration
         [Fact]
         public async Task TestBasicRejectAfterChannelRecovery()
         {
-            var allMessagesSeenTcs = new TaskCompletionSource<bool>();
+            var allMessagesSeenTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var cons = new RejectingBasicConsumer(_channel, _totalMessageCount, allMessagesSeenTcs);
 
             string queueName = (await _channel.QueueDeclareAsync(_queueName, false, false, false)).QueueName;
@@ -160,7 +160,7 @@ namespace Test.SequentialIntegration
         public async Task TestBasicAckEventHandlerRecovery()
         {
             await _channel.ConfirmSelectAsync();
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             ((AutorecoveringChannel)_channel).BasicAcks += (m, args) => tcs.SetResult(true);
             ((AutorecoveringChannel)_channel).BasicNacks += (m, args) => tcs.SetResult(true);
 
@@ -212,7 +212,7 @@ namespace Test.SequentialIntegration
         [Fact]
         public async Task TestChannelAfterDispose_GH1086()
         {
-            TaskCompletionSource<bool> sawChannelShutdownTcs = new TaskCompletionSource<bool>();
+            TaskCompletionSource<bool> sawChannelShutdownTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             void _channel_ChannelShutdown(object sender, ShutdownEventArgs e)
             {
@@ -269,7 +269,7 @@ namespace Test.SequentialIntegration
         {
             try
             {
-                var tcs = new TaskCompletionSource<bool>();
+                var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                 _conn.ConnectionBlocked += (c, reason) => tcs.SetResult(true);
                 await CloseAndWaitForRecoveryAsync();
                 await CloseAndWaitForRecoveryAsync();
@@ -329,7 +329,7 @@ namespace Test.SequentialIntegration
                 await _channel.BasicConsumeAsync(q, true, cons);
             }
 
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             ((AutorecoveringConnection)_conn).ConsumerTagChangeAfterRecovery += (prev, current) => tcs.SetResult(true);
 
             await CloseAndWaitForRecoveryAsync();
@@ -522,7 +522,7 @@ namespace Test.SequentialIntegration
             string q = (await _channel.QueueDeclareAsync(queue: "", durable: false, exclusive: false, autoDelete: true, arguments: null)).QueueName;
             string nameBefore = q;
             string nameAfter = null;
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             ((AutorecoveringConnection)_conn).QueueNameChangedAfterRecovery += (source, ea) =>
             {
@@ -634,7 +634,7 @@ namespace Test.SequentialIntegration
             string nameBefore = q;
             string nameAfter = null;
 
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var connection = (AutorecoveringConnection)_conn;
             connection.RecoverySucceeded += (source, ea) => tcs.SetResult(true);
             connection.QueueNameChangedAfterRecovery += (source, ea) => { nameAfter = ea.NameAfter; };
@@ -730,7 +730,7 @@ namespace Test.SequentialIntegration
             await CloseAndWaitForRecoveryAsync();
             await AssertConsumerCountAsync(_channel, q, 1);
 
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             cons.Received += (s, args) => tcs.SetResult(true);
 
             await _channel.BasicPublishAsync("", q, _messageBody);
@@ -752,7 +752,7 @@ namespace Test.SequentialIntegration
             properties.ReplyTo = "amq.rabbitmq.reply-to";
 
             TimeSpan doneSpan = TimeSpan.FromMilliseconds(100);
-            var doneTcs = new TaskCompletionSource<bool>();
+            var doneTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             Task closeTask = Task.Run(async () =>
             {
                 try
@@ -913,7 +913,7 @@ namespace Test.SequentialIntegration
         [Fact]
         public async Task TestUnblockedListenersRecovery()
         {
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             _conn.ConnectionUnblocked += (source, ea) => tcs.SetResult(true);
             await CloseAndWaitForRecoveryAsync();
             await CloseAndWaitForRecoveryAsync();

--- a/projects/Test/SequentialIntegration/TestConnectionRecoveryBase.cs
+++ b/projects/Test/SequentialIntegration/TestConnectionRecoveryBase.cs
@@ -229,7 +229,7 @@ namespace Test.SequentialIntegration
 
         protected static TaskCompletionSource<bool> PrepareForShutdown(IConnection conn)
         {
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             AutorecoveringConnection aconn = conn as AutorecoveringConnection;
             aconn.ConnectionShutdown += (c, args) => tcs.SetResult(true);
@@ -239,7 +239,7 @@ namespace Test.SequentialIntegration
 
         protected static TaskCompletionSource<bool> PrepareForRecovery(IConnection conn)
         {
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             AutorecoveringConnection aconn = conn as AutorecoveringConnection;
             aconn.RecoverySucceeded += (source, ea) => tcs.SetResult(true);
@@ -392,7 +392,7 @@ namespace Test.SequentialIntegration
             {
                 await ch.ConfirmSelectAsync();
 
-                var tcs = new TaskCompletionSource<bool>();
+                var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 var consumer = new AckingBasicConsumer(ch, 1, tcs);
 

--- a/projects/Test/SequentialIntegration/TestConnectionRecoveryWithoutSetup.cs
+++ b/projects/Test/SequentialIntegration/TestConnectionRecoveryWithoutSetup.cs
@@ -132,7 +132,7 @@ namespace Test.SequentialIntegration
                     await CloseAndWaitForRecoveryAsync(c);
 
                     Assert.True(ch.IsOpen);
-                    var tcs = new TaskCompletionSource<bool>();
+                    var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                     cons.Received += (s, args) => tcs.SetResult(true);
 
                     await ch.BasicPublishAsync("", q, _encoding.GetBytes("msg"));
@@ -177,7 +177,7 @@ namespace Test.SequentialIntegration
                     await AssertConsumerCountAsync(ch, q1, 1);
                     Assert.False(queueNameChangeAfterRecoveryCalled);
 
-                    var tcs = new TaskCompletionSource<bool>();
+                    var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                     cons.Received += (s, args) => tcs.SetResult(true);
 
                     await ch.BasicPublishAsync("", q1, _encoding.GetBytes("msg"));
@@ -265,7 +265,7 @@ namespace Test.SequentialIntegration
                 ConsumerFilter = consumer => !consumer.ConsumerTag.Contains("filtered")
             };
 
-            var connectionRecoveryTcs = new TaskCompletionSource<bool>();
+            var connectionRecoveryTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             using (AutorecoveringConnection conn = await CreateAutorecoveringConnectionWithTopologyRecoveryFilterAsync(filter))
             {
@@ -289,12 +289,12 @@ namespace Test.SequentialIntegration
                     await ch.QueuePurgeAsync(queueWithRecoveredConsumer);
                     await ch.QueuePurgeAsync(queueWithIgnoredConsumer);
 
-                    var consumerRecoveryTcs = new TaskCompletionSource<bool>();
+                    var consumerRecoveryTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                     var consumerToRecover = new EventingBasicConsumer(ch);
                     consumerToRecover.Received += (source, ea) => consumerRecoveryTcs.SetResult(true);
                     await ch.BasicConsumeAsync(queueWithRecoveredConsumer, true, "recovered.consumer", consumerToRecover);
 
-                    var ignoredTcs = new TaskCompletionSource<bool>();
+                    var ignoredTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                     var consumerToIgnore = new EventingBasicConsumer(ch);
                     consumerToIgnore.Received += (source, ea) => ignoredTcs.SetResult(true);
                     await ch.BasicConsumeAsync(queueWithIgnoredConsumer, true, "filtered.consumer", consumerToIgnore);

--- a/projects/Test/SequentialIntegration/TestConnectionTopologyRecovery.cs
+++ b/projects/Test/SequentialIntegration/TestConnectionTopologyRecovery.cs
@@ -70,7 +70,7 @@ namespace Test.SequentialIntegration
             await CloseAndWaitForRecoveryAsync();
             await AssertConsumerCountAsync(_channel, q, 1);
 
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             cons.Received += (s, args) => tcs.SetResult(true);
 
             await _channel.BasicPublishAsync("", q, _messageBody);
@@ -84,7 +84,7 @@ namespace Test.SequentialIntegration
         [Fact]
         public async Task TestTopologyRecoveryQueueFilter()
         {
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var filter = new TopologyRecoveryFilter
             {
@@ -130,7 +130,7 @@ namespace Test.SequentialIntegration
         [Fact]
         public async Task TestTopologyRecoveryExchangeFilter()
         {
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var filter = new TopologyRecoveryFilter
             {
@@ -174,7 +174,7 @@ namespace Test.SequentialIntegration
         [Fact]
         public async Task TestTopologyRecoveryBindingFilter()
         {
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var filter = new TopologyRecoveryFilter
             {
@@ -222,7 +222,7 @@ namespace Test.SequentialIntegration
         [Fact]
         public async Task TestTopologyRecoveryDefaultFilterRecoversAllEntities()
         {
-            var connectionRecoveryTcs = new TaskCompletionSource<bool>();
+            var connectionRecoveryTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var filter = new TopologyRecoveryFilter();
             AutorecoveringConnection conn = await CreateAutorecoveringConnectionWithTopologyRecoveryFilterAsync(filter);
             conn.RecoverySucceeded += (source, ea) => connectionRecoveryTcs.SetResult(true);
@@ -245,12 +245,12 @@ namespace Test.SequentialIntegration
                 await ch.QueuePurgeAsync(queue1);
                 await ch.QueuePurgeAsync(queue2);
 
-                var consumerReceivedTcs1 = new TaskCompletionSource<bool>();
+                var consumerReceivedTcs1 = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                 var consumer1 = new EventingBasicConsumer(ch);
                 consumer1.Received += (source, ea) => consumerReceivedTcs1.SetResult(true);
                 await ch.BasicConsumeAsync(queue1, true, "recovered.consumer", consumer1);
 
-                var consumerReceivedTcs2 = new TaskCompletionSource<bool>();
+                var consumerReceivedTcs2 = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                 var consumer2 = new EventingBasicConsumer(ch);
                 consumer2.Received += (source, ea) => consumerReceivedTcs2.SetResult(true);
                 await ch.BasicConsumeAsync(queue2, true, "filtered.consumer", consumer2);
@@ -290,7 +290,7 @@ namespace Test.SequentialIntegration
         [Fact]
         public async Task TestTopologyRecoveryQueueExceptionHandler()
         {
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var changedQueueArguments = new Dictionary<string, object>
             {
@@ -352,7 +352,7 @@ namespace Test.SequentialIntegration
         [Fact]
         public async Task TestTopologyRecoveryExchangeExceptionHandler()
         {
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var exceptionHandler = new TopologyRecoveryExceptionHandler
             {
@@ -408,7 +408,7 @@ namespace Test.SequentialIntegration
         [Fact]
         public async Task TestTopologyRecoveryBindingExceptionHandler()
         {
-            var connectionRecoveryTcs = new TaskCompletionSource<bool>();
+            var connectionRecoveryTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             const string exchange = "topology.recovery.exchange";
             const string queueWithExceptionBinding = "recovery.exception.queue";
@@ -469,7 +469,7 @@ namespace Test.SequentialIntegration
         [Fact]
         public async Task TestTopologyRecoveryConsumerExceptionHandler()
         {
-            var connectionRecoveryTcs = new TaskCompletionSource<bool>();
+            var connectionRecoveryTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             string queueWithExceptionConsumer = "recovery.exception.queue";
 

--- a/projects/Test/Unit/TestTimerBasedCredentialRefresher.cs
+++ b/projects/Test/Unit/TestTimerBasedCredentialRefresher.cs
@@ -129,7 +129,7 @@ namespace Test.Unit
         [Fact]
         public async Task TestRefreshToken()
         {
-            var cbtcs = new TaskCompletionSource<bool>();
+            var cbtcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             bool? callbackArg = null;
             var credentialsProvider = new MockCredentialsProvider(_testOutputHelper, TimeSpan.FromSeconds(1));
             Task cb(bool arg)
@@ -158,7 +158,7 @@ namespace Test.Unit
         [Fact]
         public async Task TestRefreshTokenFailed()
         {
-            var cbtcs = new TaskCompletionSource<bool>();
+            var cbtcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             bool? callbackArg = null;
             var credentialsProvider = new MockCredentialsProvider(_testOutputHelper, TimeSpan.FromSeconds(1));
             Task cb(bool arg)


### PR DESCRIPTION
## Proposed Changes

This is the basic implementation to add OpenTelemetry support to the .NET RabbitMQ Client. This implements an ActivitySource that creates and propagates Activities for BasicPublish (send), BasicDeliver (receive) and when consumers receive messages (process). This enables distributed tracing scenarios such as showing traces. Below is a screenshot from Honeycomb.io to show what happens when tracing is enabled.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

This should have minimal overhead when tracing is not enabled since no Activity generation occurs and no tags need to be populated.

Currently, to propagate the trace and span ids to correlate events, I'm taking advantage of the `BasicProperties.Headers` to send and parse the information needed to correlate individual traces.

Here is a screenshot from Honeycomb of what this can look like:
<img width="1331" alt="image" src="https://user-images.githubusercontent.com/661658/195118844-b24cce61-f5cf-484e-a579-a79302f4feaf.png">