### PR TITLE
Fix consumer recovery with server-named queues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,8 @@ build/
 
 BenchmarkDotNet.Artifacts/*
 
-APIApproval.Approve.received.txt
+projects/Unit/APIApproval.Approve.received.txt
+projects/Unit/APIApproval.Approve.*.received.txt
 
 # Visual Studio 2015 cache/options directory
 .vs/

--- a/projects/RabbitMQ.Client/client/api/IChannel.cs
+++ b/projects/RabbitMQ.Client/client/api/IChannel.cs
@@ -98,6 +98,14 @@ namespace RabbitMQ.Client
         ulong NextPublishSeqNo { get; }
 
         /// <summary>
+        /// The name of the last queue declared on this channel.
+        /// </summary>
+        /// <remarks>
+        /// https://www.rabbitmq.com/amqp-0-9-1-reference.html#domain.queue-name
+        /// </remarks>
+        string CurrentQueue { get; }
+
+        /// <summary>
         /// Signalled when a Basic.Ack command arrives from the broker.
         /// </summary>
         event EventHandler<BasicAckEventArgs> BasicAcks;

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringChannel.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringChannel.cs
@@ -123,23 +123,76 @@ namespace RabbitMQ.Client.Impl
             remove { InnerChannel.Recovery -= value; }
         }
 
-        public IEnumerable<string> ConsumerTags => _recordedConsumerTags;
+        public IEnumerable<string> ConsumerTags
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return _recordedConsumerTags;
+            }
+        }
 
-        public int ChannelNumber => InnerChannel.ChannelNumber;
+        public int ChannelNumber
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return InnerChannel.ChannelNumber;
+            }
+        }
 
-        public ShutdownEventArgs CloseReason => InnerChannel.CloseReason;
+        public ShutdownEventArgs CloseReason
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return InnerChannel.CloseReason;
+            }
+        }
 
         public IBasicConsumer DefaultConsumer
         {
-            get => InnerChannel.DefaultConsumer;
-            set => InnerChannel.DefaultConsumer = value;
+            get
+            {
+                ThrowIfDisposed();
+                return InnerChannel.DefaultConsumer;
+            }
+
+            set
+            {
+                ThrowIfDisposed();
+                InnerChannel.DefaultConsumer = value;
+            }
         }
 
         public bool IsClosed => !IsOpen;
 
-        public bool IsOpen => _innerChannel != null && _innerChannel.IsOpen;
+        public bool IsOpen
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return _innerChannel != null && _innerChannel.IsOpen;
+            }
+        }
 
-        public ulong NextPublishSeqNo => InnerChannel.NextPublishSeqNo;
+        public ulong NextPublishSeqNo
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return InnerChannel.NextPublishSeqNo;
+            }
+        }
+
+        public string CurrentQueue
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return InnerChannel.CurrentQueue;
+            }
+        }
 
         internal void AutomaticallyRecover(AutorecoveringConnection conn, bool recoverConsumers)
         {

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recording.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recording.cs
@@ -152,7 +152,7 @@ namespace RabbitMQ.Client.Framing.Impl
                 {
                     if (consumer.Queue == oldName)
                     {
-                        _recordedConsumers[consumer.ConsumerTag] = RecordedConsumer.WithNewQueueNameTag(newName, consumer);
+                        _recordedConsumers[consumer.ConsumerTag] = RecordedConsumer.WithNewQueueName(newName, consumer);
                     }
                 }
             }

--- a/projects/RabbitMQ.Client/client/impl/ChannelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ChannelBase.cs
@@ -175,6 +175,8 @@ namespace RabbitMQ.Client.Impl
 
         public ulong NextPublishSeqNo { get; private set; }
 
+        public string CurrentQueue { get; private set; }
+
         public ISession Session { get; private set; }
 
         protected void TakeOver(ChannelBase other)
@@ -1169,7 +1171,9 @@ namespace RabbitMQ.Client.Impl
                 _Private_QueueDeclare(queue, passive, durable, exclusive, autoDelete, false, arguments);
                 k.GetReply(ContinuationTimeout);
             }
-            return k.m_result;
+            QueueDeclareOk result = k.m_result;
+            CurrentQueue = result.QueueName;
+            return result;
         }
 
 

--- a/projects/RabbitMQ.Client/client/impl/RecordedConsumer.cs
+++ b/projects/RabbitMQ.Client/client/impl/RecordedConsumer.cs
@@ -59,11 +59,21 @@ namespace RabbitMQ.Client.Impl
             }
             _consumer = consumer;
 
-            if (string.IsNullOrEmpty(queue))
+            if (queue is null)
             {
                 throw new ArgumentNullException(nameof(queue));
             }
-            _queue = queue;
+            else
+            {
+                if (queue == string.Empty)
+                {
+                    _queue = _channel.CurrentQueue;
+                }
+                else
+                {
+                    _queue = queue;
+                }
+            }
 
             if (string.IsNullOrEmpty(consumerTag))
             {
@@ -89,7 +99,7 @@ namespace RabbitMQ.Client.Impl
             return new RecordedConsumer(old.Channel, old.Consumer, newTag, old.Queue, old.AutoAck, old.Exclusive, old.Arguments);
         }
 
-        public static RecordedConsumer WithNewQueueNameTag(string newQueueName, in RecordedConsumer old)
+        public static RecordedConsumer WithNewQueueName(string newQueueName, in RecordedConsumer old)
         {
             return new RecordedConsumer(old.Channel, old.Consumer, old.ConsumerTag, newQueueName, old.AutoAck, old.Exclusive, old.Arguments);
         }

--- a/projects/Unit/APIApproval.Approve.verified.txt
+++ b/projects/Unit/APIApproval.Approve.verified.txt
@@ -380,6 +380,7 @@ namespace RabbitMQ.Client
         int ChannelNumber { get; }
         RabbitMQ.Client.ShutdownEventArgs CloseReason { get; }
         System.TimeSpan ContinuationTimeout { get; set; }
+        string CurrentQueue { get; }
         RabbitMQ.Client.IBasicConsumer DefaultConsumer { get; set; }
         bool IsClosed { get; }
         bool IsOpen { get; }


### PR DESCRIPTION
Port of #1324 to main

Fixes #1238

* Add failing test
* Fix `RecordedConsumer` to allow the empty string for a queue name
* Add `CurrentQueue` to `IChannel` to keep track of the last declared queue name as defined in the AMQP 091 spec
* Fix `RecordedConsumer` to use `CurrentQueue` when passed in name is `string.Empty`
* Fixup API Approval