### PR TITLE
Add exception logging on WriteLoop

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
+++ b/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
@@ -89,7 +89,7 @@ namespace RabbitMQ.Client.Impl
                     SingleReader = true,
                     SingleWriter = false
                 });
-
+            
             _channelReader = channel.Reader;
             _channelWriter = channel.Writer;
 
@@ -294,7 +294,7 @@ namespace RabbitMQ.Client.Impl
                     {
                         MemoryMarshal.TryGetArray(memory, out ArraySegment<byte> segment);
 #if NETSTANDARD
-                    await _writer.WriteAsync(segment.Array, segment.Offset, segment.Count).ConfigureAwait(false);
+                        await _writer.WriteAsync(segment.Array, segment.Offset, segment.Count).ConfigureAwait(false);
 #else
                         await _writer.WriteAsync(memory).ConfigureAwait(false);
 #endif

--- a/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
+++ b/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
@@ -89,7 +89,7 @@ namespace RabbitMQ.Client.Impl
                     SingleReader = true,
                     SingleWriter = false
                 });
-            
+
             _channelReader = channel.Reader;
             _channelWriter = channel.Writer;
 

--- a/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
+++ b/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
@@ -286,21 +286,29 @@ namespace RabbitMQ.Client.Impl
 
         private async Task WriteLoop()
         {
-            while (await _channelReader.WaitToReadAsync().ConfigureAwait(false))
+            try
             {
-                while (_channelReader.TryRead(out ReadOnlyMemory<byte> memory))
+                while (await _channelReader.WaitToReadAsync().ConfigureAwait(false))
                 {
-                    MemoryMarshal.TryGetArray(memory, out ArraySegment<byte> segment);
+                    while (_channelReader.TryRead(out ReadOnlyMemory<byte> memory))
+                    {
+                        MemoryMarshal.TryGetArray(memory, out ArraySegment<byte> segment);
 #if NETSTANDARD
                     await _writer.WriteAsync(segment.Array, segment.Offset, segment.Count).ConfigureAwait(false);
 #else
-                    await _writer.WriteAsync(memory).ConfigureAwait(false);
+                        await _writer.WriteAsync(memory).ConfigureAwait(false);
 #endif
-                    RabbitMqClientEventSource.Log.CommandSent(segment.Count);
-                    ArrayPool<byte>.Shared.Return(segment.Array);
-                }
+                        RabbitMqClientEventSource.Log.CommandSent(segment.Count);
+                        ArrayPool<byte>.Shared.Return(segment.Array);
+                    }
 
-                await _writer.FlushAsync().ConfigureAwait(false);
+                    await _writer.FlushAsync().ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex)
+            {
+                ESLog.Error("Background socket write loop has crashed", ex);
+                throw;
             }
         }
 


### PR DESCRIPTION
## Proposed Changes

Currently the socket write loop can silently fail with no ability to detect the failure. When it fails, assuming the whole socket isn't down, creates a weird situation where socket reads work fine but writes never occur.

While it would be ideal to be able to restart the write loop on such a failure, at least being able to log such a failure would be a good start.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

I'd assume that the vast majority of the time, the problems that affect writing to the socket also affect reading from it. The reason I'm suggesting this change is because that doesn't _always_ seem to be the case and really, there isn't any harm adding a logging call here.