### PR TITLE
Target netstandard2.1

### DIFF
--- a/projects/Benchmarks/Benchmarks.csproj
+++ b/projects/Benchmarks/Benchmarks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AssemblyOriginatorKeyFile>../rabbit.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/projects/RabbitMQ.Client/RabbitMQ.Client.csproj
+++ b/projects/RabbitMQ.Client/RabbitMQ.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyTitle>RabbitMQ Client Library for .NET</AssemblyTitle>

--- a/projects/TestApplications/CreateChannel/CreateChannel.csproj
+++ b/projects/TestApplications/CreateChannel/CreateChannel.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/projects/TestApplications/MassPublish/MassPublish.csproj
+++ b/projects/TestApplications/MassPublish/MassPublish.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/projects/Unit/Unit.csproj
+++ b/projects/Unit/Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
     <AssemblyOriginatorKeyFile>../rabbit.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <LangVersion>latest</LangVersion>

--- a/run-test.sh
+++ b/run-test.sh
@@ -13,4 +13,4 @@ fi
 
 cd "$script_dir"
 
-dotnet test --no-build --logger 'console;verbosity=detailed' --framework 'net6.0' ./RabbitMQDotNetClient.sln < /dev/null
+dotnet test --no-build --logger 'console;verbosity=detailed' ./RabbitMQDotNetClient.sln < /dev/null


### PR DESCRIPTION
In `main` it feels appropriate to target a supported modern LTS version of .NET.

Per discussion with @Zerpet.