### PR TITLE
Add custom filtering and exception handling to topology recovery

### DIFF
--- a/projects/RabbitMQ.Client/client/api/ConnectionConfig.cs
+++ b/projects/RabbitMQ.Client/client/api/ConnectionConfig.cs
@@ -87,6 +87,12 @@ namespace RabbitMQ.Client
         public bool TopologyRecoveryEnabled { get; }
 
         /// <summary>
+        /// Filter to include/exclude entities from topology recovery.
+        /// Default filter includes all entities in topology recovery.
+        /// </summary>
+        public TopologyRecoveryFilter TopologyRecoveryFilter { get; }
+
+        /// <summary>
         /// Amount of time client will wait for before re-trying  to recover connection.
         /// </summary>
         public TimeSpan NetworkRecoveryInterval { get; }
@@ -127,7 +133,7 @@ namespace RabbitMQ.Client
 
         internal ConnectionConfig(string virtualHost, string userName, string password, IList<IAuthMechanismFactory> authMechanisms,
             IDictionary<string, object?> clientProperties, string? clientProvidedName,
-            ushort maxChannelCount, uint maxFrameSize, bool topologyRecoveryEnabled,
+            ushort maxChannelCount, uint maxFrameSize, bool topologyRecoveryEnabled, TopologyRecoveryFilter topologyRecoveryFilter,
             TimeSpan networkRecoveryInterval, TimeSpan heartbeatInterval, TimeSpan continuationTimeout, TimeSpan handshakeContinuationTimeout, TimeSpan requestedConnectionTimeout,
             bool dispatchConsumersAsync, int dispatchConsumerConcurrency,
             Func<AmqpTcpEndpoint, IFrameHandler> frameHandlerFactory)
@@ -141,6 +147,7 @@ namespace RabbitMQ.Client
             MaxChannelCount = maxChannelCount;
             MaxFrameSize = maxFrameSize;
             TopologyRecoveryEnabled = topologyRecoveryEnabled;
+            TopologyRecoveryFilter = topologyRecoveryFilter;
             NetworkRecoveryInterval = networkRecoveryInterval;
             HeartbeatInterval = heartbeatInterval;
             ContinuationTimeout = continuationTimeout;

--- a/projects/RabbitMQ.Client/client/api/ConnectionConfig.cs
+++ b/projects/RabbitMQ.Client/client/api/ConnectionConfig.cs
@@ -93,6 +93,11 @@ namespace RabbitMQ.Client
         public TopologyRecoveryFilter TopologyRecoveryFilter { get; }
 
         /// <summary>
+        /// Custom logic for handling topology recovery exceptions that match the specified filters.
+        /// </summary>
+        public TopologyRecoveryExceptionHandler TopologyRecoveryExceptionHandler { get; }
+
+        /// <summary>
         /// Amount of time client will wait for before re-trying  to recover connection.
         /// </summary>
         public TimeSpan NetworkRecoveryInterval { get; }
@@ -133,7 +138,8 @@ namespace RabbitMQ.Client
 
         internal ConnectionConfig(string virtualHost, string userName, string password, IList<IAuthMechanismFactory> authMechanisms,
             IDictionary<string, object?> clientProperties, string? clientProvidedName,
-            ushort maxChannelCount, uint maxFrameSize, bool topologyRecoveryEnabled, TopologyRecoveryFilter topologyRecoveryFilter,
+            ushort maxChannelCount, uint maxFrameSize, bool topologyRecoveryEnabled,
+            TopologyRecoveryFilter topologyRecoveryFilter, TopologyRecoveryExceptionHandler topologyRecoveryExceptionHandler,
             TimeSpan networkRecoveryInterval, TimeSpan heartbeatInterval, TimeSpan continuationTimeout, TimeSpan handshakeContinuationTimeout, TimeSpan requestedConnectionTimeout,
             bool dispatchConsumersAsync, int dispatchConsumerConcurrency,
             Func<AmqpTcpEndpoint, IFrameHandler> frameHandlerFactory)
@@ -148,6 +154,7 @@ namespace RabbitMQ.Client
             MaxFrameSize = maxFrameSize;
             TopologyRecoveryEnabled = topologyRecoveryEnabled;
             TopologyRecoveryFilter = topologyRecoveryFilter;
+            TopologyRecoveryExceptionHandler = topologyRecoveryExceptionHandler;
             NetworkRecoveryInterval = networkRecoveryInterval;
             HeartbeatInterval = heartbeatInterval;
             ContinuationTimeout = continuationTimeout;

--- a/projects/RabbitMQ.Client/client/api/ConnectionFactory.cs
+++ b/projects/RabbitMQ.Client/client/api/ConnectionFactory.cs
@@ -266,6 +266,11 @@ namespace RabbitMQ.Client
         public TopologyRecoveryFilter TopologyRecoveryFilter { get; set; } = new TopologyRecoveryFilter();
 
         /// <summary>
+        /// Custom logic for handling topology recovery exceptions that match the specified filters.
+        /// </summary>
+        public TopologyRecoveryExceptionHandler TopologyRecoveryExceptionHandler { get; set; } = new TopologyRecoveryExceptionHandler();
+
+        /// <summary>
         /// Construct a fresh instance, with all fields set to their respective defaults.
         /// </summary>
         public ConnectionFactory()
@@ -542,6 +547,7 @@ namespace RabbitMQ.Client
                 RequestedFrameMax,
                 TopologyRecoveryEnabled,
                 TopologyRecoveryFilter,
+                TopologyRecoveryExceptionHandler,
                 NetworkRecoveryInterval,
                 RequestedHeartbeat,
                 ContinuationTimeout,

--- a/projects/RabbitMQ.Client/client/api/ConnectionFactory.cs
+++ b/projects/RabbitMQ.Client/client/api/ConnectionFactory.cs
@@ -260,6 +260,12 @@ namespace RabbitMQ.Client
         public bool TopologyRecoveryEnabled { get; set; } = true;
 
         /// <summary>
+        /// Filter to include/exclude entities from topology recovery.
+        /// Default filter includes all entities in topology recovery.
+        /// </summary>
+        public TopologyRecoveryFilter TopologyRecoveryFilter { get; set; } = new TopologyRecoveryFilter();
+
+        /// <summary>
         /// Construct a fresh instance, with all fields set to their respective defaults.
         /// </summary>
         public ConnectionFactory()
@@ -535,6 +541,7 @@ namespace RabbitMQ.Client
                 RequestedChannelMax,
                 RequestedFrameMax,
                 TopologyRecoveryEnabled,
+                TopologyRecoveryFilter,
                 NetworkRecoveryInterval,
                 RequestedHeartbeat,
                 ContinuationTimeout,

--- a/projects/RabbitMQ.Client/client/api/IRecordedBinding.cs
+++ b/projects/RabbitMQ.Client/client/api/IRecordedBinding.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace RabbitMQ.Client
+{
+#nullable enable
+    public interface IRecordedBinding
+    {
+        string Source { get; }
+
+        string Destination { get; }
+
+        string RoutingKey { get; }
+
+        IDictionary<string, object>? Arguments { get; }
+    }
+}

--- a/projects/RabbitMQ.Client/client/api/IRecordedConsumer.cs
+++ b/projects/RabbitMQ.Client/client/api/IRecordedConsumer.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace RabbitMQ.Client
+{
+#nullable enable
+    public interface IRecordedConsumer
+    {
+        string ConsumerTag { get; }
+
+        string Queue { get; }
+
+        bool AutoAck { get; }
+
+        bool Exclusive { get; }
+
+        IDictionary<string, object>? Arguments { get; }
+    }
+}

--- a/projects/RabbitMQ.Client/client/api/IRecordedConsumer.cs
+++ b/projects/RabbitMQ.Client/client/api/IRecordedConsumer.cs
@@ -5,8 +5,6 @@ namespace RabbitMQ.Client
 #nullable enable
     public interface IRecordedConsumer
     {
-        IBasicConsumer Consumer { get; }
-
         string ConsumerTag { get; }
 
         string Queue { get; }

--- a/projects/RabbitMQ.Client/client/api/IRecordedConsumer.cs
+++ b/projects/RabbitMQ.Client/client/api/IRecordedConsumer.cs
@@ -5,6 +5,8 @@ namespace RabbitMQ.Client
 #nullable enable
     public interface IRecordedConsumer
     {
+        IBasicConsumer Consumer { get; }
+
         string ConsumerTag { get; }
 
         string Queue { get; }

--- a/projects/RabbitMQ.Client/client/api/IRecordedExchange.cs
+++ b/projects/RabbitMQ.Client/client/api/IRecordedExchange.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace RabbitMQ.Client
+{
+#nullable enable
+    public interface IRecordedExchange
+    {
+        string Name { get; }
+
+        string Type { get; }
+
+        bool Durable { get; }
+
+        bool AutoDelete { get; }
+
+        IDictionary<string, object>? Arguments { get; }
+    }
+}

--- a/projects/RabbitMQ.Client/client/api/IRecordedQueue.cs
+++ b/projects/RabbitMQ.Client/client/api/IRecordedQueue.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace RabbitMQ.Client
+{
+#nullable enable
+    public interface IRecordedQueue
+    {
+        string Name { get; }
+
+        bool Durable { get; }
+
+        bool Exclusive { get; }
+
+        bool AutoDelete { get; }
+
+        IDictionary<string, object>? Arguments { get; }
+
+        bool IsServerNamed { get; }
+    }
+}

--- a/projects/RabbitMQ.Client/client/api/TopologyRecoveryExceptionHandler.cs
+++ b/projects/RabbitMQ.Client/client/api/TopologyRecoveryExceptionHandler.cs
@@ -16,10 +16,10 @@ namespace RabbitMQ.Client
         private Func<IRecordedQueue, Exception, bool> _queueRecoveryExceptionCondition;
         private Func<IRecordedBinding, Exception, bool> _bindingRecoveryExceptionCondition;
         private Func<IRecordedConsumer, Exception, bool> _consumerRecoveryExceptionCondition;
-        private Action<IRecordedExchange, Exception> _exchangeRecoveryExceptionHandler;
-        private Action<IRecordedQueue, Exception> _queueRecoveryExceptionHandler;
-        private Action<IRecordedBinding, Exception> _bindingRecoveryExceptionHandler;
-        private Action<IRecordedConsumer, Exception> _consumerRecoveryExceptionHandler;
+        private Action<IRecordedExchange, Exception, IConnection> _exchangeRecoveryExceptionHandler;
+        private Action<IRecordedQueue, Exception, IConnection> _queueRecoveryExceptionHandler;
+        private Action<IRecordedBinding, Exception, IConnection> _bindingRecoveryExceptionHandler;
+        private Action<IRecordedConsumer, Exception, IConnection> _consumerRecoveryExceptionHandler;
 
         /// <summary>
         /// Decides which exchange recovery exceptions the custom exception handler is applied to.
@@ -92,7 +92,7 @@ namespace RabbitMQ.Client
         /// <summary>
         /// Retries, or otherwise handles, an exception thrown when attempting to recover an exchange.
         /// </summary>
-        public Action<IRecordedExchange, Exception> ExchangeRecoveryExceptionHandler
+        public Action<IRecordedExchange, Exception, IConnection> ExchangeRecoveryExceptionHandler
         {
             get => _exchangeRecoveryExceptionHandler;
 
@@ -108,7 +108,7 @@ namespace RabbitMQ.Client
         /// <summary>
         /// Retries, or otherwise handles, an exception thrown when attempting to recover a queue.
         /// </summary>
-        public Action<IRecordedQueue, Exception> QueueRecoveryExceptionHandler
+        public Action<IRecordedQueue, Exception, IConnection> QueueRecoveryExceptionHandler
         {
             get => _queueRecoveryExceptionHandler;
 
@@ -124,7 +124,7 @@ namespace RabbitMQ.Client
         /// <summary>
         /// Retries, or otherwise handles, an exception thrown when attempting to recover a binding.
         /// </summary>
-        public Action<IRecordedBinding, Exception> BindingRecoveryExceptionHandler
+        public Action<IRecordedBinding, Exception, IConnection> BindingRecoveryExceptionHandler
         {
             get => _bindingRecoveryExceptionHandler;
 
@@ -141,7 +141,7 @@ namespace RabbitMQ.Client
         /// Retries, or otherwise handles, an exception thrown when attempting to recover a consumer.
         /// Is only called when the exception did not cause the consumer's channel to close.
         /// </summary>
-        public Action<IRecordedConsumer, Exception> ConsumerRecoveryExceptionHandler
+        public Action<IRecordedConsumer, Exception, IConnection> ConsumerRecoveryExceptionHandler
         {
             get => _consumerRecoveryExceptionHandler;
 

--- a/projects/RabbitMQ.Client/client/api/TopologyRecoveryExceptionHandler.cs
+++ b/projects/RabbitMQ.Client/client/api/TopologyRecoveryExceptionHandler.cs
@@ -1,0 +1,157 @@
+﻿using System;
+
+namespace RabbitMQ.Client
+{
+    /// <summary>
+    /// Custom logic for handling topology recovery exceptions that match the specified filters.
+    /// </summary>
+    public class TopologyRecoveryExceptionHandler
+    {
+        private static readonly Func<IRecordedExchange, Exception, bool> s_defaultExchangeExceptionCondition = (e, ex) => true;
+        private static readonly Func<IRecordedQueue, Exception, bool> s_defaultQueueExceptionCondition = (q, ex) => true;
+        private static readonly Func<IRecordedBinding, Exception, bool> s_defaultBindingExceptionCondition = (b, ex) => true;
+        private static readonly Func<IRecordedConsumer, Exception, bool> s_defaultConsumerExceptionCondition = (c, ex) => true;
+
+        private Func<IRecordedExchange, Exception, bool> _exchangeRecoveryExceptionCondition;
+        private Func<IRecordedQueue, Exception, bool> _queueRecoveryExceptionCondition;
+        private Func<IRecordedBinding, Exception, bool> _bindingRecoveryExceptionCondition;
+        private Func<IRecordedConsumer, Exception, bool> _consumerRecoveryExceptionCondition;
+        private Action<IRecordedExchange, Exception> _exchangeRecoveryExceptionHandler;
+        private Action<IRecordedQueue, Exception> _queueRecoveryExceptionHandler;
+        private Action<IRecordedBinding, Exception> _bindingRecoveryExceptionHandler;
+        private Action<IRecordedConsumer, Exception> _consumerRecoveryExceptionHandler;
+
+        /// <summary>
+        /// Decides which exchange recovery exceptions the custom exception handler is applied to.
+        /// Default condition applies the exception handler to all exchange recovery exceptions.
+        /// </summary>
+        public Func<IRecordedExchange, Exception, bool> ExchangeRecoveryExceptionCondition
+        {
+            get => _exchangeRecoveryExceptionCondition ?? s_defaultExchangeExceptionCondition;
+
+            set
+            {
+                if (_exchangeRecoveryExceptionCondition != null)
+                    throw new InvalidOperationException($"Cannot modify {nameof(ExchangeRecoveryExceptionCondition)} after it has been initialized.");
+
+                _exchangeRecoveryExceptionCondition = value ?? throw new ArgumentNullException(nameof(ExchangeRecoveryExceptionCondition));
+            }
+        }
+
+        /// <summary>
+        /// Decides which queue recovery exceptions the custom exception handler is applied to.
+        /// Default condition applies the exception handler to all queue recovery exceptions.
+        /// </summary>
+        public Func<IRecordedQueue, Exception, bool> QueueRecoveryExceptionCondition
+        {
+            get => _queueRecoveryExceptionCondition ?? s_defaultQueueExceptionCondition;
+
+            set
+            {
+                if (_queueRecoveryExceptionCondition != null)
+                    throw new InvalidOperationException($"Cannot modify {nameof(QueueRecoveryExceptionCondition)} after it has been initialized.");
+
+                _queueRecoveryExceptionCondition = value ?? throw new ArgumentNullException(nameof(QueueRecoveryExceptionCondition));
+            }
+        }
+
+        /// <summary>
+        /// Decides which binding recovery exceptions the custom exception handler is applied to.
+        /// Default condition applies the exception handler to all binding recovery exceptions.
+        /// </summary>
+        public Func<IRecordedBinding, Exception, bool> BindingRecoveryExceptionCondition
+        {
+            get => _bindingRecoveryExceptionCondition ?? s_defaultBindingExceptionCondition;
+
+            set
+            {
+                if (_bindingRecoveryExceptionCondition != null)
+                    throw new InvalidOperationException($"Cannot modify {nameof(ExchangeRecoveryExceptionCondition)} after it has been initialized.");
+
+                _bindingRecoveryExceptionCondition = value ?? throw new ArgumentNullException(nameof(ExchangeRecoveryExceptionCondition));
+            }
+        }
+
+        /// <summary>
+        /// Decides which consumer recovery exceptions the custom exception handler is applied to.
+        /// Default condition applies the exception handler to all consumer recovery exceptions.
+        /// </summary>
+        public Func<IRecordedConsumer, Exception, bool> ConsumerRecoveryExceptionCondition
+        {
+            get => _consumerRecoveryExceptionCondition ?? s_defaultConsumerExceptionCondition;
+
+            set
+            {
+                if (_consumerRecoveryExceptionCondition != null)
+                    throw new InvalidOperationException($"Cannot modify {nameof(ConsumerRecoveryExceptionCondition)} after it has been initialized.");
+
+                _consumerRecoveryExceptionCondition = value ?? throw new ArgumentNullException(nameof(ConsumerRecoveryExceptionCondition));
+            }
+        }
+
+        /// <summary>
+        /// Retries, or otherwise handles, an exception thrown when attempting to recover an exchange.
+        /// </summary>
+        public Action<IRecordedExchange, Exception> ExchangeRecoveryExceptionHandler
+        {
+            get => _exchangeRecoveryExceptionHandler;
+
+            set
+            {
+                if (_exchangeRecoveryExceptionHandler != null)
+                    throw new InvalidOperationException($"Cannot modify {nameof(ExchangeRecoveryExceptionHandler)} after it has been initialized.");
+
+                _exchangeRecoveryExceptionHandler = value ?? throw new ArgumentNullException(nameof(ExchangeRecoveryExceptionHandler));
+            }
+        }
+
+        /// <summary>
+        /// Retries, or otherwise handles, an exception thrown when attempting to recover a queue.
+        /// </summary>
+        public Action<IRecordedQueue, Exception> QueueRecoveryExceptionHandler
+        {
+            get => _queueRecoveryExceptionHandler;
+
+            set
+            {
+                if (_queueRecoveryExceptionHandler != null)
+                    throw new InvalidOperationException($"Cannot modify {nameof(QueueRecoveryExceptionHandler)} after it has been initialized.");
+
+                _queueRecoveryExceptionHandler = value ?? throw new ArgumentNullException(nameof(QueueRecoveryExceptionHandler));
+            }
+        }
+
+        /// <summary>
+        /// Retries, or otherwise handles, an exception thrown when attempting to recover a binding.
+        /// </summary>
+        public Action<IRecordedBinding, Exception> BindingRecoveryExceptionHandler
+        {
+            get => _bindingRecoveryExceptionHandler;
+
+            set
+            {
+                if (_bindingRecoveryExceptionHandler != null)
+                    throw new InvalidOperationException($"Cannot modify {nameof(BindingRecoveryExceptionHandler)} after it has been initialized.");
+
+                _bindingRecoveryExceptionHandler = value ?? throw new ArgumentNullException(nameof(BindingRecoveryExceptionHandler));
+            }
+        }
+
+        /// <summary>
+        /// Retries, or otherwise handles, an exception thrown when attempting to recover a consumer.
+        /// Is only called when the exception did not cause the consumer's channel to close.
+        /// </summary>
+        public Action<IRecordedConsumer, Exception> ConsumerRecoveryExceptionHandler
+        {
+            get => _consumerRecoveryExceptionHandler;
+
+            set
+            {
+                if (_consumerRecoveryExceptionHandler != null)
+                    throw new InvalidOperationException($"Cannot modify {nameof(ConsumerRecoveryExceptionHandler)} after it has been initialized.");
+
+                _consumerRecoveryExceptionHandler = value ?? throw new ArgumentNullException(nameof(ConsumerRecoveryExceptionHandler));
+            }
+        }
+    }
+}

--- a/projects/RabbitMQ.Client/client/api/TopologyRecoveryExceptionHandler.cs
+++ b/projects/RabbitMQ.Client/client/api/TopologyRecoveryExceptionHandler.cs
@@ -139,7 +139,6 @@ namespace RabbitMQ.Client
 
         /// <summary>
         /// Retries, or otherwise handles, an exception thrown when attempting to recover a consumer.
-        /// Is only called when the exception did not cause the consumer's channel to close.
         /// </summary>
         public Action<IRecordedConsumer, Exception, IConnection> ConsumerRecoveryExceptionHandler
         {

--- a/projects/RabbitMQ.Client/client/api/TopologyRecoveryFilter.cs
+++ b/projects/RabbitMQ.Client/client/api/TopologyRecoveryFilter.cs
@@ -1,0 +1,68 @@
+﻿using System;
+
+namespace RabbitMQ.Client
+{
+    /// <summary>
+    /// Filter to know which entities (exchanges, queues, bindings, consumers) should be recovered by topology recovery.
+    /// By default, allows all entities to be recovered.
+    /// </summary>
+    public class TopologyRecoveryFilter
+    {
+        private Func<IRecordedExchange, bool> _exchangeFilter = exchange => true;
+        private Func<IRecordedQueue, bool> _queueFilter = queue => true;
+        private Func<IRecordedBinding, bool> _bindingFilter = binding => true;
+        private Func<IRecordedConsumer, bool> _consumerFilter = consumer => true;
+
+        /// <summary>
+        /// Decides whether an exchange is recovered or not.
+        /// </summary>
+        public Func<IRecordedExchange, bool> ExchangeFilter
+        {
+            get => _exchangeFilter;
+
+            init
+            {
+                _exchangeFilter = value ?? throw new ArgumentNullException(nameof(ExchangeFilter));
+            }
+        }
+
+        /// <summary>
+        /// Decides whether a queue is recovered or not.
+        /// </summary>
+        public Func<IRecordedQueue, bool> QueueFilter
+        {
+            get => _queueFilter;
+
+            init
+            {
+                _queueFilter = value ?? throw new ArgumentNullException(nameof(QueueFilter));
+            }
+        }
+
+        /// <summary>
+        /// Decides whether a binding is recovered or not.
+        /// </summary>
+        public Func<IRecordedBinding, bool> BindingFilter
+        {
+            get => _bindingFilter;
+
+            init
+            {
+                _bindingFilter = value ?? throw new ArgumentNullException(nameof(BindingFilter));
+            }
+        }
+
+        /// <summary>
+        /// Decides whether a consumer is recovered or not.
+        /// </summary>
+        public Func<IRecordedConsumer, bool> ConsumerFilter
+        {
+            get => _consumerFilter;
+
+            init
+            {
+                _consumerFilter = value ?? throw new ArgumentNullException(nameof(ConsumerFilter));
+            }
+        }
+    }
+}

--- a/projects/RabbitMQ.Client/client/api/TopologyRecoveryFilter.cs
+++ b/projects/RabbitMQ.Client/client/api/TopologyRecoveryFilter.cs
@@ -8,20 +8,28 @@ namespace RabbitMQ.Client
     /// </summary>
     public class TopologyRecoveryFilter
     {
-        private Func<IRecordedExchange, bool> _exchangeFilter = exchange => true;
-        private Func<IRecordedQueue, bool> _queueFilter = queue => true;
-        private Func<IRecordedBinding, bool> _bindingFilter = binding => true;
-        private Func<IRecordedConsumer, bool> _consumerFilter = consumer => true;
+        private static readonly Func<IRecordedExchange, bool> s_defaultExchangeFilter = exchange => true;
+        private static readonly Func<IRecordedQueue, bool> s_defaultQueueFilter = queue => true;
+        private static readonly Func<IRecordedBinding, bool> s_defaultBindingFilter = binding => true;
+        private static readonly Func<IRecordedConsumer, bool> s_defaultConsumerFilter = consumer => true;
+
+        private Func<IRecordedExchange, bool> _exchangeFilter;
+        private Func<IRecordedQueue, bool> _queueFilter;
+        private Func<IRecordedBinding, bool> _bindingFilter;
+        private Func<IRecordedConsumer, bool> _consumerFilter;
 
         /// <summary>
         /// Decides whether an exchange is recovered or not.
         /// </summary>
         public Func<IRecordedExchange, bool> ExchangeFilter
         {
-            get => _exchangeFilter;
+            get => _exchangeFilter ?? s_defaultExchangeFilter;
 
-            init
+            set
             {
+                if (_exchangeFilter != null)
+                    throw new InvalidOperationException($"Cannot modify {nameof(ExchangeFilter)} after it has been initialized.");
+
                 _exchangeFilter = value ?? throw new ArgumentNullException(nameof(ExchangeFilter));
             }
         }
@@ -31,10 +39,13 @@ namespace RabbitMQ.Client
         /// </summary>
         public Func<IRecordedQueue, bool> QueueFilter
         {
-            get => _queueFilter;
+            get => _queueFilter ?? s_defaultQueueFilter;
 
-            init
+            set
             {
+                if (_queueFilter != null)
+                    throw new InvalidOperationException($"Cannot modify {nameof(QueueFilter)} after it has been initialized.");
+
                 _queueFilter = value ?? throw new ArgumentNullException(nameof(QueueFilter));
             }
         }
@@ -44,10 +55,13 @@ namespace RabbitMQ.Client
         /// </summary>
         public Func<IRecordedBinding, bool> BindingFilter
         {
-            get => _bindingFilter;
+            get => _bindingFilter ?? s_defaultBindingFilter;
 
-            init
+            set
             {
+                if (_bindingFilter != null)
+                    throw new InvalidOperationException($"Cannot modify {nameof(BindingFilter)} after it has been initialized.");
+
                 _bindingFilter = value ?? throw new ArgumentNullException(nameof(BindingFilter));
             }
         }
@@ -57,10 +71,13 @@ namespace RabbitMQ.Client
         /// </summary>
         public Func<IRecordedConsumer, bool> ConsumerFilter
         {
-            get => _consumerFilter;
+            get => _consumerFilter ?? s_defaultConsumerFilter;
 
-            init
+            set
             {
+                if (_consumerFilter != null)
+                    throw new InvalidOperationException($"Cannot modify {nameof(ConsumerFilter)} after it has been initialized.");
+
                 _consumerFilter = value ?? throw new ArgumentNullException(nameof(ConsumerFilter));
             }
         }

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recording.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recording.cs
@@ -77,7 +77,7 @@ namespace RabbitMQ.Client.Framing.Impl
         {
             lock (_recordedEntitiesLock)
             {
-                if (_recordedExchanges.TryGetValue(exchangeName, out var recordedExchange) && recordedExchange.IsAutoDelete)
+                if (_recordedExchanges.TryGetValue(exchangeName, out var recordedExchange) && recordedExchange.AutoDelete)
                 {
                     if (!AnyBindingsOnExchange(exchangeName))
                     {
@@ -204,7 +204,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
             void DeleteAutoDeleteQueue(string queue)
             {
-                if (_recordedQueues.TryGetValue(queue, out var recordedQueue) && recordedQueue.IsAutoDelete)
+                if (_recordedQueues.TryGetValue(queue, out var recordedQueue) && recordedQueue.AutoDelete)
                 {
                     // last consumer on this connection is gone, remove recorded queue if it is auto-deleted.
                     if (!AnyConsumersOnQueue(queue))

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recovery.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recovery.cs
@@ -224,7 +224,7 @@ namespace RabbitMQ.Client.Framing.Impl
                     if (_config.TopologyRecoveryExceptionHandler.ExchangeRecoveryExceptionHandler != null
                         && _config.TopologyRecoveryExceptionHandler.ExchangeRecoveryExceptionCondition(recordedExchange, ex))
                     {
-                        _config.TopologyRecoveryExceptionHandler.ExchangeRecoveryExceptionHandler(recordedExchange, ex);
+                        _config.TopologyRecoveryExceptionHandler.ExchangeRecoveryExceptionHandler(recordedExchange, ex, this);
                     }
                     else
                     {
@@ -270,7 +270,7 @@ namespace RabbitMQ.Client.Framing.Impl
                     if (_config.TopologyRecoveryExceptionHandler.QueueRecoveryExceptionHandler != null
                         && _config.TopologyRecoveryExceptionHandler.QueueRecoveryExceptionCondition(recordedQueue, ex))
                     {
-                        _config.TopologyRecoveryExceptionHandler.QueueRecoveryExceptionHandler(recordedQueue, ex);
+                        _config.TopologyRecoveryExceptionHandler.QueueRecoveryExceptionHandler(recordedQueue, ex, this);
                     }
                     else
                     {
@@ -293,7 +293,7 @@ namespace RabbitMQ.Client.Framing.Impl
                     if (_config.TopologyRecoveryExceptionHandler.BindingRecoveryExceptionHandler != null
                         && _config.TopologyRecoveryExceptionHandler.BindingRecoveryExceptionCondition(binding, ex))
                     {
-                        _config.TopologyRecoveryExceptionHandler.BindingRecoveryExceptionHandler(binding, ex);
+                        _config.TopologyRecoveryExceptionHandler.BindingRecoveryExceptionHandler(binding, ex, this);
                     }
                     else
                     {
@@ -330,7 +330,7 @@ namespace RabbitMQ.Client.Framing.Impl
                     if (_config.TopologyRecoveryExceptionHandler.ConsumerRecoveryExceptionHandler != null
                         && _config.TopologyRecoveryExceptionHandler.ConsumerRecoveryExceptionCondition(consumer, ex))
                     {
-                        _config.TopologyRecoveryExceptionHandler.ConsumerRecoveryExceptionHandler(consumer, ex);
+                        _config.TopologyRecoveryExceptionHandler.ConsumerRecoveryExceptionHandler(consumer, ex, this);
                     }
                     else
                     {

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recovery.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recovery.cs
@@ -213,7 +213,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         private void RecoverExchanges(IChannel channel)
         {
-            foreach (var recordedExchange in _recordedExchanges.Values)
+            foreach (var recordedExchange in _recordedExchanges.Values.Where(x => _config.TopologyRecoveryFilter?.ExchangeFilter(x) ?? true))
             {
                 try
                 {
@@ -228,7 +228,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         private void RecoverQueues(IChannel channel)
         {
-            foreach (var recordedQueue in _recordedQueues.Values.ToArray())
+            foreach (var recordedQueue in _recordedQueues.Values.Where(x => _config.TopologyRecoveryFilter?.QueueFilter(x) ?? true).ToArray())
             {
                 try
                 {
@@ -266,7 +266,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         private void RecoverBindings(IChannel channel)
         {
-            foreach (var binding in _recordedBindings)
+            foreach (var binding in _recordedBindings.Where(x => _config.TopologyRecoveryFilter?.BindingFilter(x) ?? true))
             {
                 try
                 {
@@ -281,7 +281,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         internal void RecoverConsumers(AutorecoveringChannel channelToRecover, IChannel channelToUse)
         {
-            foreach (var consumer in _recordedConsumers.Values.ToArray())
+            foreach (var consumer in _recordedConsumers.Values.Where(x => _config.TopologyRecoveryFilter?.ConsumerFilter(x) ?? true).ToArray())
             {
                 if (consumer.Channel != channelToRecover)
                 {

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recovery.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recovery.cs
@@ -143,11 +143,11 @@ namespace RabbitMQ.Client.Framing.Impl
                             // 2. Recover queues
                             // 3. Recover bindings
                             // 4. Recover consumers
-                            using (var recoveryChannel = _innerConnection.CreateChannel())
+                            using (var recoveryChannelFactory = new RecoveryChannelFactory(_innerConnection))
                             {
-                                RecoverExchanges(recoveryChannel);
-                                RecoverQueues(recoveryChannel);
-                                RecoverBindings(recoveryChannel);
+                                RecoverExchanges(recoveryChannelFactory);
+                                RecoverQueues(recoveryChannelFactory);
+                                RecoverBindings(recoveryChannelFactory);
                             }
 
                         }
@@ -211,28 +211,36 @@ namespace RabbitMQ.Client.Framing.Impl
             return false;
         }
 
-        private void RecoverExchanges(IChannel channel)
+        private void RecoverExchanges(RecoveryChannelFactory recoveryChannelFactory)
         {
             foreach (var recordedExchange in _recordedExchanges.Values.Where(x => _config.TopologyRecoveryFilter?.ExchangeFilter(x) ?? true))
             {
                 try
                 {
-                    recordedExchange.Recover(channel);
+                    recordedExchange.Recover(recoveryChannelFactory.RecoveryChannel);
                 }
                 catch (Exception ex)
                 {
-                    HandleTopologyRecoveryException(new TopologyRecoveryException($"Caught an exception while recovering exchange '{recordedExchange}'", ex));
+                    if (_config.TopologyRecoveryExceptionHandler.ExchangeRecoveryExceptionHandler != null
+                        && _config.TopologyRecoveryExceptionHandler.ExchangeRecoveryExceptionCondition(recordedExchange, ex))
+                    {
+                        _config.TopologyRecoveryExceptionHandler.ExchangeRecoveryExceptionHandler(recordedExchange, ex);
+                    }
+                    else
+                    {
+                        HandleTopologyRecoveryException(new TopologyRecoveryException($"Caught an exception while recovering exchange '{recordedExchange}'", ex));
+                    }
                 }
             }
         }
 
-        private void RecoverQueues(IChannel channel)
+        private void RecoverQueues(RecoveryChannelFactory recoveryChannelFactory)
         {
             foreach (var recordedQueue in _recordedQueues.Values.Where(x => _config.TopologyRecoveryFilter?.QueueFilter(x) ?? true).ToArray())
             {
                 try
                 {
-                    var newName = recordedQueue.Recover(channel);
+                    var newName = recordedQueue.Recover(recoveryChannelFactory.RecoveryChannel);
                     var oldName = recordedQueue.Name;
 
                     if (oldName != newName)
@@ -259,22 +267,38 @@ namespace RabbitMQ.Client.Framing.Impl
                 }
                 catch (Exception ex)
                 {
-                    HandleTopologyRecoveryException(new TopologyRecoveryException($"Caught an exception while recovering queue '{recordedQueue}'", ex));
+                    if (_config.TopologyRecoveryExceptionHandler.QueueRecoveryExceptionHandler != null
+                        && _config.TopologyRecoveryExceptionHandler.QueueRecoveryExceptionCondition(recordedQueue, ex))
+                    {
+                        _config.TopologyRecoveryExceptionHandler.QueueRecoveryExceptionHandler(recordedQueue, ex);
+                    }
+                    else
+                    {
+                        HandleTopologyRecoveryException(new TopologyRecoveryException($"Caught an exception while recovering queue '{recordedQueue}'", ex));
+                    }
                 }
             }
         }
 
-        private void RecoverBindings(IChannel channel)
+        private void RecoverBindings(RecoveryChannelFactory recoveryChannelFactory)
         {
             foreach (var binding in _recordedBindings.Where(x => _config.TopologyRecoveryFilter?.BindingFilter(x) ?? true))
             {
                 try
                 {
-                    binding.Recover(channel);
+                    binding.Recover(recoveryChannelFactory.RecoveryChannel);
                 }
                 catch (Exception ex)
                 {
-                    HandleTopologyRecoveryException(new TopologyRecoveryException($"Caught an exception while recovering binding between {binding.Source} and {binding.Destination}", ex));
+                    if (_config.TopologyRecoveryExceptionHandler.BindingRecoveryExceptionHandler != null
+                        && _config.TopologyRecoveryExceptionHandler.BindingRecoveryExceptionCondition(binding, ex))
+                    {
+                        _config.TopologyRecoveryExceptionHandler.BindingRecoveryExceptionHandler(binding, ex);
+                    }
+                    else
+                    {
+                        HandleTopologyRecoveryException(new TopologyRecoveryException($"Caught an exception while recovering binding between {binding.Source} and {binding.Destination}", ex));
+                    }
                 }
             }
         }
@@ -303,7 +327,15 @@ namespace RabbitMQ.Client.Framing.Impl
                 }
                 catch (Exception ex)
                 {
-                    HandleTopologyRecoveryException(new TopologyRecoveryException($"Caught an exception while recovering consumer {oldTag} on queue {consumer.Queue}", ex));
+                    if (_config.TopologyRecoveryExceptionHandler.ConsumerRecoveryExceptionHandler != null
+                        && _config.TopologyRecoveryExceptionHandler.ConsumerRecoveryExceptionCondition(consumer, ex))
+                    {
+                        _config.TopologyRecoveryExceptionHandler.ConsumerRecoveryExceptionHandler(consumer, ex);
+                    }
+                    else
+                    {
+                        HandleTopologyRecoveryException(new TopologyRecoveryException($"Caught an exception while recovering consumer {oldTag} on queue {consumer.Queue}", ex));
+                    }
                 }
             }
         }
@@ -315,6 +347,45 @@ namespace RabbitMQ.Client.Framing.Impl
                 foreach (AutorecoveringChannel m in _channels)
                 {
                     m.AutomaticallyRecover(this, _config.TopologyRecoveryEnabled);
+                }
+            }
+        }
+
+        private sealed class RecoveryChannelFactory : IDisposable
+        {
+            private readonly IConnection _connection;
+            private IModel? _recoveryChannel;
+
+            public RecoveryChannelFactory(IConnection connection)
+            {
+                _connection = connection;
+            }
+
+            public IModel RecoveryChannel
+            {
+                get
+                {
+                    if (_recoveryChannel == null)
+                    {
+                        _recoveryChannel = _connection.CreateModel();
+                    }
+
+                    if (_recoveryChannel.IsClosed)
+                    {
+                        _recoveryChannel.Dispose();
+                        _recoveryChannel = _connection.CreateModel();
+                    }
+
+                    return _recoveryChannel;
+                }
+            }
+
+            public void Dispose()
+            {
+                if (_recoveryChannel != null)
+                {
+                    _recoveryChannel.Close();
+                    _recoveryChannel.Dispose();
                 }
             }
         }

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recovery.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recovery.cs
@@ -354,26 +354,26 @@ namespace RabbitMQ.Client.Framing.Impl
         private sealed class RecoveryChannelFactory : IDisposable
         {
             private readonly IConnection _connection;
-            private IModel? _recoveryChannel;
+            private IChannel? _recoveryChannel;
 
             public RecoveryChannelFactory(IConnection connection)
             {
                 _connection = connection;
             }
 
-            public IModel RecoveryChannel
+            public IChannel RecoveryChannel
             {
                 get
                 {
                     if (_recoveryChannel == null)
                     {
-                        _recoveryChannel = _connection.CreateModel();
+                        _recoveryChannel = _connection.CreateChannel();
                     }
 
                     if (_recoveryChannel.IsClosed)
                     {
                         _recoveryChannel.Dispose();
-                        _recoveryChannel = _connection.CreateModel();
+                        _recoveryChannel = _connection.CreateChannel();
                     }
 
                     return _recoveryChannel;

--- a/projects/RabbitMQ.Client/client/impl/RecordedBinding.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedBinding.cs
@@ -35,7 +35,7 @@ using System.Collections.Generic;
 namespace RabbitMQ.Client.Impl
 {
 #nullable enable
-    internal readonly struct RecordedBinding : IEquatable<RecordedBinding>
+    internal readonly struct RecordedBinding : IEquatable<RecordedBinding>, IRecordedBinding
     {
         private readonly bool _isQueueBinding;
         private readonly string _destination;
@@ -45,6 +45,8 @@ namespace RabbitMQ.Client.Impl
 
         public string Destination => _destination;
         public string Source => _source;
+        public string RoutingKey => _routingKey;
+        public IDictionary<string, object>? Arguments => _arguments;
 
         public RecordedBinding(bool isQueueBinding, string destination, string source, string routingKey, IDictionary<string, object>? arguments)
         {

--- a/projects/RabbitMQ.Client/client/impl/RecordedConsumer.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedConsumer.cs
@@ -34,7 +34,7 @@ using System.Collections.Generic;
 namespace RabbitMQ.Client.Impl
 {
 #nullable enable
-    internal readonly struct RecordedConsumer
+    internal readonly struct RecordedConsumer : IRecordedConsumer
     {
         public AutorecoveringChannel Channel { get; }
         public IBasicConsumer Consumer { get; }

--- a/projects/RabbitMQ.Client/client/impl/RecordedExchange.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedExchange.cs
@@ -34,7 +34,7 @@ using System.Collections.Generic;
 namespace RabbitMQ.Client.Impl
 {
 #nullable enable
-    internal readonly struct RecordedExchange
+    internal readonly struct RecordedExchange : IRecordedExchange
     {
         private readonly string _name;
         private readonly string _type;
@@ -43,7 +43,10 @@ namespace RabbitMQ.Client.Impl
         private readonly IDictionary<string, object>? _arguments;
 
         public string Name => _name;
-        public bool IsAutoDelete => _isAutoDelete;
+        public bool AutoDelete => _isAutoDelete;
+        public string Type => _type;
+        public bool Durable => _durable;
+        public IDictionary<string, object>? Arguments => _arguments;
 
         public RecordedExchange(string name, string type, bool durable, bool isAutoDelete, IDictionary<string, object>? arguments)
         {
@@ -56,12 +59,12 @@ namespace RabbitMQ.Client.Impl
 
         public void Recover(IChannel channel)
         {
-            channel.ExchangeDeclare(Name, _type, _durable, IsAutoDelete, _arguments);
+            channel.ExchangeDeclare(Name, _type, _durable, AutoDelete, _arguments);
         }
 
         public override string ToString()
         {
-            return $"{nameof(RecordedExchange)}: name = '{Name}', type = '{_type}', durable = {_durable}, autoDelete = {IsAutoDelete}, arguments = '{_arguments}'";
+            return $"{nameof(RecordedExchange)}: name = '{Name}', type = '{_type}', durable = {_durable}, autoDelete = {AutoDelete}, arguments = '{_arguments}'";
         }
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/RecordedExchange.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedExchange.cs
@@ -39,21 +39,21 @@ namespace RabbitMQ.Client.Impl
         private readonly string _name;
         private readonly string _type;
         private readonly bool _durable;
-        private readonly bool _isAutoDelete;
+        private readonly bool _autoDelete;
         private readonly IDictionary<string, object>? _arguments;
 
         public string Name => _name;
-        public bool AutoDelete => _isAutoDelete;
+        public bool AutoDelete => _autoDelete;
         public string Type => _type;
         public bool Durable => _durable;
         public IDictionary<string, object>? Arguments => _arguments;
 
-        public RecordedExchange(string name, string type, bool durable, bool isAutoDelete, IDictionary<string, object>? arguments)
+        public RecordedExchange(string name, string type, bool durable, bool autoDelete, IDictionary<string, object>? arguments)
         {
             _name = name;
             _type = type;
             _durable = durable;
-            _isAutoDelete = isAutoDelete;
+            _autoDelete = autoDelete;
             _arguments = arguments;
         }
 

--- a/projects/RabbitMQ.Client/client/impl/RecordedQueue.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedQueue.cs
@@ -40,11 +40,11 @@ namespace RabbitMQ.Client.Impl
         private readonly IDictionary<string, object>? _arguments;
         private readonly bool _durable;
         private readonly bool _exclusive;
-        private readonly bool _isAutoDelete;
+        private readonly bool _autoDelete;
         private readonly bool _isServerNamed;
 
         public string Name => _name;
-        public bool AutoDelete => _isAutoDelete;
+        public bool AutoDelete => _autoDelete;
         public bool IsServerNamed => _isServerNamed;
         public bool Durable => _durable;
         public bool Exclusive => _exclusive;
@@ -56,7 +56,7 @@ namespace RabbitMQ.Client.Impl
             _isServerNamed = isServerNamed;
             _durable = durable;
             _exclusive = exclusive;
-            _isAutoDelete = autoDelete;
+            _autoDelete = autoDelete;
             _arguments = arguments;
         }
 
@@ -66,7 +66,7 @@ namespace RabbitMQ.Client.Impl
             _isServerNamed = old._isServerNamed;
             _durable = old._durable;
             _exclusive = old._exclusive;
-            _isAutoDelete = old._isAutoDelete;
+            _autoDelete = old._autoDelete;
             _arguments = old._arguments;
         }
 

--- a/projects/RabbitMQ.Client/client/impl/RecordedQueue.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedQueue.cs
@@ -34,7 +34,7 @@ using System.Collections.Generic;
 namespace RabbitMQ.Client.Impl
 {
 #nullable enable
-    internal readonly struct RecordedQueue
+    internal readonly struct RecordedQueue : IRecordedQueue
     {
         private readonly string _name;
         private readonly IDictionary<string, object>? _arguments;
@@ -44,8 +44,11 @@ namespace RabbitMQ.Client.Impl
         private readonly bool _isServerNamed;
 
         public string Name => _name;
-        public bool IsAutoDelete => _isAutoDelete;
+        public bool AutoDelete => _isAutoDelete;
         public bool IsServerNamed => _isServerNamed;
+        public bool Durable => _durable;
+        public bool Exclusive => _exclusive;
+        public IDictionary<string, object>? Arguments => _arguments;
 
         public RecordedQueue(string name, bool isServerNamed, bool durable, bool exclusive, bool autoDelete, IDictionary<string, object>? arguments)
         {
@@ -70,12 +73,12 @@ namespace RabbitMQ.Client.Impl
         public string Recover(IChannel channel)
         {
             var queueName = IsServerNamed ? string.Empty : Name;
-            return channel.QueueDeclare(queueName, _durable, _exclusive, IsAutoDelete, _arguments).QueueName;
+            return channel.QueueDeclare(queueName, _durable, _exclusive, AutoDelete, _arguments).QueueName;
         }
 
         public override string ToString()
         {
-            return $"{nameof(RecordedQueue)}: name = '{Name}', durable = {_durable}, exclusive = {_exclusive}, autoDelete = {IsAutoDelete}, arguments = '{_arguments}'";
+            return $"{nameof(RecordedQueue)}: name = '{Name}', durable = {_durable}, exclusive = {_exclusive}, autoDelete = {AutoDelete}, arguments = '{_arguments}'";
         }
     }
 }

--- a/projects/Unit/APIApproval.Approve.verified.txt
+++ b/projects/Unit/APIApproval.Approve.verified.txt
@@ -145,6 +145,8 @@ namespace RabbitMQ.Client
         public string Password { get; }
         public System.TimeSpan RequestedConnectionTimeout { get; }
         public bool TopologyRecoveryEnabled { get; }
+        public RabbitMQ.Client.TopologyRecoveryExceptionHandler TopologyRecoveryExceptionHandler { get; }
+        public RabbitMQ.Client.TopologyRecoveryFilter TopologyRecoveryFilter { get; }
         public string UserName { get; }
         public string VirtualHost { get; }
     }
@@ -184,6 +186,8 @@ namespace RabbitMQ.Client
         public System.TimeSpan SocketWriteTimeout { get; set; }
         public RabbitMQ.Client.SslOption Ssl { get; set; }
         public bool TopologyRecoveryEnabled { get; set; }
+        public RabbitMQ.Client.TopologyRecoveryExceptionHandler TopologyRecoveryExceptionHandler { get; set; }
+        public RabbitMQ.Client.TopologyRecoveryFilter TopologyRecoveryFilter { get; set; }
         public System.Uri Uri { get; set; }
         public string UserName { get; set; }
         public string VirtualHost { get; set; }
@@ -566,6 +570,38 @@ namespace RabbitMQ.Client
         bool IsTypePresent();
         bool IsUserIdPresent();
     }
+    public interface IRecordedBinding
+    {
+        System.Collections.Generic.IDictionary<string, object>? Arguments { get; }
+        string Destination { get; }
+        string RoutingKey { get; }
+        string Source { get; }
+    }
+    public interface IRecordedConsumer
+    {
+        System.Collections.Generic.IDictionary<string, object>? Arguments { get; }
+        bool AutoAck { get; }
+        string ConsumerTag { get; }
+        bool Exclusive { get; }
+        string Queue { get; }
+    }
+    public interface IRecordedExchange
+    {
+        System.Collections.Generic.IDictionary<string, object>? Arguments { get; }
+        bool AutoDelete { get; }
+        bool Durable { get; }
+        string Name { get; }
+        string Type { get; }
+    }
+    public interface IRecordedQueue
+    {
+        System.Collections.Generic.IDictionary<string, object>? Arguments { get; }
+        bool AutoDelete { get; }
+        bool Durable { get; }
+        bool Exclusive { get; }
+        bool IsServerNamed { get; }
+        string Name { get; }
+    }
     public interface IRecoverable
     {
         event System.EventHandler<System.EventArgs> Recovery;
@@ -688,6 +724,26 @@ namespace RabbitMQ.Client
         public bool Enabled { get; set; }
         public string ServerName { get; set; }
         public System.Security.Authentication.SslProtocols Version { get; set; }
+    }
+    public class TopologyRecoveryExceptionHandler
+    {
+        public TopologyRecoveryExceptionHandler() { }
+        public System.Func<RabbitMQ.Client.IRecordedBinding, System.Exception, bool> BindingRecoveryExceptionCondition { get; set; }
+        public System.Action<RabbitMQ.Client.IRecordedBinding, System.Exception, RabbitMQ.Client.IConnection> BindingRecoveryExceptionHandler { get; set; }
+        public System.Func<RabbitMQ.Client.IRecordedConsumer, System.Exception, bool> ConsumerRecoveryExceptionCondition { get; set; }
+        public System.Action<RabbitMQ.Client.IRecordedConsumer, System.Exception, RabbitMQ.Client.IConnection> ConsumerRecoveryExceptionHandler { get; set; }
+        public System.Func<RabbitMQ.Client.IRecordedExchange, System.Exception, bool> ExchangeRecoveryExceptionCondition { get; set; }
+        public System.Action<RabbitMQ.Client.IRecordedExchange, System.Exception, RabbitMQ.Client.IConnection> ExchangeRecoveryExceptionHandler { get; set; }
+        public System.Func<RabbitMQ.Client.IRecordedQueue, System.Exception, bool> QueueRecoveryExceptionCondition { get; set; }
+        public System.Action<RabbitMQ.Client.IRecordedQueue, System.Exception, RabbitMQ.Client.IConnection> QueueRecoveryExceptionHandler { get; set; }
+    }
+    public class TopologyRecoveryFilter
+    {
+        public TopologyRecoveryFilter() { }
+        public System.Func<RabbitMQ.Client.IRecordedBinding, bool> BindingFilter { get; set; }
+        public System.Func<RabbitMQ.Client.IRecordedConsumer, bool> ConsumerFilter { get; set; }
+        public System.Func<RabbitMQ.Client.IRecordedExchange, bool> ExchangeFilter { get; set; }
+        public System.Func<RabbitMQ.Client.IRecordedQueue, bool> QueueFilter { get; set; }
     }
 }
 namespace RabbitMQ.Client.Events

--- a/projects/Unit/Fixtures.cs
+++ b/projects/Unit/Fixtures.cs
@@ -163,6 +163,18 @@ namespace RabbitMQ.Client.Unit
             return (AutorecoveringConnection)cf.CreateConnection($"{_testDisplayName}:{Guid.NewGuid()}");
         }
 
+        internal AutorecoveringConnection CreateAutorecoveringConnectionWithTopologyRecoveryFilter(TopologyRecoveryFilter filter)
+        {
+            var cf = new ConnectionFactory
+            {
+                AutomaticRecoveryEnabled = true,
+                TopologyRecoveryEnabled = true,
+                TopologyRecoveryFilter = filter
+            };
+
+            return (AutorecoveringConnection)cf.CreateConnection($"{_testDisplayName}:{Guid.NewGuid()}");
+        }
+
         internal IConnection CreateConnectionWithContinuationTimeout(bool automaticRecoveryEnabled, TimeSpan continuationTimeout)
         {
             var cf = new ConnectionFactory

--- a/projects/Unit/Fixtures.cs
+++ b/projects/Unit/Fixtures.cs
@@ -175,6 +175,18 @@ namespace RabbitMQ.Client.Unit
             return (AutorecoveringConnection)cf.CreateConnection($"{_testDisplayName}:{Guid.NewGuid()}");
         }
 
+        internal AutorecoveringConnection CreateAutorecoveringConnectionWithTopologyRecoveryExceptionHandler(TopologyRecoveryExceptionHandler handler)
+        {
+            var cf = new ConnectionFactory
+            {
+                AutomaticRecoveryEnabled = true,
+                TopologyRecoveryEnabled = true,
+                TopologyRecoveryExceptionHandler = handler
+            };
+
+            return (AutorecoveringConnection)cf.CreateConnection($"{_testDisplayName}:{Guid.NewGuid()}");
+        }
+
         internal IConnection CreateConnectionWithContinuationTimeout(bool automaticRecoveryEnabled, TimeSpan continuationTimeout)
         {
             var cf = new ConnectionFactory

--- a/projects/Unit/TestConnectionRecovery.cs
+++ b/projects/Unit/TestConnectionRecovery.cs
@@ -1064,15 +1064,15 @@ namespace RabbitMQ.Client.Unit
             var latch = new ManualResetEventSlim(false);
             AutorecoveringConnection conn = CreateAutorecoveringConnectionWithTopologyRecoveryFilter(filter);
             conn.RecoverySucceeded += (source, ea) => latch.Set();
-            IModel ch = conn.CreateModel();
+            IChannel ch = conn.CreateChannel();
 
             var queueToRecover = "recovered.queue";
             var queueToIgnore = "filtered.queue";
             ch.QueueDeclare(queueToRecover, false, false, false, null);
             ch.QueueDeclare(queueToIgnore, false, false, false, null);
 
-            _model.QueueDelete(queueToRecover);
-            _model.QueueDelete(queueToIgnore);
+            _channel.QueueDelete(queueToRecover);
+            _channel.QueueDelete(queueToIgnore);
 
             try
             {
@@ -1108,15 +1108,15 @@ namespace RabbitMQ.Client.Unit
             var latch = new ManualResetEventSlim(false);
             AutorecoveringConnection conn = CreateAutorecoveringConnectionWithTopologyRecoveryFilter(filter);
             conn.RecoverySucceeded += (source, ea) => latch.Set();
-            IModel ch = conn.CreateModel();
+            IChannel ch = conn.CreateChannel();
 
             var exchangeToRecover = "recovered.exchange";
             var exchangeToIgnore = "filtered.exchange";
             ch.ExchangeDeclare(exchangeToRecover, "topic", false, true);
             ch.ExchangeDeclare(exchangeToIgnore, "direct", false, true);
 
-            _model.ExchangeDelete(exchangeToRecover);
-            _model.ExchangeDelete(exchangeToIgnore);
+            _channel.ExchangeDelete(exchangeToRecover);
+            _channel.ExchangeDelete(exchangeToIgnore);
 
             try
             {
@@ -1152,7 +1152,7 @@ namespace RabbitMQ.Client.Unit
             var latch = new ManualResetEventSlim(false);
             AutorecoveringConnection conn = CreateAutorecoveringConnectionWithTopologyRecoveryFilter(filter);
             conn.RecoverySucceeded += (source, ea) => latch.Set();
-            IModel ch = conn.CreateModel();
+            IChannel ch = conn.CreateChannel();
 
             var exchange = "topology.recovery.exchange";
             var queueWithRecoveredBinding = "topology.recovery.queue.1";
@@ -1168,8 +1168,8 @@ namespace RabbitMQ.Client.Unit
             ch.QueuePurge(queueWithRecoveredBinding);
             ch.QueuePurge(queueWithIgnoredBinding);
 
-            _model.QueueUnbind(queueWithRecoveredBinding, exchange, bindingToRecover);
-            _model.QueueUnbind(queueWithIgnoredBinding, exchange, bindingToIgnore);
+            _channel.QueueUnbind(queueWithRecoveredBinding, exchange, bindingToRecover);
+            _channel.QueueUnbind(queueWithIgnoredBinding, exchange, bindingToIgnore);
 
             try
             {
@@ -1196,7 +1196,7 @@ namespace RabbitMQ.Client.Unit
             var latch = new ManualResetEventSlim(false);
             AutorecoveringConnection conn = CreateAutorecoveringConnectionWithTopologyRecoveryFilter(filter);
             conn.RecoverySucceeded += (source, ea) => latch.Set();
-            IModel ch = conn.CreateModel();
+            IChannel ch = conn.CreateChannel();
             ch.ConfirmSelect();
 
             var exchange = "topology.recovery.exchange";
@@ -1260,7 +1260,7 @@ namespace RabbitMQ.Client.Unit
             var latch = new ManualResetEventSlim(false);
             AutorecoveringConnection conn = CreateAutorecoveringConnectionWithTopologyRecoveryFilter(filter);
             conn.RecoverySucceeded += (source, ea) => latch.Set();
-            IModel ch = conn.CreateModel();
+            IChannel ch = conn.CreateChannel();
             ch.ConfirmSelect();
 
             var exchange = "topology.recovery.exchange";
@@ -1287,9 +1287,9 @@ namespace RabbitMQ.Client.Unit
             consumer2.Received += (source, ea) => consumerLatch2.Set();
             ch.BasicConsume(queue2, true, "filtered.consumer", consumer2);
 
-            _model.ExchangeDelete(exchange);
-            _model.QueueDelete(queue1);
-            _model.QueueDelete(queue2);
+            _channel.ExchangeDelete(exchange);
+            _channel.QueueDelete(queue1);
+            _channel.QueueDelete(queue2);
 
             try
             {
@@ -1330,25 +1330,25 @@ namespace RabbitMQ.Client.Unit
                 },
                 QueueRecoveryExceptionHandler = (rq, ex, connection) =>
                 {
-                    using (var model = connection.CreateModel())
+                    using (var channel = connection.CreateChannel())
                     {
-                        model.QueueDeclare(rq.Name, false, false, false, changedQueueArguments);
+                        channel.QueueDeclare(rq.Name, false, false, false, changedQueueArguments);
                     }
                 }
             };
             var latch = new ManualResetEventSlim(false);
             AutorecoveringConnection conn = CreateAutorecoveringConnectionWithTopologyRecoveryExceptionHandler(exceptionHandler);
             conn.RecoverySucceeded += (source, ea) => latch.Set();
-            IModel ch = conn.CreateModel();
+            IChannel ch = conn.CreateChannel();
 
             var queueToRecoverWithException = "recovery.exception.queue";
             var queueToRecoverSuccessfully = "successfully.recovered.queue";
             ch.QueueDeclare(queueToRecoverWithException, false, false, false, null);
             ch.QueueDeclare(queueToRecoverSuccessfully, false, false, false, null);
 
-            _model.QueueDelete(queueToRecoverSuccessfully);
-            _model.QueueDelete(queueToRecoverWithException);
-            _model.QueueDeclare(queueToRecoverWithException, false, false, false, changedQueueArguments);
+            _channel.QueueDelete(queueToRecoverSuccessfully);
+            _channel.QueueDelete(queueToRecoverWithException);
+            _channel.QueueDeclare(queueToRecoverWithException, false, false, false, changedQueueArguments);
 
             try
             {
@@ -1362,7 +1362,7 @@ namespace RabbitMQ.Client.Unit
             finally
             {
                 //Cleanup
-                _model.QueueDelete(queueToRecoverWithException);
+                _channel.QueueDelete(queueToRecoverWithException);
 
                 conn.Abort();
             }
@@ -1381,25 +1381,25 @@ namespace RabbitMQ.Client.Unit
                 },
                 ExchangeRecoveryExceptionHandler = (re, ex, connection) =>
                 {
-                    using (var model = connection.CreateModel())
+                    using (var channel = connection.CreateChannel())
                     {
-                        model.ExchangeDeclare(re.Name, "topic", false, false);
+                        channel.ExchangeDeclare(re.Name, "topic", false, false);
                     }
                 }
             };
             var latch = new ManualResetEventSlim(false);
             AutorecoveringConnection conn = CreateAutorecoveringConnectionWithTopologyRecoveryExceptionHandler(exceptionHandler);
             conn.RecoverySucceeded += (source, ea) => latch.Set();
-            IModel ch = conn.CreateModel();
+            IChannel ch = conn.CreateChannel();
 
             var exchangeToRecoverWithException = "recovery.exception.exchange";
             var exchangeToRecoverSuccessfully = "successfully.recovered.exchange";
             ch.ExchangeDeclare(exchangeToRecoverWithException, "direct", false, false);
             ch.ExchangeDeclare(exchangeToRecoverSuccessfully, "direct", false, false);
 
-            _model.ExchangeDelete(exchangeToRecoverSuccessfully);
-            _model.ExchangeDelete(exchangeToRecoverWithException);
-            _model.ExchangeDeclare(exchangeToRecoverWithException, "topic", false, false);
+            _channel.ExchangeDelete(exchangeToRecoverSuccessfully);
+            _channel.ExchangeDelete(exchangeToRecoverWithException);
+            _channel.ExchangeDeclare(exchangeToRecoverWithException, "topic", false, false);
 
             try
             {
@@ -1413,7 +1413,7 @@ namespace RabbitMQ.Client.Unit
             finally
             {
                 //Cleanup
-                _model.ExchangeDelete(exchangeToRecoverWithException);
+                _channel.ExchangeDelete(exchangeToRecoverWithException);
 
                 conn.Abort();
             }
@@ -1436,22 +1436,22 @@ namespace RabbitMQ.Client.Unit
                 },
                 BindingRecoveryExceptionHandler = (b, ex, connection) =>
                 {
-                    using (var model = connection.CreateModel())
+                    using (var channel = connection.CreateChannel())
                     {
-                        model.QueueDeclare(queueWithExceptionBinding, false, false, false, null);
-                        model.QueueBind(queueWithExceptionBinding, exchange, bindingToRecoverWithException);
+                        channel.QueueDeclare(queueWithExceptionBinding, false, false, false, null);
+                        channel.QueueBind(queueWithExceptionBinding, exchange, bindingToRecoverWithException);
                     }
                 }
             };
             var latch = new ManualResetEventSlim(false);
             AutorecoveringConnection conn = CreateAutorecoveringConnectionWithTopologyRecoveryExceptionHandler(exceptionHandler);
             conn.RecoverySucceeded += (source, ea) => latch.Set();
-            IModel ch = conn.CreateModel();
+            IChannel ch = conn.CreateChannel();
 
             var queueWithRecoveredBinding = "successfully.recovered.queue";
             var bindingToRecoverSuccessfully = "successfully.recovered.binding";
 
-            _model.QueueDeclare(queueWithExceptionBinding, false, false, false, null);
+            _channel.QueueDeclare(queueWithExceptionBinding, false, false, false, null);
 
             ch.ExchangeDeclare(exchange, "direct");
             ch.QueueDeclare(queueWithRecoveredBinding, false, false, false, null);
@@ -1460,9 +1460,9 @@ namespace RabbitMQ.Client.Unit
             ch.QueuePurge(queueWithRecoveredBinding);
             ch.QueuePurge(queueWithExceptionBinding);
 
-            _model.QueueUnbind(queueWithRecoveredBinding, exchange, bindingToRecoverSuccessfully);
-            _model.QueueUnbind(queueWithExceptionBinding, exchange, bindingToRecoverWithException);
-            _model.QueueDelete(queueWithExceptionBinding);
+            _channel.QueueUnbind(queueWithRecoveredBinding, exchange, bindingToRecoverSuccessfully);
+            _channel.QueueUnbind(queueWithExceptionBinding, exchange, bindingToRecoverWithException);
+            _channel.QueueDelete(queueWithExceptionBinding);
 
             try
             {
@@ -1494,9 +1494,9 @@ namespace RabbitMQ.Client.Unit
                 },
                 ConsumerRecoveryExceptionHandler = (c, ex, connection) =>
                 {
-                    using (var model = connection.CreateModel())
+                    using (var channel = connection.CreateChannel())
                     {
-                        model.QueueDeclare(queueWithExceptionConsumer, false, false, false, null);
+                        channel.QueueDeclare(queueWithExceptionConsumer, false, false, false, null);
                     }
 
                     // So topology recovery runs again. This time he missing queue should exist, making
@@ -1507,18 +1507,18 @@ namespace RabbitMQ.Client.Unit
             var latch = new ManualResetEventSlim(false);
             AutorecoveringConnection conn = CreateAutorecoveringConnectionWithTopologyRecoveryExceptionHandler(exceptionHandler);
             conn.RecoverySucceeded += (source, ea) => latch.Set();
-            IModel ch = conn.CreateModel();
+            IChannel ch = conn.CreateChannel();
             ch.ConfirmSelect();
 
-            _model.QueueDeclare(queueWithExceptionConsumer, false, false, false, null);
-            _model.QueuePurge(queueWithExceptionConsumer);
+            _channel.QueueDeclare(queueWithExceptionConsumer, false, false, false, null);
+            _channel.QueuePurge(queueWithExceptionConsumer);
 
             var recoverLatch = new ManualResetEventSlim(false);
             var consumerToRecover = new EventingBasicConsumer(ch);
             consumerToRecover.Received += (source, ea) => recoverLatch.Set();
             ch.BasicConsume(queueWithExceptionConsumer, true, "exception.consumer", consumerToRecover);
 
-            _model.QueueDelete(queueWithExceptionConsumer);
+            _channel.QueueDelete(queueWithExceptionConsumer);
 
             try
             {
@@ -1549,7 +1549,7 @@ namespace RabbitMQ.Client.Unit
 
         internal bool SendAndConsumeMessage(string queue, string exchange, string routingKey)
         {
-            using (var ch = _conn.CreateModel())
+            using (var ch = _conn.CreateChannel())
             {
                 var latch = new ManualResetEventSlim(false);
 


### PR DESCRIPTION
Fixes #658 

## Proposed Changes

This PR introduces changes that address issue #658. The changes I made are based on @acogoluegnes's suggestion of adapting the features related to topology recovery included in the Java client.

For topology recovery filtering, I added class `TopologyRecoveryFilter`, which is initialized at the `ConnectionFactory` level. It allows users to specify filters for each type of recorded entity (exchanges, queues, bindings, consumers). During topology recovery, the recorded entities will or won't be recovered based on whether they match the condition specified in the `TopologyRecoveryFilter` or not. If no filter is specified for an entity type, all entities of that type will be recovered.

For exception handling, I added class `TopologyRecoveryExceptionHandler`, which is also initialized at the `ConnectionFactory` level. For each type of recorded entity, it allows users to provide: a custom exception handler, which defines what action is taken in the case of an exception, and a condition, which determines what exceptions the custom exception handler applies to. If no custom exception handler is specified for an entity type, the default exception handling behavior (defined in `HandleTopologyRecoveryException()`) is used for all exceptions.

## Types of Changes

What types of changes does your code introduce to this project?

- [x] Bug fix (non-breaking change which fixes issue #658)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
