### PR TITLE
Using interface IReadOnlyDictionary instead of a IDictionary

### DIFF
--- a/projects/Benchmarks/WireFormatting/DataTypeSerialization.cs
+++ b/projects/Benchmarks/WireFormatting/DataTypeSerialization.cs
@@ -128,8 +128,8 @@ namespace RabbitMQ.Benchmarks
 
     public class DataTypeTableSerialization : DataTypeSerialization
     {
-        private IDictionary<string, object> _emptyDict = new Dictionary<string, object>();
-        private IDictionary<string, object> _populatedDict;
+        private IReadOnlyDictionary<string, object> _emptyDict = new Dictionary<string, object>();
+        private IReadOnlyDictionary<string, object> _populatedDict;
         private Memory<byte> _emptyDictionaryBuffer;
         private Memory<byte> _populatedDictionaryBuffer;
 

--- a/projects/RabbitMQ.Client/client/api/BasicProperties.cs
+++ b/projects/RabbitMQ.Client/client/api/BasicProperties.cs
@@ -44,7 +44,7 @@ namespace RabbitMQ.Client
     {
         public string? ContentType { get; set; }
         public string? ContentEncoding { get; set; }
-        public IDictionary<string, object?>? Headers { get; set; }
+        public IReadOnlyDictionary<string, object?>? Headers { get; set; }
         public DeliveryModes DeliveryMode { get; set; }
         public byte Priority { get; set; }
         public string? CorrelationId { get; set; }

--- a/projects/RabbitMQ.Client/client/api/IBasicProperties.cs
+++ b/projects/RabbitMQ.Client/client/api/IBasicProperties.cs
@@ -79,7 +79,7 @@ namespace RabbitMQ.Client
         /// <summary>
         /// Message header field table. Is of type <see cref="IDictionary{TKey,TValue}" />.
         /// </summary>
-        IDictionary<string, object?>? Headers { get; }
+        IReadOnlyDictionary<string, object?>? Headers { get; }
 
         /// <summary>
         /// Application message Id.
@@ -244,9 +244,9 @@ namespace RabbitMQ.Client
         new string? Expiration { get; set; }
 
         /// <summary>
-        /// Message header field table. Is of type <see cref="IDictionary{TKey,TValue}" />.
+        /// Message header field table. Is of type <see cref="IReadOnlyDictionary{TKey,TValue}" />.
         /// </summary>
-        new IDictionary<string, object?>? Headers { get; set; }
+        new IReadOnlyDictionary<string, object?>? Headers { get; set; }
 
         /// <summary>
         /// Application message Id.

--- a/projects/RabbitMQ.Client/client/api/IConnection.cs
+++ b/projects/RabbitMQ.Client/client/api/IConnection.cs
@@ -64,7 +64,7 @@ namespace RabbitMQ.Client
         /// <summary>
         /// A copy of the client properties that has been sent to the server.
         /// </summary>
-        IDictionary<string, object> ClientProperties { get; }
+        IReadOnlyDictionary<string, object> ClientProperties { get; }
 
         /// <summary>
         /// Returns null if the connection is still in a state
@@ -116,7 +116,7 @@ namespace RabbitMQ.Client
         /// A dictionary of the server properties sent by the server while establishing the connection.
         /// This typically includes the product name and version of the server.
         /// </summary>
-        IDictionary<string, object> ServerProperties { get; }
+        IReadOnlyDictionary<string, object> ServerProperties { get; }
 
         /// <summary>
         /// Returns the list of <see cref="ShutdownReportEntry"/> objects that contain information

--- a/projects/RabbitMQ.Client/client/api/IModel.cs
+++ b/projects/RabbitMQ.Client/client/api/IModel.cs
@@ -166,7 +166,7 @@ namespace RabbitMQ.Client
             string consumerTag,
             bool noLocal,
             bool exclusive,
-            IDictionary<string, object> arguments,
+            IReadOnlyDictionary<string, object> arguments,
             IBasicConsumer consumer);
 
         /// <summary>
@@ -241,7 +241,7 @@ namespace RabbitMQ.Client
         ///     Routing key must be shorter than 255 bytes.
         ///   </para>
         /// </remarks>
-        void ExchangeBind(string destination, string source, string routingKey, IDictionary<string, object> arguments);
+        void ExchangeBind(string destination, string source, string routingKey, IReadOnlyDictionary<string, object> arguments);
 
         /// <summary>
         /// Like ExchangeBind but sets nowait to true.
@@ -251,20 +251,20 @@ namespace RabbitMQ.Client
         ///     Routing key must be shorter than 255 bytes.
         ///   </para>
         /// </remarks>
-        void ExchangeBindNoWait(string destination, string source, string routingKey, IDictionary<string, object> arguments);
+        void ExchangeBindNoWait(string destination, string source, string routingKey, IReadOnlyDictionary<string, object> arguments);
 
         /// <summary>Declare an exchange.</summary>
         /// <remarks>
         /// The exchange is declared non-passive and non-internal.
         /// The "nowait" option is not exercised.
         /// </remarks>
-        void ExchangeDeclare(string exchange, string type, bool durable, bool autoDelete, IDictionary<string, object> arguments);
+        void ExchangeDeclare(string exchange, string type, bool durable, bool autoDelete, IReadOnlyDictionary<string, object> arguments);
 
         /// <summary>
         /// Same as ExchangeDeclare but sets nowait to true and returns void (as there
         /// will be no response from the server).
         /// </summary>
-        void ExchangeDeclareNoWait(string exchange, string type, bool durable, bool autoDelete, IDictionary<string, object> arguments);
+        void ExchangeDeclareNoWait(string exchange, string type, bool durable, bool autoDelete, IReadOnlyDictionary<string, object> arguments);
 
         /// <summary>
         /// Do a passive exchange declaration.
@@ -293,7 +293,7 @@ namespace RabbitMQ.Client
         /// <remarks>
         /// Routing key must be shorter than 255 bytes.
         /// </remarks>
-        void ExchangeUnbind(string destination, string source, string routingKey, IDictionary<string, object> arguments);
+        void ExchangeUnbind(string destination, string source, string routingKey, IReadOnlyDictionary<string, object> arguments);
 
         /// <summary>
         /// Like ExchangeUnbind but sets nowait to true.
@@ -303,7 +303,7 @@ namespace RabbitMQ.Client
         ///     Routing key must be shorter than 255 bytes.
         ///   </para>
         /// </remarks>
-        void ExchangeUnbindNoWait(string destination, string source, string routingKey, IDictionary<string, object> arguments);
+        void ExchangeUnbindNoWait(string destination, string source, string routingKey, IReadOnlyDictionary<string, object> arguments);
 
         /// <summary>
         /// Bind a queue to an exchange.
@@ -313,7 +313,7 @@ namespace RabbitMQ.Client
         ///     Routing key must be shorter than 255 bytes.
         ///   </para>
         /// </remarks>
-        void QueueBind(string queue, string exchange, string routingKey, IDictionary<string, object> arguments);
+        void QueueBind(string queue, string exchange, string routingKey, IReadOnlyDictionary<string, object> arguments);
 
         /// <summary>Same as QueueBind but sets nowait parameter to true.</summary>
         /// <remarks>
@@ -321,7 +321,7 @@ namespace RabbitMQ.Client
         ///     Routing key must be shorter than 255 bytes.
         ///   </para>
         /// </remarks>
-        void QueueBindNoWait(string queue, string exchange, string routingKey, IDictionary<string, object> arguments);
+        void QueueBindNoWait(string queue, string exchange, string routingKey, IReadOnlyDictionary<string, object> arguments);
 
         /// <summary>
         /// Declares a queue. See the <a href="https://www.rabbitmq.com/queues.html">Queues guide</a> to learn more.
@@ -331,7 +331,7 @@ namespace RabbitMQ.Client
         /// <param name="exclusive">Should this queue use be limited to its declaring connection? Such a queue will be deleted when its declaring connection closes.</param>
         /// <param name="autoDelete">Should this queue be auto-deleted when its last consumer (if any) unsubscribes?</param>
         /// <param name="arguments">Optional; additional queue arguments, e.g. "x-queue-type"</param>
-        QueueDeclareOk QueueDeclare(string queue, bool durable, bool exclusive, bool autoDelete, IDictionary<string, object> arguments);
+        QueueDeclareOk QueueDeclare(string queue, bool durable, bool exclusive, bool autoDelete, IReadOnlyDictionary<string, object> arguments);
 
         /// <summary>
         /// Declares a queue. See the <a href="https://www.rabbitmq.com/queues.html">Queues guide</a> to learn more.
@@ -341,7 +341,7 @@ namespace RabbitMQ.Client
         /// <param name="exclusive">Should this queue use be limited to its declaring connection? Such a queue will be deleted when its declaring connection closes.</param>
         /// <param name="autoDelete">Should this queue be auto-deleted when its last consumer (if any) unsubscribes?</param>
         /// <param name="arguments">Optional; additional queue arguments, e.g. "x-queue-type"</param>
-        void QueueDeclareNoWait(string queue, bool durable, bool exclusive, bool autoDelete, IDictionary<string, object> arguments);
+        void QueueDeclareNoWait(string queue, bool durable, bool exclusive, bool autoDelete, IReadOnlyDictionary<string, object> arguments);
 
         /// <summary>Declare a queue passively.</summary>
         /// <remarks>
@@ -397,7 +397,7 @@ namespace RabbitMQ.Client
         ///     Routing key must be shorter than 255 bytes.
         ///   </para>
         /// </remarks>
-        void QueueUnbind(string queue, string exchange, string routingKey, IDictionary<string, object> arguments);
+        void QueueUnbind(string queue, string exchange, string routingKey, IReadOnlyDictionary<string, object> arguments);
 
         /// <summary>
         /// Commit this session's active TX transaction.

--- a/projects/RabbitMQ.Client/client/api/IModelExtensions.cs
+++ b/projects/RabbitMQ.Client/client/api/IModelExtensions.cs
@@ -45,7 +45,7 @@ namespace RabbitMQ.Client
             string consumerTag = "",
             bool noLocal = false,
             bool exclusive = false,
-            IDictionary<string, object> arguments = null)
+            IReadOnlyDictionary<string, object> arguments = null)
         {
             return model.BasicConsume(queue, autoAck, consumerTag, noLocal, exclusive, arguments, consumer);
         }
@@ -69,7 +69,7 @@ namespace RabbitMQ.Client
         public static string BasicConsume(this IModel model, string queue,
             bool autoAck,
             string consumerTag,
-            IDictionary<string, object> arguments,
+            IReadOnlyDictionary<string, object> arguments,
             IBasicConsumer consumer)
         {
             return model.BasicConsume(queue, autoAck, consumerTag, false, false, arguments, consumer);
@@ -99,7 +99,7 @@ namespace RabbitMQ.Client
         /// (Spec method) Declare a queue.
         /// </summary>
         public static QueueDeclareOk QueueDeclare(this IModel model, string queue = "", bool durable = false, bool exclusive = true,
-            bool autoDelete = true, IDictionary<string, object> arguments = null)
+            bool autoDelete = true, IReadOnlyDictionary<string, object> arguments = null)
         {
             return model.QueueDeclare(queue, durable, exclusive, autoDelete, arguments);
         }
@@ -107,7 +107,7 @@ namespace RabbitMQ.Client
         /// <summary>
         /// (Extension method) Bind an exchange to an exchange.
         /// </summary>
-        public static void ExchangeBind(this IModel model, string destination, string source, string routingKey, IDictionary<string, object> arguments = null)
+        public static void ExchangeBind(this IModel model, string destination, string source, string routingKey, IReadOnlyDictionary<string, object> arguments = null)
         {
             model.ExchangeBind(destination, source, routingKey, arguments);
         }
@@ -115,7 +115,7 @@ namespace RabbitMQ.Client
         /// <summary>
         /// (Extension method) Like exchange bind but sets nowait to true.
         /// </summary>
-        public static void ExchangeBindNoWait(this IModel model, string destination, string source, string routingKey, IDictionary<string, object> arguments = null)
+        public static void ExchangeBindNoWait(this IModel model, string destination, string source, string routingKey, IReadOnlyDictionary<string, object> arguments = null)
         {
             model.ExchangeBindNoWait(destination, source, routingKey, arguments);
         }
@@ -124,7 +124,7 @@ namespace RabbitMQ.Client
         /// (Spec method) Declare an exchange.
         /// </summary>
         public static void ExchangeDeclare(this IModel model, string exchange, string type, bool durable = false, bool autoDelete = false,
-            IDictionary<string, object> arguments = null)
+            IReadOnlyDictionary<string, object> arguments = null)
         {
             model.ExchangeDeclare(exchange, type, durable, autoDelete, arguments);
         }
@@ -133,7 +133,7 @@ namespace RabbitMQ.Client
         /// (Extension method) Like ExchangeDeclare but sets nowait to true.
         /// </summary>
         public static void ExchangeDeclareNoWait(this IModel model, string exchange, string type, bool durable = false, bool autoDelete = false,
-            IDictionary<string, object> arguments = null)
+            IReadOnlyDictionary<string, object> arguments = null)
         {
             model.ExchangeDeclareNoWait(exchange, type, durable, autoDelete, arguments);
         }
@@ -144,7 +144,7 @@ namespace RabbitMQ.Client
         public static void ExchangeUnbind(this IModel model, string destination,
             string source,
             string routingKey,
-            IDictionary<string, object> arguments = null)
+            IReadOnlyDictionary<string, object> arguments = null)
         {
             model.ExchangeUnbind(destination, source, routingKey, arguments);
         }
@@ -168,7 +168,7 @@ namespace RabbitMQ.Client
         /// <summary>
         /// (Spec method) Binds a queue.
         /// </summary>
-        public static void QueueBind(this IModel model, string queue, string exchange, string routingKey, IDictionary<string, object> arguments = null)
+        public static void QueueBind(this IModel model, string queue, string exchange, string routingKey, IReadOnlyDictionary<string, object> arguments = null)
         {
             model.QueueBind(queue, exchange, routingKey, arguments);
         }
@@ -192,7 +192,7 @@ namespace RabbitMQ.Client
         /// <summary>
         /// (Spec method) Unbinds a queue.
         /// </summary>
-        public static void QueueUnbind(this IModel model, string queue, string exchange, string routingKey, IDictionary<string, object> arguments = null)
+        public static void QueueUnbind(this IModel model, string queue, string exchange, string routingKey, IReadOnlyDictionary<string, object> arguments = null)
         {
             model.QueueUnbind(queue, exchange, routingKey, arguments);
         }

--- a/projects/RabbitMQ.Client/client/api/ReadonlyBasicProperties.cs
+++ b/projects/RabbitMQ.Client/client/api/ReadonlyBasicProperties.cs
@@ -43,7 +43,7 @@ namespace RabbitMQ.Client
     {
         private readonly string? _contentType;
         private readonly string? _contentEncoding;
-        private readonly IDictionary<string, object?>? _headers;
+        private readonly IReadOnlyDictionary<string, object?>? _headers;
         private readonly DeliveryModes _deliveryMode;
         private readonly byte _priority;
         private readonly string? _correlationId;
@@ -58,7 +58,7 @@ namespace RabbitMQ.Client
 
         public string? ContentType => _contentType;
         public string? ContentEncoding => _contentEncoding;
-        public IDictionary<string, object?>? Headers => _headers;
+        public IReadOnlyDictionary<string, object?>? Headers => _headers;
         public DeliveryModes DeliveryMode => _deliveryMode;
         public byte Priority => _priority;
         public string? CorrelationId => _correlationId;

--- a/projects/RabbitMQ.Client/client/extensions/EnumerableExtensions.cs
+++ b/projects/RabbitMQ.Client/client/extensions/EnumerableExtensions.cs
@@ -26,19 +26,21 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
+//  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
+using System;
+using System.Collections;
 using System.Collections.Generic;
 
-namespace RabbitMQ.Client.Impl
+namespace RabbitMQ.Client.Extensions
 {
-    internal class ConnectionStartDetails
+    internal static class EnumerableExtensions
     {
-        public byte[] m_locales;
-        public byte[] m_mechanisms;
-        public IReadOnlyDictionary<string, object> m_serverProperties;
-        public byte m_versionMajor;
-        public byte m_versionMinor;
+        public static bool Any(this IEnumerable source)
+        {
+            var enumerator = source.GetEnumerator();
+            return enumerator.MoveNext();
+        }
     }
 }

--- a/projects/RabbitMQ.Client/client/framing/BasicConsume.cs
+++ b/projects/RabbitMQ.Client/client/framing/BasicConsume.cs
@@ -47,9 +47,9 @@ namespace RabbitMQ.Client.Framing.Impl
         public readonly bool _noAck;
         public readonly bool _exclusive;
         public readonly bool _nowait;
-        public readonly IDictionary<string, object> _arguments;
+        public readonly IReadOnlyDictionary<string, object> _arguments;
 
-        public BasicConsume(string Queue, string ConsumerTag, bool NoLocal, bool NoAck, bool Exclusive, bool Nowait, IDictionary<string, object> Arguments)
+        public BasicConsume(string Queue, string ConsumerTag, bool NoLocal, bool NoAck, bool Exclusive, bool Nowait, IReadOnlyDictionary<string, object> Arguments)
         {
             _queue = Queue;
             _consumerTag = ConsumerTag;

--- a/projects/RabbitMQ.Client/client/framing/ConnectionStartOk.cs
+++ b/projects/RabbitMQ.Client/client/framing/ConnectionStartOk.cs
@@ -39,12 +39,12 @@ namespace RabbitMQ.Client.Framing.Impl
 {
     internal readonly struct ConnectionStartOk : IOutgoingAmqpMethod
     {
-        public readonly IDictionary<string, object> _clientProperties;
+        public readonly IReadOnlyDictionary<string, object> _clientProperties;
         public readonly string _mechanism;
         public readonly byte[] _response;
         public readonly string _locale;
 
-        public ConnectionStartOk(IDictionary<string, object> ClientProperties, string Mechanism, byte[] Response, string Locale)
+        public ConnectionStartOk(IReadOnlyDictionary<string, object> ClientProperties, string Mechanism, byte[] Response, string Locale)
         {
             _clientProperties = ClientProperties;
             _mechanism = Mechanism;

--- a/projects/RabbitMQ.Client/client/framing/ExchangeBind.cs
+++ b/projects/RabbitMQ.Client/client/framing/ExchangeBind.cs
@@ -45,9 +45,9 @@ namespace RabbitMQ.Client.Framing.Impl
         public readonly string _source;
         public readonly string _routingKey;
         public readonly bool _nowait;
-        public readonly IDictionary<string, object> _arguments;
+        public readonly IReadOnlyDictionary<string, object> _arguments;
 
-        public ExchangeBind(string Destination, string Source, string RoutingKey, bool Nowait, IDictionary<string, object> Arguments)
+        public ExchangeBind(string Destination, string Source, string RoutingKey, bool Nowait, IReadOnlyDictionary<string, object> Arguments)
         {
             _destination = Destination;
             _source = Source;

--- a/projects/RabbitMQ.Client/client/framing/ExchangeDeclare.cs
+++ b/projects/RabbitMQ.Client/client/framing/ExchangeDeclare.cs
@@ -48,9 +48,9 @@ namespace RabbitMQ.Client.Framing.Impl
         public readonly bool _autoDelete;
         public readonly bool _internal;
         public readonly bool _nowait;
-        public readonly IDictionary<string, object> _arguments;
+        public readonly IReadOnlyDictionary<string, object> _arguments;
 
-        public ExchangeDeclare(string Exchange, string Type, bool Passive, bool Durable, bool AutoDelete, bool Internal, bool Nowait, IDictionary<string, object> Arguments)
+        public ExchangeDeclare(string Exchange, string Type, bool Passive, bool Durable, bool AutoDelete, bool Internal, bool Nowait, IReadOnlyDictionary<string, object> Arguments)
         {
             _exchange = Exchange;
             _type = Type;

--- a/projects/RabbitMQ.Client/client/framing/ExchangeUnbind.cs
+++ b/projects/RabbitMQ.Client/client/framing/ExchangeUnbind.cs
@@ -45,9 +45,9 @@ namespace RabbitMQ.Client.Framing.Impl
         public readonly string _source;
         public readonly string _routingKey;
         public readonly bool _nowait;
-        public readonly IDictionary<string, object> _arguments;
+        public readonly IReadOnlyDictionary<string, object> _arguments;
 
-        public ExchangeUnbind(string Destination, string Source, string RoutingKey, bool Nowait, IDictionary<string, object> Arguments)
+        public ExchangeUnbind(string Destination, string Source, string RoutingKey, bool Nowait, IReadOnlyDictionary<string, object> Arguments)
         {
             _destination = Destination;
             _source = Source;

--- a/projects/RabbitMQ.Client/client/framing/Model.cs
+++ b/projects/RabbitMQ.Client/client/framing/Model.cs
@@ -52,7 +52,7 @@ namespace RabbitMQ.Client.Framing.Impl
             ModelSend(new BasicCancel(consumerTag, nowait));
         }
 
-        public override void _Private_BasicConsume(string queue, string consumerTag, bool noLocal, bool autoAck, bool exclusive, bool nowait, IDictionary<string, object> arguments)
+        public override void _Private_BasicConsume(string queue, string consumerTag, bool noLocal, bool autoAck, bool exclusive, bool nowait, IReadOnlyDictionary<string, object> arguments)
         {
             ModelSend(new BasicConsume(queue, consumerTag, noLocal, autoAck, exclusive, nowait, arguments));
         }
@@ -115,7 +115,7 @@ namespace RabbitMQ.Client.Framing.Impl
             ModelSend(new ConnectionSecureOk(response));
         }
 
-        public override void _Private_ConnectionStartOk(IDictionary<string, object> clientProperties, string mechanism, byte[] response, string locale)
+        public override void _Private_ConnectionStartOk(IReadOnlyDictionary<string, object> clientProperties, string mechanism, byte[] response, string locale)
         {
             ModelSend(new ConnectionStartOk(clientProperties, mechanism, response, locale));
         }
@@ -125,7 +125,7 @@ namespace RabbitMQ.Client.Framing.Impl
             ModelRpc(new ConnectionUpdateSecret(newSecret, reason), ProtocolCommandId.ConnectionUpdateSecretOk);
         }
 
-        public override void _Private_ExchangeBind(string destination, string source, string routingKey, bool nowait, IDictionary<string, object> arguments)
+        public override void _Private_ExchangeBind(string destination, string source, string routingKey, bool nowait, IReadOnlyDictionary<string, object> arguments)
         {
             var method = new ExchangeBind(destination, source, routingKey, nowait, arguments);
             if (nowait)
@@ -138,7 +138,7 @@ namespace RabbitMQ.Client.Framing.Impl
             }
         }
 
-        public override void _Private_ExchangeDeclare(string exchange, string type, bool passive, bool durable, bool autoDelete, bool @internal, bool nowait, IDictionary<string, object> arguments)
+        public override void _Private_ExchangeDeclare(string exchange, string type, bool passive, bool durable, bool autoDelete, bool @internal, bool nowait, IReadOnlyDictionary<string, object> arguments)
         {
             var method = new ExchangeDeclare(exchange, type, passive, durable, autoDelete, @internal, nowait, arguments);
             if (nowait)
@@ -164,7 +164,7 @@ namespace RabbitMQ.Client.Framing.Impl
             }
         }
 
-        public override void _Private_ExchangeUnbind(string destination, string source, string routingKey, bool nowait, IDictionary<string, object> arguments)
+        public override void _Private_ExchangeUnbind(string destination, string source, string routingKey, bool nowait, IReadOnlyDictionary<string, object> arguments)
         {
             var method = new ExchangeUnbind(destination, source, routingKey, nowait, arguments);
             if (nowait)
@@ -177,7 +177,7 @@ namespace RabbitMQ.Client.Framing.Impl
             }
         }
 
-        public override void _Private_QueueBind(string queue, string exchange, string routingKey, bool nowait, IDictionary<string, object> arguments)
+        public override void _Private_QueueBind(string queue, string exchange, string routingKey, bool nowait, IReadOnlyDictionary<string, object> arguments)
         {
             var method = new QueueBind(queue, exchange, routingKey, nowait, arguments);
             if (nowait)
@@ -190,7 +190,7 @@ namespace RabbitMQ.Client.Framing.Impl
             }
         }
 
-        public override void _Private_QueueDeclare(string queue, bool passive, bool durable, bool exclusive, bool autoDelete, bool nowait, IDictionary<string, object> arguments)
+        public override void _Private_QueueDeclare(string queue, bool passive, bool durable, bool exclusive, bool autoDelete, bool nowait, IReadOnlyDictionary<string, object> arguments)
         {
             var method = new QueueDeclare(queue, passive, durable, exclusive, autoDelete, nowait, arguments);
             if (nowait)
@@ -252,7 +252,7 @@ namespace RabbitMQ.Client.Framing.Impl
             ModelSend(new BasicReject(deliveryTag, requeue));
         }
 
-        public override void QueueUnbind(string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
+        public override void QueueUnbind(string queue, string exchange, string routingKey, IReadOnlyDictionary<string, object> arguments)
         {
             ModelRpc(new QueueUnbind(queue, exchange, routingKey, arguments), ProtocolCommandId.QueueUnbindOk);
         }

--- a/projects/RabbitMQ.Client/client/framing/QueueBind.cs
+++ b/projects/RabbitMQ.Client/client/framing/QueueBind.cs
@@ -45,9 +45,9 @@ namespace RabbitMQ.Client.Framing.Impl
         public readonly string _exchange;
         public readonly string _routingKey;
         public readonly bool _nowait;
-        public readonly IDictionary<string, object> _arguments;
+        public readonly IReadOnlyDictionary<string, object> _arguments;
 
-        public QueueBind(string Queue, string Exchange, string RoutingKey, bool Nowait, IDictionary<string, object> Arguments)
+        public QueueBind(string Queue, string Exchange, string RoutingKey, bool Nowait, IReadOnlyDictionary<string, object> Arguments)
         {
             _queue = Queue;
             _exchange = Exchange;

--- a/projects/RabbitMQ.Client/client/framing/QueueDeclare.cs
+++ b/projects/RabbitMQ.Client/client/framing/QueueDeclare.cs
@@ -47,9 +47,9 @@ namespace RabbitMQ.Client.Framing.Impl
         public readonly bool _exclusive;
         public readonly bool _autoDelete;
         public readonly bool _nowait;
-        public readonly IDictionary<string, object> _arguments;
+        public readonly IReadOnlyDictionary<string, object> _arguments;
 
-        public QueueDeclare(string Queue, bool Passive, bool Durable, bool Exclusive, bool AutoDelete, bool Nowait, IDictionary<string, object> Arguments)
+        public QueueDeclare(string Queue, bool Passive, bool Durable, bool Exclusive, bool AutoDelete, bool Nowait, IReadOnlyDictionary<string, object> Arguments)
         {
             _queue = Queue;
             _passive = Passive;

--- a/projects/RabbitMQ.Client/client/framing/QueueUnbind.cs
+++ b/projects/RabbitMQ.Client/client/framing/QueueUnbind.cs
@@ -44,9 +44,9 @@ namespace RabbitMQ.Client.Framing.Impl
         public readonly string _queue;
         public readonly string _exchange;
         public readonly string _routingKey;
-        public readonly IDictionary<string, object> _arguments;
+        public readonly IReadOnlyDictionary<string, object> _arguments;
 
-        public QueueUnbind(string Queue, string Exchange, string RoutingKey, IDictionary<string, object> Arguments)
+        public QueueUnbind(string Queue, string Exchange, string RoutingKey, IReadOnlyDictionary<string, object> Arguments)
         {
             _queue = Queue;
             _exchange = Exchange;

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.cs
@@ -133,7 +133,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public ushort ChannelMax => InnerConnection.ChannelMax;
 
-        public IDictionary<string, object> ClientProperties => InnerConnection.ClientProperties;
+        public IReadOnlyDictionary<string, object> ClientProperties => InnerConnection.ClientProperties;
 
         public ShutdownEventArgs CloseReason => InnerConnection.CloseReason;
 
@@ -149,7 +149,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public int RemotePort => InnerConnection.RemotePort;
 
-        public IDictionary<string, object> ServerProperties => InnerConnection.ServerProperties;
+        public IReadOnlyDictionary<string, object> ServerProperties => InnerConnection.ServerProperties;
 
         public IList<ShutdownReportEntry> ShutdownReport => InnerConnection.ShutdownReport;
 

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
@@ -235,7 +235,7 @@ namespace RabbitMQ.Client.Impl
             string consumerTag,
             bool noLocal,
             bool exclusive,
-            IDictionary<string, object> arguments,
+            IReadOnlyDictionary<string, object> arguments,
             IBasicConsumer consumer)
         {
             string result = InnerChannel.BasicConsume(queue, autoAck, consumerTag, noLocal, exclusive, arguments, consumer);
@@ -286,24 +286,24 @@ namespace RabbitMQ.Client.Impl
             _usesPublisherConfirms = true;
         }
 
-        public void ExchangeBind(string destination, string source, string routingKey, IDictionary<string, object> arguments)
+        public void ExchangeBind(string destination, string source, string routingKey, IReadOnlyDictionary<string, object> arguments)
         {
             ThrowIfDisposed();
             _connection.RecordBinding(new RecordedBinding(false, destination, source, routingKey, arguments));
             _innerChannel.ExchangeBind(destination, source, routingKey, arguments);
         }
 
-        public void ExchangeBindNoWait(string destination, string source, string routingKey, IDictionary<string, object> arguments)
+        public void ExchangeBindNoWait(string destination, string source, string routingKey, IReadOnlyDictionary<string, object> arguments)
             => InnerChannel.ExchangeBindNoWait(destination, source, routingKey, arguments);
 
-        public void ExchangeDeclare(string exchange, string type, bool durable, bool autoDelete, IDictionary<string, object> arguments)
+        public void ExchangeDeclare(string exchange, string type, bool durable, bool autoDelete, IReadOnlyDictionary<string, object> arguments)
         {
             ThrowIfDisposed();
             _innerChannel.ExchangeDeclare(exchange, type, durable, autoDelete, arguments);
             _connection.RecordExchange(new RecordedExchange(exchange, type, durable, autoDelete, arguments));
         }
 
-        public void ExchangeDeclareNoWait(string exchange, string type, bool durable, bool autoDelete, IDictionary<string, object> arguments)
+        public void ExchangeDeclareNoWait(string exchange, string type, bool durable, bool autoDelete, IReadOnlyDictionary<string, object> arguments)
         {
             ThrowIfDisposed();
             _innerChannel.ExchangeDeclareNoWait(exchange, type, durable, autoDelete, arguments);
@@ -325,7 +325,7 @@ namespace RabbitMQ.Client.Impl
             _connection.DeleteRecordedExchange(exchange);
         }
 
-        public void ExchangeUnbind(string destination, string source, string routingKey, IDictionary<string, object> arguments)
+        public void ExchangeUnbind(string destination, string source, string routingKey, IReadOnlyDictionary<string, object> arguments)
         {
             ThrowIfDisposed();
             _connection.DeleteRecordedBinding(new RecordedBinding(false, destination, source, routingKey, arguments));
@@ -333,20 +333,20 @@ namespace RabbitMQ.Client.Impl
             _connection.DeleteAutoDeleteExchange(source);
         }
 
-        public void ExchangeUnbindNoWait(string destination, string source, string routingKey, IDictionary<string, object> arguments)
+        public void ExchangeUnbindNoWait(string destination, string source, string routingKey, IReadOnlyDictionary<string, object> arguments)
             => InnerChannel.ExchangeUnbind(destination, source, routingKey, arguments);
 
-        public void QueueBind(string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
+        public void QueueBind(string queue, string exchange, string routingKey, IReadOnlyDictionary<string, object> arguments)
         {
             ThrowIfDisposed();
             _connection.RecordBinding(new RecordedBinding(true, queue, exchange, routingKey, arguments));
             _innerChannel.QueueBind(queue, exchange, routingKey, arguments);
         }
 
-        public void QueueBindNoWait(string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
+        public void QueueBindNoWait(string queue, string exchange, string routingKey, IReadOnlyDictionary<string, object> arguments)
             => InnerChannel.QueueBind(queue, exchange, routingKey, arguments);
 
-        public QueueDeclareOk QueueDeclare(string queue, bool durable, bool exclusive, bool autoDelete, IDictionary<string, object> arguments)
+        public QueueDeclareOk QueueDeclare(string queue, bool durable, bool exclusive, bool autoDelete, IReadOnlyDictionary<string, object> arguments)
         {
             ThrowIfDisposed();
             QueueDeclareOk result = _innerChannel.QueueDeclare(queue, durable, exclusive, autoDelete, arguments);
@@ -354,7 +354,7 @@ namespace RabbitMQ.Client.Impl
             return result;
         }
 
-        public void QueueDeclareNoWait(string queue, bool durable, bool exclusive, bool autoDelete, IDictionary<string, object> arguments)
+        public void QueueDeclareNoWait(string queue, bool durable, bool exclusive, bool autoDelete, IReadOnlyDictionary<string, object> arguments)
         {
             ThrowIfDisposed();
             _innerChannel.QueueDeclareNoWait(queue, durable, exclusive, autoDelete, arguments);
@@ -387,7 +387,7 @@ namespace RabbitMQ.Client.Impl
         public uint QueuePurge(string queue)
             => InnerChannel.QueuePurge(queue);
 
-        public void QueueUnbind(string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
+        public void QueueUnbind(string queue, string exchange, string routingKey, IReadOnlyDictionary<string, object> arguments)
         {
             ThrowIfDisposed();
             _connection.DeleteRecordedBinding(new RecordedBinding(true, queue, exchange, routingKey, arguments));

--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -98,7 +98,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public ushort ChannelMax => _sessionManager.ChannelMax;
 
-        public IDictionary<string, object?> ClientProperties { get; private set; }
+        public IReadOnlyDictionary<string, object?> ClientProperties { get; private set; }
 
         public AmqpTcpEndpoint Endpoint => _frameHandler.Endpoint;
 
@@ -109,7 +109,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public int LocalPort => _frameHandler.LocalPort;
         public int RemotePort => _frameHandler.RemotePort;
 
-        public IDictionary<string, object?>? ServerProperties { get; private set; }
+        public IReadOnlyDictionary<string, object?>? ServerProperties { get; private set; }
 
         public IList<ShutdownReportEntry> ShutdownReport => _shutdownReport;
         private ShutdownReportEntry[] _shutdownReport = Array.Empty<ShutdownReportEntry>();

--- a/projects/RabbitMQ.Client/client/impl/EmptyBasicProperty.cs
+++ b/projects/RabbitMQ.Client/client/impl/EmptyBasicProperty.cs
@@ -29,7 +29,7 @@ namespace RabbitMQ.Client.client.impl
         public string? CorrelationId => default;
         public DeliveryModes DeliveryMode => default;
         public string? Expiration => default;
-        public IDictionary<string, object?>? Headers => default;
+        public IReadOnlyDictionary<string, object?>? Headers => default;
         public string? MessageId => default;
         public bool Persistent => default;
         public byte Priority => default;

--- a/projects/RabbitMQ.Client/client/impl/ModelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ModelBase.cs
@@ -278,7 +278,7 @@ namespace RabbitMQ.Client.Impl
             return k.m_result;
         }
 
-        internal ConnectionSecureOrTune ConnectionStartOk(IDictionary<string, object> clientProperties, string mechanism, byte[] response, string locale)
+        internal ConnectionSecureOrTune ConnectionStartOk(IReadOnlyDictionary<string, object> clientProperties, string mechanism, byte[] response, string locale)
         {
             var k = new ConnectionStartRpcContinuation();
             lock (_rpcLock)
@@ -793,7 +793,7 @@ namespace RabbitMQ.Client.Impl
 
         public abstract void _Private_BasicCancel(string consumerTag, bool nowait);
 
-        public abstract void _Private_BasicConsume(string queue, string consumerTag, bool noLocal, bool autoAck, bool exclusive, bool nowait, IDictionary<string, object> arguments);
+        public abstract void _Private_BasicConsume(string queue, string consumerTag, bool noLocal, bool autoAck, bool exclusive, bool nowait, IReadOnlyDictionary<string, object> arguments);
 
         public abstract void _Private_BasicGet(string queue, bool autoAck);
 
@@ -815,21 +815,21 @@ namespace RabbitMQ.Client.Impl
 
         public abstract void _Private_ConnectionSecureOk(byte[] response);
 
-        public abstract void _Private_ConnectionStartOk(IDictionary<string, object> clientProperties, string mechanism, byte[] response, string locale);
+        public abstract void _Private_ConnectionStartOk(IReadOnlyDictionary<string, object> clientProperties, string mechanism, byte[] response, string locale);
 
         public abstract void _Private_UpdateSecret(byte[] @newSecret, string @reason);
 
-        public abstract void _Private_ExchangeBind(string destination, string source, string routingKey, bool nowait, IDictionary<string, object> arguments);
+        public abstract void _Private_ExchangeBind(string destination, string source, string routingKey, bool nowait, IReadOnlyDictionary<string, object> arguments);
 
-        public abstract void _Private_ExchangeDeclare(string exchange, string type, bool passive, bool durable, bool autoDelete, bool @internal, bool nowait, IDictionary<string, object> arguments);
+        public abstract void _Private_ExchangeDeclare(string exchange, string type, bool passive, bool durable, bool autoDelete, bool @internal, bool nowait, IReadOnlyDictionary<string, object> arguments);
 
         public abstract void _Private_ExchangeDelete(string exchange, bool ifUnused, bool nowait);
 
-        public abstract void _Private_ExchangeUnbind(string destination, string source, string routingKey, bool nowait, IDictionary<string, object> arguments);
+        public abstract void _Private_ExchangeUnbind(string destination, string source, string routingKey, bool nowait, IReadOnlyDictionary<string, object> arguments);
 
-        public abstract void _Private_QueueBind(string queue, string exchange, string routingKey, bool nowait, IDictionary<string, object> arguments);
+        public abstract void _Private_QueueBind(string queue, string exchange, string routingKey, bool nowait, IReadOnlyDictionary<string, object> arguments);
 
-        public abstract void _Private_QueueDeclare(string queue, bool passive, bool durable, bool exclusive, bool autoDelete, bool nowait, IDictionary<string, object> arguments);
+        public abstract void _Private_QueueDeclare(string queue, bool passive, bool durable, bool exclusive, bool autoDelete, bool nowait, IReadOnlyDictionary<string, object> arguments);
 
         public abstract uint _Private_QueueDelete(string queue, bool ifUnused, bool ifEmpty, bool nowait);
 
@@ -855,7 +855,7 @@ namespace RabbitMQ.Client.Impl
             ConsumerDispatcher.GetAndRemoveConsumer(consumerTag);
         }
 
-        public string BasicConsume(string queue, bool autoAck, string consumerTag, bool noLocal, bool exclusive, IDictionary<string, object> arguments, IBasicConsumer consumer)
+        public string BasicConsume(string queue, bool autoAck, string consumerTag, bool noLocal, bool exclusive, IReadOnlyDictionary<string, object> arguments, IBasicConsumer consumer)
         {
             // TODO: Replace with flag
             if (ConsumerDispatcher is AsyncConsumerDispatcher)
@@ -972,22 +972,22 @@ namespace RabbitMQ.Client.Impl
             _Private_ConfirmSelect(false);
         }
 
-        public void ExchangeBind(string destination, string source, string routingKey, IDictionary<string, object> arguments)
+        public void ExchangeBind(string destination, string source, string routingKey, IReadOnlyDictionary<string, object> arguments)
         {
             _Private_ExchangeBind(destination, source, routingKey, false, arguments);
         }
 
-        public void ExchangeBindNoWait(string destination, string source, string routingKey, IDictionary<string, object> arguments)
+        public void ExchangeBindNoWait(string destination, string source, string routingKey, IReadOnlyDictionary<string, object> arguments)
         {
             _Private_ExchangeBind(destination, source, routingKey, true, arguments);
         }
 
-        public void ExchangeDeclare(string exchange, string type, bool durable, bool autoDelete, IDictionary<string, object> arguments)
+        public void ExchangeDeclare(string exchange, string type, bool durable, bool autoDelete, IReadOnlyDictionary<string, object> arguments)
         {
             _Private_ExchangeDeclare(exchange, type, false, durable, autoDelete, false, false, arguments);
         }
 
-        public void ExchangeDeclareNoWait(string exchange, string type, bool durable, bool autoDelete, IDictionary<string, object> arguments)
+        public void ExchangeDeclareNoWait(string exchange, string type, bool durable, bool autoDelete, IReadOnlyDictionary<string, object> arguments)
         {
             _Private_ExchangeDeclare(exchange, type, false, durable, autoDelete, false, true, arguments);
         }
@@ -1007,32 +1007,32 @@ namespace RabbitMQ.Client.Impl
             _Private_ExchangeDelete(exchange, ifUnused, true);
         }
 
-        public void ExchangeUnbind(string destination, string source, string routingKey, IDictionary<string, object> arguments)
+        public void ExchangeUnbind(string destination, string source, string routingKey, IReadOnlyDictionary<string, object> arguments)
         {
             _Private_ExchangeUnbind(destination, source, routingKey, false, arguments);
         }
 
-        public void ExchangeUnbindNoWait(string destination, string source, string routingKey, IDictionary<string, object> arguments)
+        public void ExchangeUnbindNoWait(string destination, string source, string routingKey, IReadOnlyDictionary<string, object> arguments)
         {
             _Private_ExchangeUnbind(destination, source, routingKey, true, arguments);
         }
 
-        public void QueueBind(string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
+        public void QueueBind(string queue, string exchange, string routingKey, IReadOnlyDictionary<string, object> arguments)
         {
             _Private_QueueBind(queue, exchange, routingKey, false, arguments);
         }
 
-        public void QueueBindNoWait(string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
+        public void QueueBindNoWait(string queue, string exchange, string routingKey, IReadOnlyDictionary<string, object> arguments)
         {
             _Private_QueueBind(queue, exchange, routingKey, true, arguments);
         }
 
-        public QueueDeclareOk QueueDeclare(string queue, bool durable, bool exclusive, bool autoDelete, IDictionary<string, object> arguments)
+        public QueueDeclareOk QueueDeclare(string queue, bool durable, bool exclusive, bool autoDelete, IReadOnlyDictionary<string, object> arguments)
         {
             return QueueDeclare(queue, false, durable, exclusive, autoDelete, arguments);
         }
 
-        public void QueueDeclareNoWait(string queue, bool durable, bool exclusive, bool autoDelete, IDictionary<string, object> arguments)
+        public void QueueDeclareNoWait(string queue, bool durable, bool exclusive, bool autoDelete, IReadOnlyDictionary<string, object> arguments)
         {
             _Private_QueueDeclare(queue, false, durable, exclusive, autoDelete, true, arguments);
         }
@@ -1069,7 +1069,7 @@ namespace RabbitMQ.Client.Impl
             return _Private_QueuePurge(queue, false);
         }
 
-        public abstract void QueueUnbind(string queue, string exchange, string routingKey, IDictionary<string, object> arguments);
+        public abstract void QueueUnbind(string queue, string exchange, string routingKey, IReadOnlyDictionary<string, object> arguments);
 
         public abstract void TxCommit();
 
@@ -1160,7 +1160,7 @@ namespace RabbitMQ.Client.Impl
             }
         }
 
-        private QueueDeclareOk QueueDeclare(string queue, bool passive, bool durable, bool exclusive, bool autoDelete, IDictionary<string, object> arguments)
+        private QueueDeclareOk QueueDeclare(string queue, bool passive, bool durable, bool exclusive, bool autoDelete, IReadOnlyDictionary<string, object> arguments)
         {
             var k = new QueueDeclareRpcContinuation();
             lock (_rpcLock)

--- a/projects/RabbitMQ.Client/client/impl/RecordedBinding.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedBinding.cs
@@ -41,12 +41,12 @@ namespace RabbitMQ.Client.Impl
         private readonly string _destination;
         private readonly string _source;
         private readonly string _routingKey;
-        private readonly IDictionary<string, object>? _arguments;
+        private readonly IReadOnlyDictionary<string, object>? _arguments;
 
         public string Destination => _destination;
         public string Source => _source;
 
-        public RecordedBinding(bool isQueueBinding, string destination, string source, string routingKey, IDictionary<string, object>? arguments)
+        public RecordedBinding(bool isQueueBinding, string destination, string source, string routingKey, IReadOnlyDictionary<string, object>? arguments)
         {
             _isQueueBinding = isQueueBinding;
             _destination = destination;

--- a/projects/RabbitMQ.Client/client/impl/RecordedConsumer.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedConsumer.cs
@@ -42,9 +42,9 @@ namespace RabbitMQ.Client.Impl
         public bool AutoAck { get; }
         public string ConsumerTag { get; }
         public bool Exclusive { get; }
-        public IDictionary<string, object>? Arguments { get; }
+        public IReadOnlyDictionary<string, object>? Arguments { get; }
 
-        public RecordedConsumer(AutorecoveringModel channel, IBasicConsumer consumer, string queue, bool autoAck, string consumerTag, bool exclusive, IDictionary<string, object>? arguments)
+        public RecordedConsumer(AutorecoveringModel channel, IBasicConsumer consumer, string queue, bool autoAck, string consumerTag, bool exclusive, IReadOnlyDictionary<string, object>? arguments)
         {
             Channel = channel;
             Consumer = consumer;

--- a/projects/RabbitMQ.Client/client/impl/RecordedExchange.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedExchange.cs
@@ -40,12 +40,12 @@ namespace RabbitMQ.Client.Impl
         private readonly string _type;
         private readonly bool _durable;
         private readonly bool _isAutoDelete;
-        private readonly IDictionary<string, object>? _arguments;
+        private readonly IReadOnlyDictionary<string, object>? _arguments;
 
         public string Name => _name;
         public bool IsAutoDelete => _isAutoDelete;
 
-        public RecordedExchange(string name, string type, bool durable, bool isAutoDelete, IDictionary<string, object>? arguments)
+        public RecordedExchange(string name, string type, bool durable, bool isAutoDelete, IReadOnlyDictionary<string, object>? arguments)
         {
             _name = name;
             _type = type;

--- a/projects/RabbitMQ.Client/client/impl/RecordedQueue.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedQueue.cs
@@ -37,7 +37,7 @@ namespace RabbitMQ.Client.Impl
     internal readonly struct RecordedQueue
     {
         private readonly string _name;
-        private readonly IDictionary<string, object>? _arguments;
+        private readonly IReadOnlyDictionary<string, object>? _arguments;
         private readonly bool _durable;
         private readonly bool _exclusive;
         private readonly bool _isAutoDelete;
@@ -47,7 +47,7 @@ namespace RabbitMQ.Client.Impl
         public bool IsAutoDelete => _isAutoDelete;
         public bool IsServerNamed => _isServerNamed;
 
-        public RecordedQueue(string name, bool isServerNamed, bool durable, bool exclusive, bool autoDelete, IDictionary<string, object>? arguments)
+        public RecordedQueue(string name, bool isServerNamed, bool durable, bool exclusive, bool autoDelete, IReadOnlyDictionary<string, object>? arguments)
         {
             _name = name;
             _isServerNamed = isServerNamed;

--- a/projects/RabbitMQ.Client/client/impl/WireFormatting.Write.cs
+++ b/projects/RabbitMQ.Client/client/impl/WireFormatting.Write.cs
@@ -158,7 +158,7 @@ namespace RabbitMQ.Client.Impl
                         destination = (byte)'f';
                         NetworkOrderSerializer.WriteSingle(ref fieldValue, val);
                         return 5;
-                    case IDictionary<string, object> val:
+                    case IReadOnlyDictionary<string, object> val:
                         destination = (byte)'F';
                         return 1 + WriteTable(ref fieldValue, val);
                     case IList val:
@@ -226,7 +226,7 @@ namespace RabbitMQ.Client.Impl
                     return 5;
                 case byte[] val:
                     return 5 + val.Length;
-                case IDictionary<string, object> val:
+                case IReadOnlyDictionary<string, object> val:
                     return 1 + GetTableByteCount(val);
                 case IList val:
                     return 1 + GetArrayByteCount(val);
@@ -399,7 +399,7 @@ namespace RabbitMQ.Client.Impl
             return bytesWritten;
         }
 
-        public static int WriteTable(ref byte destination, IDictionary<string, object> val)
+        public static int WriteTable(ref byte destination, IReadOnlyDictionary<string, object> val)
         {
             if (val is null || val.Count == 0)
             {
@@ -447,7 +447,7 @@ namespace RabbitMQ.Client.Impl
             return byteCount;
         }
 
-        public static int GetTableByteCount(IDictionary<string, object> val)
+        public static int GetTableByteCount(IReadOnlyDictionary<string, object> val)
         {
             if (val is null || val.Count == 0)
             {

--- a/projects/Unit/APIApproval.Approve.verified.txt
+++ b/projects/Unit/APIApproval.Approve.verified.txt
@@ -76,7 +76,7 @@ namespace RabbitMQ.Client
         public string? CorrelationId { get; set; }
         public RabbitMQ.Client.DeliveryModes DeliveryMode { get; set; }
         public string? Expiration { get; set; }
-        public System.Collections.Generic.IDictionary<string, object?>? Headers { get; set; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?>? Headers { get; set; }
         public string? MessageId { get; set; }
         public bool Persistent { get; set; }
         public byte Priority { get; set; }
@@ -347,7 +347,7 @@ namespace RabbitMQ.Client
         new string? CorrelationId { get; set; }
         new RabbitMQ.Client.DeliveryModes DeliveryMode { get; set; }
         new string? Expiration { get; set; }
-        new System.Collections.Generic.IDictionary<string, object?>? Headers { get; set; }
+        new System.Collections.Generic.IReadOnlyDictionary<string, object?>? Headers { get; set; }
         new string? MessageId { get; set; }
         new bool Persistent { get; set; }
         new byte Priority { get; set; }
@@ -374,7 +374,7 @@ namespace RabbitMQ.Client
     public interface IConnection : RabbitMQ.Client.INetworkConnection, System.IDisposable
     {
         ushort ChannelMax { get; }
-        System.Collections.Generic.IDictionary<string, object> ClientProperties { get; }
+        System.Collections.Generic.IReadOnlyDictionary<string, object> ClientProperties { get; }
         string ClientProvidedName { get; }
         RabbitMQ.Client.ShutdownEventArgs CloseReason { get; }
         RabbitMQ.Client.AmqpTcpEndpoint Endpoint { get; }
@@ -382,7 +382,7 @@ namespace RabbitMQ.Client
         System.TimeSpan Heartbeat { get; }
         bool IsOpen { get; }
         RabbitMQ.Client.IProtocol Protocol { get; }
-        System.Collections.Generic.IDictionary<string, object> ServerProperties { get; }
+        System.Collections.Generic.IReadOnlyDictionary<string, object> ServerProperties { get; }
         System.Collections.Generic.IList<RabbitMQ.Client.ShutdownReportEntry> ShutdownReport { get; }
         event System.EventHandler<RabbitMQ.Client.Events.CallbackExceptionEventArgs> CallbackException;
         event System.EventHandler<RabbitMQ.Client.Events.ConnectionBlockedEventArgs> ConnectionBlocked;
@@ -453,7 +453,7 @@ namespace RabbitMQ.Client
         void BasicAck(ulong deliveryTag, bool multiple);
         void BasicCancel(string consumerTag);
         void BasicCancelNoWait(string consumerTag);
-        string BasicConsume(string queue, bool autoAck, string consumerTag, bool noLocal, bool exclusive, System.Collections.Generic.IDictionary<string, object> arguments, RabbitMQ.Client.IBasicConsumer consumer);
+        string BasicConsume(string queue, bool autoAck, string consumerTag, bool noLocal, bool exclusive, System.Collections.Generic.IReadOnlyDictionary<string, object> arguments, RabbitMQ.Client.IBasicConsumer consumer);
         RabbitMQ.Client.BasicGetResult BasicGet(string queue, bool autoAck);
         void BasicNack(ulong deliveryTag, bool multiple, bool requeue);
         void BasicPublish<TProperties>(RabbitMQ.Client.CachedString exchange, RabbitMQ.Client.CachedString routingKey, in TProperties basicProperties, System.ReadOnlyMemory<byte> body = default, bool mandatory = false)
@@ -467,25 +467,25 @@ namespace RabbitMQ.Client
         void Close(ushort replyCode, string replyText, bool abort);
         void ConfirmSelect();
         uint ConsumerCount(string queue);
-        void ExchangeBind(string destination, string source, string routingKey, System.Collections.Generic.IDictionary<string, object> arguments);
-        void ExchangeBindNoWait(string destination, string source, string routingKey, System.Collections.Generic.IDictionary<string, object> arguments);
-        void ExchangeDeclare(string exchange, string type, bool durable, bool autoDelete, System.Collections.Generic.IDictionary<string, object> arguments);
-        void ExchangeDeclareNoWait(string exchange, string type, bool durable, bool autoDelete, System.Collections.Generic.IDictionary<string, object> arguments);
+        void ExchangeBind(string destination, string source, string routingKey, System.Collections.Generic.IReadOnlyDictionary<string, object> arguments);
+        void ExchangeBindNoWait(string destination, string source, string routingKey, System.Collections.Generic.IReadOnlyDictionary<string, object> arguments);
+        void ExchangeDeclare(string exchange, string type, bool durable, bool autoDelete, System.Collections.Generic.IReadOnlyDictionary<string, object> arguments);
+        void ExchangeDeclareNoWait(string exchange, string type, bool durable, bool autoDelete, System.Collections.Generic.IReadOnlyDictionary<string, object> arguments);
         void ExchangeDeclarePassive(string exchange);
         void ExchangeDelete(string exchange, bool ifUnused);
         void ExchangeDeleteNoWait(string exchange, bool ifUnused);
-        void ExchangeUnbind(string destination, string source, string routingKey, System.Collections.Generic.IDictionary<string, object> arguments);
-        void ExchangeUnbindNoWait(string destination, string source, string routingKey, System.Collections.Generic.IDictionary<string, object> arguments);
+        void ExchangeUnbind(string destination, string source, string routingKey, System.Collections.Generic.IReadOnlyDictionary<string, object> arguments);
+        void ExchangeUnbindNoWait(string destination, string source, string routingKey, System.Collections.Generic.IReadOnlyDictionary<string, object> arguments);
         uint MessageCount(string queue);
-        void QueueBind(string queue, string exchange, string routingKey, System.Collections.Generic.IDictionary<string, object> arguments);
-        void QueueBindNoWait(string queue, string exchange, string routingKey, System.Collections.Generic.IDictionary<string, object> arguments);
-        RabbitMQ.Client.QueueDeclareOk QueueDeclare(string queue, bool durable, bool exclusive, bool autoDelete, System.Collections.Generic.IDictionary<string, object> arguments);
-        void QueueDeclareNoWait(string queue, bool durable, bool exclusive, bool autoDelete, System.Collections.Generic.IDictionary<string, object> arguments);
+        void QueueBind(string queue, string exchange, string routingKey, System.Collections.Generic.IReadOnlyDictionary<string, object> arguments);
+        void QueueBindNoWait(string queue, string exchange, string routingKey, System.Collections.Generic.IReadOnlyDictionary<string, object> arguments);
+        RabbitMQ.Client.QueueDeclareOk QueueDeclare(string queue, bool durable, bool exclusive, bool autoDelete, System.Collections.Generic.IReadOnlyDictionary<string, object> arguments);
+        void QueueDeclareNoWait(string queue, bool durable, bool exclusive, bool autoDelete, System.Collections.Generic.IReadOnlyDictionary<string, object> arguments);
         RabbitMQ.Client.QueueDeclareOk QueueDeclarePassive(string queue);
         uint QueueDelete(string queue, bool ifUnused, bool ifEmpty);
         void QueueDeleteNoWait(string queue, bool ifUnused, bool ifEmpty);
         uint QueuePurge(string queue);
-        void QueueUnbind(string queue, string exchange, string routingKey, System.Collections.Generic.IDictionary<string, object> arguments);
+        void QueueUnbind(string queue, string exchange, string routingKey, System.Collections.Generic.IReadOnlyDictionary<string, object> arguments);
         void TxCommit();
         void TxRollback();
         void TxSelect();
@@ -498,26 +498,26 @@ namespace RabbitMQ.Client
         public static void Abort(this RabbitMQ.Client.IModel model, ushort replyCode, string replyText) { }
         public static string BasicConsume(this RabbitMQ.Client.IModel model, string queue, bool autoAck, RabbitMQ.Client.IBasicConsumer consumer) { }
         public static string BasicConsume(this RabbitMQ.Client.IModel model, string queue, bool autoAck, string consumerTag, RabbitMQ.Client.IBasicConsumer consumer) { }
-        public static string BasicConsume(this RabbitMQ.Client.IModel model, string queue, bool autoAck, string consumerTag, System.Collections.Generic.IDictionary<string, object> arguments, RabbitMQ.Client.IBasicConsumer consumer) { }
-        public static string BasicConsume(this RabbitMQ.Client.IModel model, RabbitMQ.Client.IBasicConsumer consumer, string queue, bool autoAck = false, string consumerTag = "", bool noLocal = false, bool exclusive = false, System.Collections.Generic.IDictionary<string, object> arguments = null) { }
+        public static string BasicConsume(this RabbitMQ.Client.IModel model, string queue, bool autoAck, string consumerTag, System.Collections.Generic.IReadOnlyDictionary<string, object> arguments, RabbitMQ.Client.IBasicConsumer consumer) { }
+        public static string BasicConsume(this RabbitMQ.Client.IModel model, RabbitMQ.Client.IBasicConsumer consumer, string queue, bool autoAck = false, string consumerTag = "", bool noLocal = false, bool exclusive = false, System.Collections.Generic.IReadOnlyDictionary<string, object> arguments = null) { }
         public static void BasicPublish(this RabbitMQ.Client.IModel model, RabbitMQ.Client.CachedString exchange, RabbitMQ.Client.CachedString routingKey, System.ReadOnlyMemory<byte> body = default, bool mandatory = false) { }
         public static void BasicPublish(this RabbitMQ.Client.IModel model, string exchange, string routingKey, System.ReadOnlyMemory<byte> body = default, bool mandatory = false) { }
         public static void BasicPublish<T>(this RabbitMQ.Client.IModel model, RabbitMQ.Client.PublicationAddress addr, in T basicProperties, System.ReadOnlyMemory<byte> body)
             where T : RabbitMQ.Client.IReadOnlyBasicProperties, RabbitMQ.Client.IAmqpHeader { }
         public static void Close(this RabbitMQ.Client.IModel model) { }
         public static void Close(this RabbitMQ.Client.IModel model, ushort replyCode, string replyText) { }
-        public static void ExchangeBind(this RabbitMQ.Client.IModel model, string destination, string source, string routingKey, System.Collections.Generic.IDictionary<string, object> arguments = null) { }
-        public static void ExchangeBindNoWait(this RabbitMQ.Client.IModel model, string destination, string source, string routingKey, System.Collections.Generic.IDictionary<string, object> arguments = null) { }
-        public static void ExchangeDeclare(this RabbitMQ.Client.IModel model, string exchange, string type, bool durable = false, bool autoDelete = false, System.Collections.Generic.IDictionary<string, object> arguments = null) { }
-        public static void ExchangeDeclareNoWait(this RabbitMQ.Client.IModel model, string exchange, string type, bool durable = false, bool autoDelete = false, System.Collections.Generic.IDictionary<string, object> arguments = null) { }
+        public static void ExchangeBind(this RabbitMQ.Client.IModel model, string destination, string source, string routingKey, System.Collections.Generic.IReadOnlyDictionary<string, object> arguments = null) { }
+        public static void ExchangeBindNoWait(this RabbitMQ.Client.IModel model, string destination, string source, string routingKey, System.Collections.Generic.IReadOnlyDictionary<string, object> arguments = null) { }
+        public static void ExchangeDeclare(this RabbitMQ.Client.IModel model, string exchange, string type, bool durable = false, bool autoDelete = false, System.Collections.Generic.IReadOnlyDictionary<string, object> arguments = null) { }
+        public static void ExchangeDeclareNoWait(this RabbitMQ.Client.IModel model, string exchange, string type, bool durable = false, bool autoDelete = false, System.Collections.Generic.IReadOnlyDictionary<string, object> arguments = null) { }
         public static void ExchangeDelete(this RabbitMQ.Client.IModel model, string exchange, bool ifUnused = false) { }
         public static void ExchangeDeleteNoWait(this RabbitMQ.Client.IModel model, string exchange, bool ifUnused = false) { }
-        public static void ExchangeUnbind(this RabbitMQ.Client.IModel model, string destination, string source, string routingKey, System.Collections.Generic.IDictionary<string, object> arguments = null) { }
-        public static void QueueBind(this RabbitMQ.Client.IModel model, string queue, string exchange, string routingKey, System.Collections.Generic.IDictionary<string, object> arguments = null) { }
-        public static RabbitMQ.Client.QueueDeclareOk QueueDeclare(this RabbitMQ.Client.IModel model, string queue = "", bool durable = false, bool exclusive = true, bool autoDelete = true, System.Collections.Generic.IDictionary<string, object> arguments = null) { }
+        public static void ExchangeUnbind(this RabbitMQ.Client.IModel model, string destination, string source, string routingKey, System.Collections.Generic.IReadOnlyDictionary<string, object> arguments = null) { }
+        public static void QueueBind(this RabbitMQ.Client.IModel model, string queue, string exchange, string routingKey, System.Collections.Generic.IReadOnlyDictionary<string, object> arguments = null) { }
+        public static RabbitMQ.Client.QueueDeclareOk QueueDeclare(this RabbitMQ.Client.IModel model, string queue = "", bool durable = false, bool exclusive = true, bool autoDelete = true, System.Collections.Generic.IReadOnlyDictionary<string, object> arguments = null) { }
         public static uint QueueDelete(this RabbitMQ.Client.IModel model, string queue, bool ifUnused = false, bool ifEmpty = false) { }
         public static void QueueDeleteNoWait(this RabbitMQ.Client.IModel model, string queue, bool ifUnused = false, bool ifEmpty = false) { }
-        public static void QueueUnbind(this RabbitMQ.Client.IModel model, string queue, string exchange, string routingKey, System.Collections.Generic.IDictionary<string, object> arguments = null) { }
+        public static void QueueUnbind(this RabbitMQ.Client.IModel model, string queue, string exchange, string routingKey, System.Collections.Generic.IReadOnlyDictionary<string, object> arguments = null) { }
     }
     public interface INetworkConnection
     {
@@ -541,7 +541,7 @@ namespace RabbitMQ.Client
         string? CorrelationId { get; }
         RabbitMQ.Client.DeliveryModes DeliveryMode { get; }
         string? Expiration { get; }
-        System.Collections.Generic.IDictionary<string, object?>? Headers { get; }
+        System.Collections.Generic.IReadOnlyDictionary<string, object?>? Headers { get; }
         string? MessageId { get; }
         bool Persistent { get; }
         byte Priority { get; }
@@ -624,7 +624,7 @@ namespace RabbitMQ.Client
         public string? CorrelationId { get; }
         public RabbitMQ.Client.DeliveryModes DeliveryMode { get; }
         public string? Expiration { get; }
-        public System.Collections.Generic.IDictionary<string, object?>? Headers { get; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?>? Headers { get; }
         public string? MessageId { get; }
         public bool Persistent { get; }
         public byte Priority { get; }

--- a/projects/Unit/TestBasicProperties.cs
+++ b/projects/Unit/TestBasicProperties.cs
@@ -210,8 +210,11 @@ namespace RabbitMQ.Client.Unit
             using (IModel m = c.CreateModel())
             {
                 QueueDeclareOk q = m.QueueDeclare();
-                var bp = new BasicProperties() { Headers = new Dictionary<string, object>() };
-                bp.Headers["Hello"] = "World";
+                var headers = new Dictionary<string, object>()
+                {
+                    ["Hello"] = "World",
+                };
+                var bp = new BasicProperties() { Headers = headers };
                 byte[] sendBody = Encoding.UTF8.GetBytes("hi");
                 byte[] consumeBody = null;
                 var consumer = new EventingBasicConsumer(m);

--- a/projects/Unit/TestFieldTableFormattingGeneric.cs
+++ b/projects/Unit/TestFieldTableFormattingGeneric.cs
@@ -46,23 +46,23 @@ namespace RabbitMQ.Client.Unit
         [Fact]
         public void TestStandardTypes()
         {
-            IDictionary<string, object> t = new Dictionary<string, object>
+            IReadOnlyDictionary<string, object> t = new Dictionary<string, object>
             {
                 ["string"] = "Hello",
                 ["int"] = 1234,
                 ["uint"] = 1234u,
                 ["decimal"] = 12.34m,
-                ["timestamp"] = new AmqpTimestamp(0)
+                ["timestamp"] = new AmqpTimestamp(0),
+                ["fieldarray"] = new List<object>
+                {
+                    "longstring",
+                    1234
+                },
+                ["fieldtable"] = new Dictionary<string, object>()
+                {
+                    ["test"] = "test",
+                },
             };
-            IDictionary<string, object> t2 = new Dictionary<string, object>();
-            t["fieldtable"] = t2;
-            t2["test"] = "test";
-            IList array = new List<object>
-            {
-                "longstring",
-                1234
-            };
-            t["fieldarray"] = array;
             int bytesNeeded = WireFormatting.GetTableByteCount(t);
             byte[] bytes = new byte[bytesNeeded];
             WireFormatting.WriteTable(ref bytes.GetStart(), t);
@@ -83,7 +83,7 @@ namespace RabbitMQ.Client.Unit
         [Fact]
         public void TestTableEncoding_S()
         {
-            IDictionary<string, object> t = new Dictionary<string, object>
+            IReadOnlyDictionary<string, object> t = new Dictionary<string, object>
             {
                 ["a"] = "bc"
             };
@@ -103,7 +103,7 @@ namespace RabbitMQ.Client.Unit
         [Fact]
         public void TestTableEncoding_x()
         {
-            IDictionary<string, object> t = new Dictionary<string, object>
+            IReadOnlyDictionary<string, object> t = new Dictionary<string, object>
             {
                 ["a"] = new BinaryTableValue(new byte[] { 0xaa, 0x55 })
             };
@@ -123,7 +123,8 @@ namespace RabbitMQ.Client.Unit
         [Fact]
         public void TestQpidJmsTypes()
         {
-            IDictionary<string, object> t = new Dictionary<string, object>
+            byte[] xbytes = new byte[] { 0xaa, 0x55 };
+            IReadOnlyDictionary<string, object> t = new Dictionary<string, object>
             {
                 ["B"] = (byte)255,
                 ["b"] = (sbyte)-128,
@@ -132,11 +133,11 @@ namespace RabbitMQ.Client.Unit
                 ["l"] = (long)123,
                 ["s"] = (short)123,
                 ["u"] = (ushort)123,
-                ["t"] = true
+                ["t"] = true,
+                ["x"] = new BinaryTableValue(xbytes),
+                ["V"] = null,
             };
-            byte[] xbytes = new byte[] { 0xaa, 0x55 };
-            t["x"] = new BinaryTableValue(xbytes);
-            t["V"] = null;
+
             int bytesNeeded = WireFormatting.GetTableByteCount(t);
             byte[] bytes = new byte[bytesNeeded];
             WireFormatting.WriteTable(ref bytes.GetStart(), t);

--- a/projects/Unit/TestUpdateSecret.cs
+++ b/projects/Unit/TestUpdateSecret.cs
@@ -60,7 +60,7 @@ namespace RabbitMQ.Client.Unit
 
         private bool RabbitMQ380OrHigher()
         {
-            System.Collections.Generic.IDictionary<string, object> properties = _conn.ServerProperties;
+            System.Collections.Generic.IReadOnlyDictionary<string, object> properties = _conn.ServerProperties;
 
             if (properties.TryGetValue("version", out object versionVal))
             {


### PR DESCRIPTION
Because IDictionary is used only for enumeration, then the interface IReadOnlyDictionarty is sufficient.