### PR TITLE
Fix consumer recovery with server-named queues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,8 @@ build/
 [Oo]bj/
 *.lock.json
 
-APIApproval.Approve.received.txt
+projects/Unit/APIApproval.Approve.received.txt
+projects/Unit/APIApproval.Approve.*.received.txt
 
 # Visual Studio 2015 cache/options directory
 .vs/

--- a/projects/RabbitMQ.Client/client/api/IModel.cs
+++ b/projects/RabbitMQ.Client/client/api/IModel.cs
@@ -98,6 +98,14 @@ namespace RabbitMQ.Client
         ulong NextPublishSeqNo { get; }
 
         /// <summary>
+        /// The name of the last queue declared on this channel.
+        /// </summary>
+        /// <remarks>
+        /// https://www.rabbitmq.com/amqp-0-9-1-reference.html#domain.queue-name
+        /// </remarks>
+        string CurrentQueue { get; }
+
+        /// <summary>
         /// Signalled when a Basic.Ack command arrives from the broker.
         /// </summary>
         event EventHandler<BasicAckEventArgs> BasicAcks;

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringModel.cs
@@ -395,6 +395,19 @@ namespace RabbitMQ.Client.Impl
             }
         }
 
+        public string CurrentQueue
+        {
+            get
+            {
+                if (_disposed)
+                {
+                    throw new ObjectDisposedException(GetType().FullName);
+                }
+
+                return _delegate.CurrentQueue;
+            }
+        }
+
         public void AutomaticallyRecover(AutorecoveringConnection conn, bool recoverConsumers)
         {
             if (_disposed)

--- a/projects/RabbitMQ.Client/client/impl/ModelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ModelBase.cs
@@ -170,6 +170,8 @@ namespace RabbitMQ.Client.Impl
 
         public ulong NextPublishSeqNo { get; private set; }
 
+        public string CurrentQueue { get; private set; }
+
         public ISession Session { get; private set; }
 
         public Task Close(ushort replyCode, string replyText, bool abort)
@@ -1481,7 +1483,9 @@ namespace RabbitMQ.Client.Impl
                 _Private_QueueDeclare(queue, passive, durable, exclusive, autoDelete, false, arguments);
                 k.GetReply(ContinuationTimeout);
             }
-            return k.m_result;
+            QueueDeclareOk result = k.m_result;
+            CurrentQueue = result.QueueName;
+            return result;
         }
 
 

--- a/projects/Unit/APIApproval.Approve.verified.txt
+++ b/projects/Unit/APIApproval.Approve.verified.txt
@@ -385,6 +385,7 @@ namespace RabbitMQ.Client
         int ChannelNumber { get; }
         RabbitMQ.Client.ShutdownEventArgs CloseReason { get; }
         System.TimeSpan ContinuationTimeout { get; set; }
+        string CurrentQueue { get; }
         RabbitMQ.Client.IBasicConsumer DefaultConsumer { get; set; }
         bool IsClosed { get; }
         bool IsOpen { get; }


### PR DESCRIPTION
Fixes #1238

* Add failing test
* Fix `RecordedConsumer` to allow the empty string for a queue name