### PR TITLE
Fix #1370 by making copy of default AuthMechanisms

### DIFF
--- a/projects/RabbitMQ.Client/client/api/ConnectionFactory.cs
+++ b/projects/RabbitMQ.Client/client/api/ConnectionFactory.cs
@@ -153,7 +153,7 @@ namespace RabbitMQ.Client
         /// <summary>
         ///  SASL auth mechanisms to use.
         /// </summary>
-        public IList<IAuthMechanismFactory> AuthMechanisms { get; set; } = DefaultAuthMechanisms;
+        public IList<IAuthMechanismFactory> AuthMechanisms { get; set; } = DefaultAuthMechanisms.ToList();
 
         /// <summary>
         /// Address family used by default.

--- a/projects/Unit/TestConnectionFactory.cs
+++ b/projects/Unit/TestConnectionFactory.cs
@@ -279,5 +279,14 @@ namespace RabbitMQ.Client.Unit
             var ep = new AmqpTcpEndpoint("localhost");
             using(IConnection conn = cf.CreateConnection(new List<AmqpTcpEndpoint> { invalidEp, ep })) {};
         }
+
+        [Test]
+        public void TestCreateConnectionTwiceDoesntClearAuthMechanisms()
+        {
+            var cf = new ConnectionFactory();
+            cf.AuthMechanisms.Clear();
+            var cf2 = new ConnectionFactory();
+            Assert.That(cf2.AuthMechanisms.Count, Is.EqualTo(1));
+        }
     }
 }


### PR DESCRIPTION
## Proposed Changes
This fixes #1370 by making a copy of the default auth mechanisms, rather than providing a reference to the static (shared) DefaultAuthMechansisms

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x ] Bug fix (non-breaking change which fixes issue #1370)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x ] I have read the `CONTRIBUTING.md` document
- [x ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x ] All tests pass locally with my changes
- [x ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
