### PR TITLE
fix: add unsigned short support in table deserialisation

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/WireFormatting.Read.cs
+++ b/projects/RabbitMQ.Client/client/impl/WireFormatting.Read.cs
@@ -130,6 +130,9 @@ namespace RabbitMQ.Client.Impl
                     case 's':
                         bytesRead = 3;
                         return NetworkOrderDeserializer.ReadInt16(slice);
+                    case 'u':
+                        bytesRead = 3;
+                        return NetworkOrderDeserializer.ReadUInt16(slice);
                     case 'T':
                         bytesRead = 1 + ReadTimestamp(slice, out var timestamp);
                         return timestamp;

--- a/projects/RabbitMQ.Client/client/impl/WireFormatting.Write.cs
+++ b/projects/RabbitMQ.Client/client/impl/WireFormatting.Write.cs
@@ -200,6 +200,10 @@ namespace RabbitMQ.Client.Impl
                     case BinaryTableValue val:
                         destination = (byte)'x';
                         return 1 + WriteLongstr(ref fieldValue, val.Bytes);
+                    case ushort val:
+                        destination = (byte)'u';
+                        NetworkOrderSerializer.WriteUInt16(ref fieldValue, val);
+                        return 3;
                     default:
                         return ThrowInvalidTableValue(value);
                 }
@@ -234,6 +238,8 @@ namespace RabbitMQ.Client.Impl
                 case sbyte _:
                     return 2;
                 case short _:
+                    return 3;
+                case ushort _:
                     return 3;
                 case uint _:
                     return 5;

--- a/projects/Unit/TestFieldTableFormatting.cs
+++ b/projects/Unit/TestFieldTableFormatting.cs
@@ -143,7 +143,7 @@ namespace RabbitMQ.Client.Unit
                 ["f"] = (float)123,  // 2+5
                 ["l"] = (long)123, // 2+9
                 ["s"] = (short)123, // 2+2
-                ["u"] = (ushort)123
+                ["u"] = (ushort)123,
                 ["t"] = true // 2+2
             };
             byte[] xbytes = { 0xaa, 0x55 };

--- a/projects/Unit/TestFieldTableFormatting.cs
+++ b/projects/Unit/TestFieldTableFormatting.cs
@@ -143,6 +143,7 @@ namespace RabbitMQ.Client.Unit
                 ["f"] = (float)123,  // 2+5
                 ["l"] = (long)123, // 2+9
                 ["s"] = (short)123, // 2+2
+                ["u"] = (ushort)123
                 ["t"] = true // 2+2
             };
             byte[] xbytes = { 0xaa, 0x55 };
@@ -159,6 +160,7 @@ namespace RabbitMQ.Client.Unit
             Assert.Equal(typeof(float), nt["f"].GetType()); Assert.Equal((float)123, nt["f"]);
             Assert.Equal(typeof(long), nt["l"].GetType()); Assert.Equal((long)123, nt["l"]);
             Assert.Equal(typeof(short), nt["s"].GetType()); Assert.Equal((short)123, nt["s"]);
+            Assert.Equal(typeof(ushort), nt["u"].GetType()); Assert.Equal((ushort)123, nt["u"]);
             Assert.Equal(true, nt["t"]);
             Assert.Equal(xbytes, ((BinaryTableValue)nt["x"]).Bytes);
             Assert.Null(nt["V"]);

--- a/projects/Unit/TestFieldTableFormattingGeneric.cs
+++ b/projects/Unit/TestFieldTableFormattingGeneric.cs
@@ -131,6 +131,7 @@ namespace RabbitMQ.Client.Unit
                 ["f"] = (float)123,
                 ["l"] = (long)123,
                 ["s"] = (short)123,
+                ["u"] = (ushort)123,
                 ["t"] = true
             };
             byte[] xbytes = new byte[] { 0xaa, 0x55 };
@@ -147,6 +148,7 @@ namespace RabbitMQ.Client.Unit
             Assert.Equal(typeof(float), nt["f"].GetType()); Assert.Equal((float)123, nt["f"]);
             Assert.Equal(typeof(long), nt["l"].GetType()); Assert.Equal((long)123, nt["l"]);
             Assert.Equal(typeof(short), nt["s"].GetType()); Assert.Equal((short)123, nt["s"]);
+            Assert.Equal(typeof(ushort), nt["u"].GetType()); Assert.Equal((ushort)123, nt["u"]);
             Assert.Equal(true, nt["t"]);
             Assert.Equal(xbytes, ((BinaryTableValue)nt["x"]).Bytes);
             Assert.Null(nt["V"]);


### PR DESCRIPTION
While it seems that this wasn't needed in the lifetime of this library so far, it seems weird not to support the full protocol as stated on the RabbitMQ website (including errata).

While I've been unable to reproduce it locally with a local install of RabbitMQ server, I have encountered at least one instance where a server sent a numeric header value that fit into an unsigned short over the wire. My extremely unscientific hypothesis is that a strict client pushed this message onto the queue which the server passed on directly, but I could be wrong here.

Bottom line is: I have a crashing `RabbitMQ.Client` that says it doesn't understand the field type `'u'` while the docs clearly say it's part of the protocol.

This commit adds parsing support for unsigned shorts, which should ensure the library conforms fully to the protocol in those few edge cases where it is still needed.

I added tests in the `TestFieldTableFormatting` and `TestFieldTableFormattingGeneric` files since that seemed the most logical place to put them, but I could have missed a more appropriate test.

Inspired by: #662

## Proposed Changes

As described in #662, `RabbitMQ.Client` does not support unsigned short reading out of the box. Since this is a trivial addition with relatively low-impact by my estimates, I'd figure I'd add it to ensure the library is not at fault when facing stricter or older servers.

~~As for the nature of the change, it would be and observable change in existing systems in that the library doesn't crash anymore when RMQ servers send unsigned shorts over the wire. I'm not sure if this is considered breaking or not.~~

I had to change the writer for the roundtrip tests as well, but that poses a conundrum: where previously unsigned shorts were
explicitly rejected, it is now accepted and serialized. That is a pretty big change to make, so I'm pretty sure that's a breaking change. Especially since it seems that some libraries (I checked [node-amqp](https://github.com/amqp-node/amqplib/blob/b3647780265dd0f84451b0a29776f6c2dbfa9d3d/lib/codec.js#L192) real quick) just do not support these types. Then again, there's a [pull request already open](https://github.com/amqp-node/amqplib/pull/620) to fix that.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #662)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

