### PR TITLE
Add event for recovering consumer

### DIFF
--- a/projects/RabbitMQ.Client/client/events/RecoveringConsumerEventArgs.cs
+++ b/projects/RabbitMQ.Client/client/events/RecoveringConsumerEventArgs.cs
@@ -4,7 +4,7 @@
 // The APL v2.0:
 //
 //---------------------------------------------------------------------------
-//   Copyright (c) 2007-2020 VMware, Inc.
+//   Copyright (c) 2007-2023 VMware, Inc.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -26,25 +26,39 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-//  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
+//  Copyright (c) 2007-2023 VMware, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 
-using RabbitMQ.Client.Events;
-
-namespace RabbitMQ.Client
+namespace RabbitMQ.Client.Events
 {
     /// <summary>
-    /// Interface to an auto-recovering AMQP connection.
+    /// Event related to consumer recovery, during automatic recovery.
     /// </summary>
-    public interface IAutorecoveringConnection : IConnection
+    public class RecoveringConsumerEventArgs : EventArgs
     {
-        event EventHandler<EventArgs> RecoverySucceeded;
-        event EventHandler<ConnectionRecoveryErrorEventArgs> ConnectionRecoveryError;
+        /// <summary>
+        /// Constructs an event containing the consumer arguments and consumer
+        /// tag of the consumer this event relates to.
+        /// </summary>
+        /// <param name="consumerArguments">Consumer arguments of the consumer for this event</param>
+        /// <param name="consumerTag">Consumer tag of the consumer for this event</param>
+        public RecoveringConsumerEventArgs(IDictionary<string, object> consumerArguments, string consumerTag)
+        {
+            ConsumerArguments = consumerArguments;
+            ConsumerTag = consumerTag;
+        }
 
-        event EventHandler<ConsumerTagChangedAfterRecoveryEventArgs> ConsumerTagChangeAfterRecovery;
-        event EventHandler<QueueNameChangedAfterRecoveryEventArgs> QueueNameChangeAfterRecovery;
-        event EventHandler<RecoveringConsumerEventArgs> RecoveringConsumer;
+        /// <summary>
+        /// Access the consumer arguments of the consumer this event relates to.
+        /// </summary>
+        public IDictionary<string, object> ConsumerArguments { get; }
+
+        /// <summary>
+        /// Access the consumer tag of the consumer this event relates to.
+        /// </summary>
+        public string ConsumerTag { get; }
     }
 }

--- a/projects/Unit/APIApproval.Approve.verified.txt
+++ b/projects/Unit/APIApproval.Approve.verified.txt
@@ -243,6 +243,7 @@ namespace RabbitMQ.Client
         event System.EventHandler<RabbitMQ.Client.Events.ConnectionRecoveryErrorEventArgs> ConnectionRecoveryError;
         event System.EventHandler<RabbitMQ.Client.Events.ConsumerTagChangedAfterRecoveryEventArgs> ConsumerTagChangeAfterRecovery;
         event System.EventHandler<RabbitMQ.Client.Events.QueueNameChangedAfterRecoveryEventArgs> QueueNameChangeAfterRecovery;
+        event System.EventHandler<RabbitMQ.Client.Events.RecoveringConsumerEventArgs> RecoveringConsumer;
         event System.EventHandler<System.EventArgs> RecoverySucceeded;
     }
     public interface IBasicConsumer
@@ -688,6 +689,12 @@ namespace RabbitMQ.Client.Events
         public QueueNameChangedAfterRecoveryEventArgs(string nameBefore, string nameAfter) { }
         public string NameAfter { get; }
         public string NameBefore { get; }
+    }
+    public class RecoveringConsumerEventArgs : System.EventArgs
+    {
+        public RecoveringConsumerEventArgs(System.Collections.Generic.IDictionary<string, object> consumerArguments, string consumerTag) { }
+        public System.Collections.Generic.IDictionary<string, object> ConsumerArguments { get; }
+        public string ConsumerTag { get; }
     }
     public class RecoveryExceptionEventArgs : RabbitMQ.Client.Events.BaseExceptionEventArgs
     {


### PR DESCRIPTION
## Proposed Changes

Related to #1293. 

In the context of Streams over AMQP, the consumer must keep track of the consumer offset. When a consumer subscribes to a stream-type queue, it may provide a consumer argument to specify a "point" in the stream to attach to.

This library records consumers, and their arguments, for topology recovery purposes. When a consumer is declared, it starts reading at an arbitrary point e.g. `offset=123`. After receiving messages, the offset "moves" forward. In the event of a connection recovery due to e.g. network error, the consumer is re-declared with the offset recorded when it was first declared i.e. `offset=123`. This is not correct, because the consumer has received some messages, and the offset value when it was first declared is not accurate anymore.

This commit adds an event that fire when a consumer is about to be recovered, but has not started recovering yet. This event exposes the consumer arguments as a reference type, allowing an event handler to update the consumer offset, or any other consumer argument.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

The recovering-consumer event is exposed and fire in the auto-recovering connection class. However, the concept of a consumer is a concern for the Model classes. IMO, this makes this feature a bit awkward to reason about, because user code responsible for connections may not necessarily know about models and consumers. In order to use this feature, such code would have to become aware of some parts of the consumer.

The above in inevitable, given that consumer and model recovery is called from the auto-recovering connection class.

------

In the scenario where a model declares more than 1 consumer, the recovering-consumer event handler will be called for each consumer recorded. It is responsibility of the caller to inspect the consumer tag, and determine if the handler logic should be applied to the consumer arguments the current event relates to.

Edit: formatting