### PR TITLE
Adding fully asynchronous versions of connect and publish.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -115,6 +115,18 @@ csharp_style_inlined_variable_declaration = true:suggestion
 csharp_style_throw_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
 
+# Async methods should have "Async" suffix
+dotnet_naming_rule.async_methods_end_in_async.symbols = any_async_methods
+dotnet_naming_rule.async_methods_end_in_async.style = end_in_async
+dotnet_naming_rule.async_methods_end_in_async.severity = warning
+
+dotnet_naming_symbols.any_async_methods.applicable_kinds = method
+dotnet_naming_symbols.any_async_methods.applicable_accessibilities = *
+dotnet_naming_symbols.any_async_methods.required_modifiers = async
+
+dotnet_naming_style.end_in_async.required_suffix = Async
+dotnet_naming_style.end_in_async.capitalization = pascal_case_style
+
 # Other features
 csharp_style_prefer_index_operator = false:none
 csharp_style_prefer_range_operator = false:none

--- a/projects/Benchmarks/Benchmarks.csproj
+++ b/projects/Benchmarks/Benchmarks.csproj
@@ -1,7 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <TargetFrameworks>net6.0;net472</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="!$([MSBuild]::IsOSPlatform('Windows'))">
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+  
+  <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AssemblyOriginatorKeyFile>../rabbit.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/projects/RabbitMQ.Client/client/api/IChannel.cs
+++ b/projects/RabbitMQ.Client/client/api/IChannel.cs
@@ -208,6 +208,26 @@ namespace RabbitMQ.Client
         /// </remarks>
         void BasicPublish<TProperties>(CachedString exchange, CachedString routingKey, in TProperties basicProperties, ReadOnlyMemory<byte> body = default, bool mandatory = false)
             where TProperties : IReadOnlyBasicProperties, IAmqpHeader;
+        /// <summary>
+        /// Asynchronously publishes a message.
+        /// </summary>
+        /// <remarks>
+        ///   <para>
+        ///     Routing key must be shorter than 255 bytes.
+        ///   </para>
+        /// </remarks>
+        ValueTask BasicPublishAsync<TProperties>(string exchange, string routingKey, in TProperties basicProperties, ReadOnlyMemory<byte> body = default, bool mandatory = false)
+            where TProperties : IReadOnlyBasicProperties, IAmqpHeader;
+        /// <summary>
+        /// Asynchronously publishes a message.
+        /// </summary>
+        /// <remarks>
+        ///   <para>
+        ///     Routing key must be shorter than 255 bytes.
+        ///   </para>
+        /// </remarks>
+        ValueTask BasicPublishAsync<TProperties>(CachedString exchange, CachedString routingKey, in TProperties basicProperties, ReadOnlyMemory<byte> body = default, bool mandatory = false)
+            where TProperties : IReadOnlyBasicProperties, IAmqpHeader;
 #nullable disable
 
         /// <summary>

--- a/projects/RabbitMQ.Client/client/api/IChannelExtensions.cs
+++ b/projects/RabbitMQ.Client/client/api/IChannelExtensions.cs
@@ -31,6 +31,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using RabbitMQ.Client.client.impl;
 
 namespace RabbitMQ.Client
@@ -93,6 +94,12 @@ namespace RabbitMQ.Client
 
         public static void BasicPublish(this IChannel channel, CachedString exchange, CachedString routingKey, ReadOnlyMemory<byte> body = default, bool mandatory = false)
             => channel.BasicPublish(exchange, routingKey, in EmptyBasicProperty.Empty, body, mandatory);
+        
+        public static ValueTask BasicPublishAsync(this IChannel channel, string exchange, string routingKey, ReadOnlyMemory<byte> body = default, bool mandatory = false)
+            => channel.BasicPublishAsync(exchange, routingKey, in EmptyBasicProperty.Empty, body, mandatory);
+
+        public static ValueTask BasicPublishAsync(this IChannel channel, CachedString exchange, CachedString routingKey, ReadOnlyMemory<byte> body = default, bool mandatory = false)
+            => channel.BasicPublishAsync(exchange, routingKey, in EmptyBasicProperty.Empty, body, mandatory);
 #nullable disable
 
         /// <summary>

--- a/projects/RabbitMQ.Client/client/api/IChannelExtensions.cs
+++ b/projects/RabbitMQ.Client/client/api/IChannelExtensions.cs
@@ -94,7 +94,7 @@ namespace RabbitMQ.Client
 
         public static void BasicPublish(this IChannel channel, CachedString exchange, CachedString routingKey, ReadOnlyMemory<byte> body = default, bool mandatory = false)
             => channel.BasicPublish(exchange, routingKey, in EmptyBasicProperty.Empty, body, mandatory);
-        
+
         public static ValueTask BasicPublishAsync(this IChannel channel, string exchange, string routingKey, ReadOnlyMemory<byte> body = default, bool mandatory = false)
             => channel.BasicPublishAsync(exchange, routingKey, in EmptyBasicProperty.Empty, body, mandatory);
 

--- a/projects/RabbitMQ.Client/client/framing/Channel.cs
+++ b/projects/RabbitMQ.Client/client/framing/Channel.cs
@@ -109,7 +109,7 @@ namespace RabbitMQ.Client.Framing.Impl
         {
             ChannelSend(new ConnectionOpen(virtualHost));
         }
-        
+
         public override ValueTask _Private_ConnectionOpenAsync(string virtualHost)
         {
             return ModelSendAsync(new ConnectionOpen(virtualHost));

--- a/projects/RabbitMQ.Client/client/framing/Channel.cs
+++ b/projects/RabbitMQ.Client/client/framing/Channel.cs
@@ -30,6 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using RabbitMQ.Client.client.framing;
 using RabbitMQ.Client.Impl;
 
@@ -107,6 +108,11 @@ namespace RabbitMQ.Client.Framing.Impl
         public override void _Private_ConnectionOpen(string virtualHost)
         {
             ChannelSend(new ConnectionOpen(virtualHost));
+        }
+        
+        public override ValueTask _Private_ConnectionOpenAsync(string virtualHost)
+        {
+            return ModelSendAsync(new ConnectionOpen(virtualHost));
         }
 
         public override void _Private_ConnectionSecureOk(byte[] response)

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringChannel.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringChannel.cs
@@ -317,7 +317,7 @@ namespace RabbitMQ.Client.Impl
         public void BasicPublish<TProperties>(CachedString exchange, CachedString routingKey, in TProperties basicProperties, ReadOnlyMemory<byte> body, bool mandatory)
             where TProperties : IReadOnlyBasicProperties, IAmqpHeader
             => InnerChannel.BasicPublish(exchange, routingKey, in basicProperties, body, mandatory);
-        
+
         public ValueTask BasicPublishAsync<TProperties>(string exchange, string routingKey, in TProperties basicProperties, ReadOnlyMemory<byte> body, bool mandatory)
             where TProperties : IReadOnlyBasicProperties, IAmqpHeader
             => InnerChannel.BasicPublishAsync(exchange, routingKey, in basicProperties, body, mandatory);

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringChannel.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringChannel.cs
@@ -317,6 +317,14 @@ namespace RabbitMQ.Client.Impl
         public void BasicPublish<TProperties>(CachedString exchange, CachedString routingKey, in TProperties basicProperties, ReadOnlyMemory<byte> body, bool mandatory)
             where TProperties : IReadOnlyBasicProperties, IAmqpHeader
             => InnerChannel.BasicPublish(exchange, routingKey, in basicProperties, body, mandatory);
+        
+        public ValueTask BasicPublishAsync<TProperties>(string exchange, string routingKey, in TProperties basicProperties, ReadOnlyMemory<byte> body, bool mandatory)
+            where TProperties : IReadOnlyBasicProperties, IAmqpHeader
+            => InnerChannel.BasicPublishAsync(exchange, routingKey, in basicProperties, body, mandatory);
+
+        public ValueTask BasicPublishAsync<TProperties>(CachedString exchange, CachedString routingKey, in TProperties basicProperties, ReadOnlyMemory<byte> body, bool mandatory)
+            where TProperties : IReadOnlyBasicProperties, IAmqpHeader
+            => InnerChannel.BasicPublishAsync(exchange, routingKey, in basicProperties, body, mandatory);
 
         public void BasicQos(uint prefetchSize, ushort prefetchCount, bool global)
         {

--- a/projects/RabbitMQ.Client/client/impl/Connection.Commands.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.Commands.cs
@@ -37,7 +37,6 @@ using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Exceptions;
 using RabbitMQ.Client.Impl;
 using RabbitMQ.Client.Logging;
-using RabbitMQ.Util;
 
 namespace RabbitMQ.Client.Framing.Impl
 {
@@ -74,17 +73,17 @@ namespace RabbitMQ.Client.Framing.Impl
         private async ValueTask OpenAsync()
         {
             RabbitMqClientEventSource.Log.ConnectionOpened();
-            await StartAndTune().ConfigureAwait(false);
+            await StartAndTuneAsync().ConfigureAwait(false);
             await _channel0.ConnectionOpenAsync(_config.VirtualHost);
         }
 
-        private async ValueTask StartAndTune()
+        private async ValueTask StartAndTuneAsync()
         {
             var connectionStartCell = new TaskCompletionSource<ConnectionStartDetails>(TaskCreationOptions.RunContinuationsAsynchronously);
             _channel0.m_connectionStartCell = connectionStartCell;
             _channel0.HandshakeContinuationTimeout = _config.HandshakeContinuationTimeout;
             _frameHandler.ReadTimeout = _config.HandshakeContinuationTimeout;
-            await _frameHandler.SendHeader().ConfigureAwait(false);
+            await _frameHandler.SendHeaderAsync().ConfigureAwait(false);
             ConnectionStartDetails connectionStart = await connectionStartCell.Task.ConfigureAwait(false);
 
             if (connectionStart is null)

--- a/projects/RabbitMQ.Client/client/impl/Connection.Commands.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.Commands.cs
@@ -32,6 +32,7 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Exceptions;
 using RabbitMQ.Client.Impl;
@@ -70,22 +71,21 @@ namespace RabbitMQ.Client.Framing.Impl
             }
         }
 
-        private void Open()
+        private async ValueTask OpenAsync()
         {
             RabbitMqClientEventSource.Log.ConnectionOpened();
-            StartAndTune();
-            _channel0.ConnectionOpen(_config.VirtualHost);
+            await StartAndTune().ConfigureAwait(false);
+            await _channel0.ConnectionOpenAsync(_config.VirtualHost);
         }
 
-        private void StartAndTune()
+        private async ValueTask StartAndTune()
         {
-            var connectionStartCell = new BlockingCell<ConnectionStartDetails>();
+            var connectionStartCell = new TaskCompletionSource<ConnectionStartDetails>(TaskCreationOptions.RunContinuationsAsynchronously);
             _channel0.m_connectionStartCell = connectionStartCell;
             _channel0.HandshakeContinuationTimeout = _config.HandshakeContinuationTimeout;
             _frameHandler.ReadTimeout = _config.HandshakeContinuationTimeout;
-            _frameHandler.SendHeader();
-
-            ConnectionStartDetails connectionStart = connectionStartCell.WaitForValue();
+            await _frameHandler.SendHeader().ConfigureAwait(false);
+            ConnectionStartDetails connectionStart = await connectionStartCell.Task.ConfigureAwait(false);
 
             if (connectionStart is null)
             {
@@ -117,14 +117,14 @@ namespace RabbitMQ.Client.Framing.Impl
                     ConnectionSecureOrTune res;
                     if (challenge is null)
                     {
-                        res = _channel0.ConnectionStartOk(ClientProperties,
+                        res = await _channel0.ConnectionStartOkAsync(ClientProperties,
                             mechanismFactory.Name,
                             response,
-                            "en_US");
+                            "en_US").ConfigureAwait(false);
                     }
                     else
                     {
-                        res = _channel0.ConnectionSecureOk(response);
+                        res = await _channel0.ConnectionSecureOkAsync(response).ConfigureAwait(false);
                     }
 
                     if (res.m_challenge is null)

--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -408,7 +408,7 @@ namespace RabbitMQ.Client.Framing.Impl
                 task.AsTask().GetAwaiter().GetResult();
             }
         }
-        
+
         internal ValueTask WriteAsync(ReadOnlyMemory<byte> memory)
         {
             return _frameHandler.WriteAsync(memory);

--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -82,6 +82,11 @@ namespace RabbitMQ.Client.Framing.Impl
             _mainLoopTask = Task.Run(MainLoop);
             try
             {
+                /*
+                 * TODO FUTURE
+                 * Connection should not happen in ctor, instead change
+                 * the API so that it's awaitable
+                 */
                 OpenAsync().AsTask().GetAwaiter().GetResult();
             }
             catch

--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -82,7 +82,7 @@ namespace RabbitMQ.Client.Framing.Impl
             _mainLoopTask = Task.Run(MainLoop);
             try
             {
-                Open();
+                OpenAsync().AsTask().GetAwaiter().GetResult();
             }
             catch
             {
@@ -402,7 +402,16 @@ namespace RabbitMQ.Client.Framing.Impl
 
         internal void Write(ReadOnlyMemory<byte> memory)
         {
-            _frameHandler.Write(memory);
+            var task = _frameHandler.WriteAsync(memory);
+            if (!task.IsCompletedSuccessfully)
+            {
+                task.AsTask().GetAwaiter().GetResult();
+            }
+        }
+        
+        internal ValueTask WriteAsync(ReadOnlyMemory<byte> memory)
+        {
+            return _frameHandler.WriteAsync(memory);
         }
 
         public void Dispose()

--- a/projects/RabbitMQ.Client/client/impl/IFrameHandler.cs
+++ b/projects/RabbitMQ.Client/client/impl/IFrameHandler.cs
@@ -65,8 +65,8 @@ namespace RabbitMQ.Client.Impl
         ///</summary>
         bool TryReadFrame(out InboundFrame frame);
 
-        void SendHeader();
+        ValueTask SendHeader();
 
-        void Write(ReadOnlyMemory<byte> memory);
+        ValueTask WriteAsync(ReadOnlyMemory<byte> memory);
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/IFrameHandler.cs
+++ b/projects/RabbitMQ.Client/client/impl/IFrameHandler.cs
@@ -65,7 +65,7 @@ namespace RabbitMQ.Client.Impl
         ///</summary>
         bool TryReadFrame(out InboundFrame frame);
 
-        ValueTask SendHeader();
+        ValueTask SendHeaderAsync();
 
         ValueTask WriteAsync(ReadOnlyMemory<byte> memory);
     }

--- a/projects/RabbitMQ.Client/client/impl/ISession.cs
+++ b/projects/RabbitMQ.Client/client/impl/ISession.cs
@@ -30,6 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using RabbitMQ.Client.Framing.Impl;
 
 namespace RabbitMQ.Client.Impl
@@ -73,7 +74,12 @@ namespace RabbitMQ.Client.Impl
         bool HandleFrame(in InboundFrame frame);
         void Notify();
         void Transmit<T>(in T cmd) where T : struct, IOutgoingAmqpMethod;
+        ValueTask TransmitAsync<T>(in T cmd) where T : struct, IOutgoingAmqpMethod;
         void Transmit<TMethod, THeader>(in TMethod cmd, in THeader header, ReadOnlyMemory<byte> body)
+            where TMethod : struct, IOutgoingAmqpMethod
+            where THeader : IAmqpHeader;
+        
+        ValueTask TransmitAsync<TMethod, THeader>(in TMethod cmd, in THeader header, ReadOnlyMemory<byte> body)
             where TMethod : struct, IOutgoingAmqpMethod
             where THeader : IAmqpHeader;
     }

--- a/projects/RabbitMQ.Client/client/impl/ISession.cs
+++ b/projects/RabbitMQ.Client/client/impl/ISession.cs
@@ -78,7 +78,7 @@ namespace RabbitMQ.Client.Impl
         void Transmit<TMethod, THeader>(in TMethod cmd, in THeader header, ReadOnlyMemory<byte> body)
             where TMethod : struct, IOutgoingAmqpMethod
             where THeader : IAmqpHeader;
-        
+
         ValueTask TransmitAsync<TMethod, THeader>(in TMethod cmd, in THeader header, ReadOnlyMemory<byte> body)
             where TMethod : struct, IOutgoingAmqpMethod
             where THeader : IAmqpHeader;

--- a/projects/RabbitMQ.Client/client/impl/SessionBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/SessionBase.cs
@@ -162,7 +162,7 @@ namespace RabbitMQ.Client.Impl
 
             Connection.Write(Framing.SerializeToFrames(ref Unsafe.AsRef(cmd), ref Unsafe.AsRef(header), body, ChannelNumber, Connection.MaxPayloadSize));
         }
-        
+
         public ValueTask TransmitAsync<TMethod, THeader>(in TMethod cmd, in THeader header, ReadOnlyMemory<byte> body)
             where TMethod : struct, IOutgoingAmqpMethod
             where THeader : IAmqpHeader

--- a/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
+++ b/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
@@ -272,7 +272,7 @@ namespace RabbitMQ.Client.Impl
             return InboundFrame.TryReadFrameFromPipe(_pipeReader, _amqpTcpEndpoint.MaxMessageSize, out frame);
         }
 
-        public async ValueTask SendHeader()
+        public async ValueTask SendHeaderAsync()
         {
             _pipeWriter.Write(ProtocolHeader);
             await _pipeWriter.FlushAsync().ConfigureAwait(false);

--- a/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
+++ b/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
@@ -306,7 +306,8 @@ namespace RabbitMQ.Client.Impl
                         ArrayPool<byte>.Shared.Return(segment.Array);
                     }
 
-                    await _pipeWriter.FlushAsync().ConfigureAwait(false);
+                    await _pipeWriter.FlushAsync()
+                        .ConfigureAwait(false);
                 }
             }
             catch (Exception ex)

--- a/projects/RabbitMQ.Client/client/logging/RabbitMqExceptionDetail.cs
+++ b/projects/RabbitMQ.Client/client/logging/RabbitMqExceptionDetail.cs
@@ -35,10 +35,7 @@ using System.Diagnostics.Tracing;
 
 namespace RabbitMQ.Client.Logging
 {
-#if NET452
-#else
     [EventData]
-#endif
     public class RabbitMqExceptionDetail
     {
         public RabbitMqExceptionDetail(Exception ex)

--- a/projects/TestApplications/CreateChannel/CreateChannel.csproj
+++ b/projects/TestApplications/CreateChannel/CreateChannel.csproj
@@ -1,8 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="!$([MSBuild]::IsOSPlatform('Windows'))">
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+  
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/projects/TestApplications/MassPublish/MassPublish.csproj
+++ b/projects/TestApplications/MassPublish/MassPublish.csproj
@@ -1,8 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="!$([MSBuild]::IsOSPlatform('Windows'))">
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+  
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/projects/Unit/APIApproval.Approve.verified.txt
+++ b/projects/Unit/APIApproval.Approve.verified.txt
@@ -403,6 +403,10 @@ namespace RabbitMQ.Client
             where TProperties : RabbitMQ.Client.IReadOnlyBasicProperties, RabbitMQ.Client.IAmqpHeader;
         void BasicPublish<TProperties>(string exchange, string routingKey, in TProperties basicProperties, System.ReadOnlyMemory<byte> body = default, bool mandatory = false)
             where TProperties : RabbitMQ.Client.IReadOnlyBasicProperties, RabbitMQ.Client.IAmqpHeader;
+        System.Threading.Tasks.ValueTask BasicPublishAsync<TProperties>(RabbitMQ.Client.CachedString exchange, RabbitMQ.Client.CachedString routingKey, in TProperties basicProperties, System.ReadOnlyMemory<byte> body = default, bool mandatory = false)
+            where TProperties : RabbitMQ.Client.IReadOnlyBasicProperties, RabbitMQ.Client.IAmqpHeader;
+        System.Threading.Tasks.ValueTask BasicPublishAsync<TProperties>(string exchange, string routingKey, in TProperties basicProperties, System.ReadOnlyMemory<byte> body = default, bool mandatory = false)
+            where TProperties : RabbitMQ.Client.IReadOnlyBasicProperties, RabbitMQ.Client.IAmqpHeader;
         void BasicQos(uint prefetchSize, ushort prefetchCount, bool global);
         void BasicRecover(bool requeue);
         void BasicRecoverAsync(bool requeue);
@@ -447,6 +451,8 @@ namespace RabbitMQ.Client
         public static void BasicPublish(this RabbitMQ.Client.IChannel channel, string exchange, string routingKey, System.ReadOnlyMemory<byte> body = default, bool mandatory = false) { }
         public static void BasicPublish<T>(this RabbitMQ.Client.IChannel channel, RabbitMQ.Client.PublicationAddress addr, in T basicProperties, System.ReadOnlyMemory<byte> body)
             where T : RabbitMQ.Client.IReadOnlyBasicProperties, RabbitMQ.Client.IAmqpHeader { }
+        public static System.Threading.Tasks.ValueTask BasicPublishAsync(this RabbitMQ.Client.IChannel channel, RabbitMQ.Client.CachedString exchange, RabbitMQ.Client.CachedString routingKey, System.ReadOnlyMemory<byte> body = default, bool mandatory = false) { }
+        public static System.Threading.Tasks.ValueTask BasicPublishAsync(this RabbitMQ.Client.IChannel channel, string exchange, string routingKey, System.ReadOnlyMemory<byte> body = default, bool mandatory = false) { }
         public static void Close(this RabbitMQ.Client.IChannel channel) { }
         public static void Close(this RabbitMQ.Client.IChannel channel, ushort replyCode, string replyText) { }
         public static void ExchangeBind(this RabbitMQ.Client.IChannel channel, string destination, string source, string routingKey, System.Collections.Generic.IDictionary<string, object> arguments = null) { }

--- a/projects/Unit/Fixtures.cs
+++ b/projects/Unit/Fixtures.cs
@@ -71,7 +71,7 @@ namespace RabbitMQ.Client.Unit
             }
             else
             {
-                _waitSpan = TimeSpan.FromSeconds(20);
+                _waitSpan = TimeSpan.FromSeconds(10);
             }
         }
 
@@ -452,12 +452,21 @@ namespace RabbitMQ.Client.Unit
 
         private static bool IsRunningInCI()
         {
+            if (bool.TryParse(Environment.GetEnvironmentVariable("CI"), out bool ci))
+            {
+                if (ci == true)
+                {
+                    return true;
+                }
+            }
+
             string concourse = Environment.GetEnvironmentVariable("CONCOURSE_CI_BUILD");
             string gha = Environment.GetEnvironmentVariable("GITHUB_ACTIONS");
             if (String.IsNullOrWhiteSpace(concourse) && String.IsNullOrWhiteSpace(gha))
             {
                 return false;
             }
+
             return true;
         }
     }

--- a/projects/Unit/Fixtures.cs
+++ b/projects/Unit/Fixtures.cs
@@ -71,7 +71,7 @@ namespace RabbitMQ.Client.Unit
             }
             else
             {
-                _waitSpan = TimeSpan.FromSeconds(10);
+                _waitSpan = TimeSpan.FromSeconds(20);
             }
         }
 

--- a/projects/Unit/TestBlockingCell.cs
+++ b/projects/Unit/TestBlockingCell.cs
@@ -112,30 +112,6 @@ namespace RabbitMQ.Client.Unit
         }
 
         [Fact]
-        public void TestGetValueWithTimeoutInfinite()
-        {
-            var k = new BlockingCell<int>();
-            SetAfter(TimingInterval, k, 123);
-
-            ResetTimer();
-            int v = k.WaitForValue(Timeout.InfiniteTimeSpan);
-            Assert.True(TimingInterval - SafetyMargin < ElapsedMs());
-            Assert.Equal(123, v);
-        }
-
-        [Fact]
-        public void TestBackgroundUpdateSucceeds()
-        {
-            var k = new BlockingCell<int>();
-            SetAfter(TimingInterval, k, 123);
-
-            ResetTimer();
-            int v = k.WaitForValue(TimingInterval_2X);
-            Assert.True(TimingInterval - SafetyMargin < ElapsedMs());
-            Assert.Equal(123, v);
-        }
-
-        [Fact]
         public void TestBackgroundUpdateSucceedsWithTimeSpan()
         {
             var k = new BlockingCell<int>();

--- a/projects/Unit/TestConcurrentAccessWithSharedConnection.cs
+++ b/projects/Unit/TestConcurrentAccessWithSharedConnection.cs
@@ -86,7 +86,7 @@ namespace RabbitMQ.Client.Unit
         {
             TestConcurrentChannelOpenAndPublishingWithBodyOfSize(1024);
         }
-        
+
         [Fact]
         public Task TestConcurrentChannelOpenAndPublishingWithBlankMessagesAsync()
         {
@@ -125,7 +125,7 @@ namespace RabbitMQ.Client.Unit
         {
             TestConcurrentChannelOpenAndPublishingWithBody(new byte[length], iterations);
         }
-        
+
         internal Task TestConcurrentChannelOpenAndPublishingWithBodyOfSizeAsync(int length, int iterations = 30)
         {
             return TestConcurrentChannelOpenAndPublishingWithBodyAsync(new byte[length], iterations);
@@ -147,7 +147,7 @@ namespace RabbitMQ.Client.Unit
                 ch.WaitForConfirmsAsync(cts.Token).GetAwaiter().GetResult();
             }, iterations);
         }
-        
+
         internal Task TestConcurrentChannelOpenAndPublishingWithBodyAsync(byte[] body, int iterations)
         {
             return TestConcurrentChannelOperationsAsync(async (conn) =>
@@ -170,7 +170,7 @@ namespace RabbitMQ.Client.Unit
         {
             TestConcurrentChannelOperations(actions, iterations, _completionTimeout);
         }
-        
+
         internal Task TestConcurrentChannelOperationsAsync(Func<IConnection, Task> actions, int iterations)
         {
             return TestConcurrentChannelOperationsAsync(actions, iterations, _completionTimeout);
@@ -198,7 +198,7 @@ namespace RabbitMQ.Client.Unit
             // closing the connection
             Assert.True(_conn.IsOpen);
         }
-        
+
         internal async Task TestConcurrentChannelOperationsAsync(Func<IConnection, Task> actions,
             int iterations, TimeSpan timeout)
         {

--- a/projects/Unit/TestPublisherConfirms.cs
+++ b/projects/Unit/TestPublisherConfirms.cs
@@ -49,7 +49,12 @@ namespace RabbitMQ.Client.Unit
 
         public TestPublisherConfirms(ITestOutputHelper output) : base(output)
         {
+#if NET6_0_OR_GREATER
             Random.Shared.NextBytes(_body);
+#else
+            var rnd = new Random();
+            rnd.NextBytes(_body);
+#endif
         }
 
         [Fact]

--- a/projects/Unit/TestPublisherConfirms.cs
+++ b/projects/Unit/TestPublisherConfirms.cs
@@ -45,14 +45,11 @@ namespace RabbitMQ.Client.Unit
     public class TestPublisherConfirms : IntegrationFixture
     {
         private const string QueueName = "RabbitMQ.Client.Unit.TestPublisherConfirms";
-        private readonly byte[] _body;
+        private readonly byte[] _body = new byte[4096];
 
         public TestPublisherConfirms(ITestOutputHelper output) : base(output)
         {
-            var rnd = new Random();
-            _body = new byte[4096];
-            rnd.NextBytes(_body);
-
+            Random.Shared.NextBytes(_body);
         }
 
         [Fact]
@@ -77,15 +74,30 @@ namespace RabbitMQ.Client.Unit
         }
 
         [Fact]
-        public void TestWaitForConfirmsWithTimeout_AllMessagesAcked_WaitingHasTimedout_ReturnTrue()
+        public void TestWaitForConfirmsWithTimeout_MightThrowTaskCanceledException()
         {
+            bool waitResult = false;
+            bool sawTaskCanceled = false;
+
             TestWaitForConfirms(10000, (ch) =>
             {
                 using (var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(1)))
                 {
-                    Assert.Throws<TaskCanceledException>(() => ch.WaitForConfirmsAsync(cts.Token).GetAwaiter().GetResult());
+                    try
+                    {
+                        waitResult = ch.WaitForConfirmsAsync(cts.Token).GetAwaiter().GetResult();
+                    }
+                    catch (TaskCanceledException)
+                    {
+                        sawTaskCanceled = true;
+                    }
                 }
             });
+
+            if (waitResult == false && sawTaskCanceled == false)
+            {
+                Assert.Fail("test failed, both waitResult and sawTaskCanceled are still false");
+            }
         }
 
         [Fact]
@@ -147,12 +159,14 @@ namespace RabbitMQ.Client.Unit
         {
             using (IChannel ch = _conn.CreateChannel())
             {
+                var props = new BasicProperties { Persistent = true };
+
                 ch.ConfirmSelect();
                 ch.QueueDeclare(QueueName);
 
                 for (int i = 0; i < numberOfMessagesToPublish; i++)
                 {
-                    ch.BasicPublish("", QueueName, _body);
+                    ch.BasicPublish(exchange: "", routingKey: QueueName, body: _body, mandatory: true, basicProperties: props);
                 }
 
                 try

--- a/projects/Unit/Unit.csproj
+++ b/projects/Unit/Unit.csproj
@@ -1,7 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <TargetFrameworks>net6.0;net472</TargetFrameworks>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="!$([MSBuild]::IsOSPlatform('Windows'))">
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+  
+  <PropertyGroup>
     <AssemblyOriginatorKeyFile>../rabbit.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
## Proposed Changes

Now that the library is using Pipelines we can create fully asynchronous versions of the RabbitMQ operations. Here is a draft PR that implements async methods to run through the connection handshake and makes an async version of BasicPublish.

TODO:
 - [ ] Run comparison benchmarks
 - [ ] Documentation
 - [ ] More tests

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Going to make this a draft for now. If this makes sense, we can gradually move other operations to be async as well, and hopefully even remove the synchronous versions completely later on.