### PR TITLE
fix: add unsigned short support in table protocol

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/WireFormatting.cs
+++ b/projects/RabbitMQ.Client/client/impl/WireFormatting.cs
@@ -152,6 +152,9 @@ namespace RabbitMQ.Client.Impl
                 case 's':
                     bytesRead += 2;
                     return NetworkOrderDeserializer.ReadInt16(span.Slice(1));
+                case 'u':
+                    bytesRead += 2;
+                    return NetworkOrderDeserializer.ReadUInt16(span.Slice(1));
                 case 't':
                     bytesRead += 1;
                     return span[1] != 0;
@@ -342,6 +345,10 @@ namespace RabbitMQ.Client.Impl
                     span[0] = (byte)'s';
                     NetworkOrderSerializer.WriteInt16(slice, val);
                     return 3;
+                case ushort val:
+                    span[0] = (byte)'u';
+                    NetworkOrderSerializer.WriteUInt16(slice, val);
+                    return 3;
                 case bool val:
                     span[0] = (byte)'t';
                     span[1] = (byte)(val ? 1 : 0);
@@ -365,6 +372,7 @@ namespace RabbitMQ.Client.Impl
                 case bool _:
                     return 2;
                 case short _:
+                case ushort _:
                     return 3;
                 case int _:
                 case uint _:

--- a/projects/Unit/TestFieldTableFormatting.cs
+++ b/projects/Unit/TestFieldTableFormatting.cs
@@ -144,6 +144,7 @@ namespace RabbitMQ.Client.Unit
                 ["f"] = (float)123,  // 2+5
                 ["l"] = (long)123, // 2+9
                 ["s"] = (short)123, // 2+2
+                ["u"] = (ushort)123,
                 ["t"] = true // 2+2
             };
             byte[] xbytes = { 0xaa, 0x55 };
@@ -160,6 +161,7 @@ namespace RabbitMQ.Client.Unit
             Assert.AreEqual(typeof(float), nt["f"].GetType()); Assert.AreEqual((float)123, nt["f"]);
             Assert.AreEqual(typeof(long), nt["l"].GetType()); Assert.AreEqual((long)123, nt["l"]);
             Assert.AreEqual(typeof(short), nt["s"].GetType()); Assert.AreEqual((short)123, nt["s"]);
+            Assert.AreEqual(typeof(ushort), nt["u"].GetType()); Assert.AreEqual((ushort)123, nt["u"]);
             Assert.AreEqual(true, nt["t"]);
             Assert.AreEqual(xbytes, ((BinaryTableValue)nt["x"]).Bytes);
             Assert.AreEqual(null, nt["V"]);

--- a/projects/Unit/TestFieldTableFormattingGeneric.cs
+++ b/projects/Unit/TestFieldTableFormattingGeneric.cs
@@ -131,6 +131,7 @@ namespace RabbitMQ.Client.Unit
                 ["f"] = (float)123,
                 ["l"] = (long)123,
                 ["s"] = (short)123,
+                ["u"] = (ushort)123,
                 ["t"] = true
             };
             byte[] xbytes = new byte[] { 0xaa, 0x55 };
@@ -147,6 +148,7 @@ namespace RabbitMQ.Client.Unit
             Assert.AreEqual(typeof(float), nt["f"].GetType()); Assert.AreEqual((float)123, nt["f"]);
             Assert.AreEqual(typeof(long), nt["l"].GetType()); Assert.AreEqual((long)123, nt["l"]);
             Assert.AreEqual(typeof(short), nt["s"].GetType()); Assert.AreEqual((short)123, nt["s"]);
+            Assert.AreEqual(typeof(ushort), nt["u"].GetType()); Assert.AreEqual((ushort)123, nt["u"]);
             Assert.AreEqual(true, nt["t"]);
             Assert.AreEqual(xbytes, ((BinaryTableValue)nt["x"]).Bytes);
             Assert.AreEqual(null, nt["V"]);


### PR DESCRIPTION
As promised in #1270, a backport for the 6.x branch.

I elected not to cherrypick the relevant commits as the code was refactored between versions. Instead, I made a transliteration of the code to keep the 6.x patch in line with the existing code.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
