### PR TITLE
Update Task.Factory.StartNew to specify TaskScheduler.Default

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -850,7 +850,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public void StartMainLoop(bool useBackgroundThread)
         {
-            _mainLoopTask = Task.Factory.StartNew(MainLoop, TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach);
+            _mainLoopTask = Task.Factory.StartNew(MainLoop, CancellationToken.None, TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
         }
 
         public void HeartbeatReadTimerCallback(object state)


### PR DESCRIPTION
## Proposed Changes

Without specifying TaskScheduler.Default explicitly it will use TaskScheduler.Current, which could lead to unexpected behavior depending on what tasks call into this code

This fixes https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/1357

## Types of Changes

What types of changes does your code introduce to this project?

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
