### PR TITLE
Update API documentation of MaxMessageSize

### DIFF
--- a/projects/RabbitMQ.Client/client/api/AmqpTcpEndpoint.cs
+++ b/projects/RabbitMQ.Client/client/api/AmqpTcpEndpoint.cs
@@ -70,13 +70,14 @@ namespace RabbitMQ.Client
         /// <param name="hostName">Hostname.</param>
         /// <param name="portOrMinusOne"> Port number. If the port number is -1, the default port number will be used.</param>
         /// <param name="ssl">Ssl option.</param>
-        /// <param name="maxMessageSize">Maximum message size from RabbitMQ. 0 means "unlimited"</param>
+        /// <param name="maxMessageSize">Maximum message size from RabbitMQ. <see cref="ConnectionFactory.MaximumMaxMessageSize"/>. It defaults to 
+        /// MaximumMaxMessageSize if the parameter is greater than MaximumMaxMessageSize.</param>
         public AmqpTcpEndpoint(string hostName, int portOrMinusOne, SslOption ssl, uint maxMessageSize)
         {
             HostName = hostName;
             _port = portOrMinusOne;
             Ssl = ssl;
-            _maxMessageSize = Math.Min(maxMessageSize, ConnectionFactory.DefaultMaxMessageSize);
+            _maxMessageSize = Math.Min(maxMessageSize, ConnectionFactory.MaximumMaxMessageSize);
         }
 
         /// <summary>
@@ -193,7 +194,8 @@ namespace RabbitMQ.Client
         public SslOption Ssl { get; set; }
 
         /// <summary>
-        /// Get the maximum size for a message in bytes. The default value is 128MiB to match RabbitMQ's default
+        /// Get the maximum size for a message in bytes. 
+        /// The default value is defined in <see cref="ConnectionFactory.DefaultMaxMessageSize"/>. 
         /// </summary>
         public uint MaxMessageSize
         {

--- a/projects/RabbitMQ.Client/client/api/ConnectionFactory.cs
+++ b/projects/RabbitMQ.Client/client/api/ConnectionFactory.cs
@@ -105,11 +105,15 @@ namespace RabbitMQ.Client
         public const uint DefaultFrameMax = 0;
 
         /// <summary>
-        /// Default value for the maximum allowed message size, in bytes, from RabbitMQ.
-        /// Corresponds to the <code>rabbit.max_message_size</code> setting.
-        /// Note: the default is 0 which means "unlimited".
+        /// Default value for <code>ConnectionFactory</code>'s <code>MaxMessageSize</code>.        
         /// </summary>
-        public const uint DefaultMaxMessageSize = 536870912;
+        public const uint DefaultMaxMessageSize = 134217728;
+        /// <summary>
+        /// Largest message size, in bytes, allowed in RabbitMQ.        
+        /// Note: <code>rabbit.max_message_size</code> setting (https://www.rabbitmq.com/configure.html)
+        /// configures the largest message size which should be lower than this maximum of 536 Mbs.
+        /// </summary>
+        public const uint MaximumMaxMessageSize = 536870912;
 
         /// <summary>
         /// Default value for desired heartbeat interval. Default is 60 seconds,
@@ -351,7 +355,7 @@ namespace RabbitMQ.Client
 
         /// <summary>
         /// Maximum allowed message size, in bytes, from RabbitMQ.
-        /// Corresponds to the <code>rabbit.max_message_size</code> setting.
+        /// Corresponds to the <code>ConnectionFactory.DefaultMaxMessageSize</code> setting.
         /// </summary>
         public uint MaxMessageSize { get; set; } = DefaultMaxMessageSize;
 

--- a/projects/Unit/APIApproval.Approve.verified.txt
+++ b/projects/Unit/APIApproval.Approve.verified.txt
@@ -165,10 +165,11 @@ namespace RabbitMQ.Client
     {
         public const ushort DefaultChannelMax = 2047;
         public const uint DefaultFrameMax = 0u;
-        public const uint DefaultMaxMessageSize = 536870912u;
+        public const uint DefaultMaxMessageSize = 134217728u;
         public const string DefaultPass = "guest";
         public const string DefaultUser = "guest";
         public const string DefaultVHost = "/";
+        public const uint MaximumMaxMessageSize = 536870912u;
         public static readonly System.Collections.Generic.IList<RabbitMQ.Client.IAuthMechanismFactory> DefaultAuthMechanisms;
         public static readonly System.TimeSpan DefaultConnectionTimeout;
         public static readonly RabbitMQ.Client.ICredentialsRefresher DefaultCredentialsRefresher;

--- a/projects/Unit/TestConnectionFactory.cs
+++ b/projects/Unit/TestConnectionFactory.cs
@@ -268,6 +268,12 @@ namespace RabbitMQ.Client.Unit
         }
 
         [Fact]
+        public void TestCreateAmqpTCPEndPointOverridesMaxMessageSizeWhenGreaterThanMaximumAllowed()
+        {
+            var ep = new AmqpTcpEndpoint("localhost", -1, new SslOption(), ConnectionFactory.MaximumMaxMessageSize);
+        }
+
+        [Fact]
         public void TestCreateConnectionUsesConfiguredMaxMessageSize()
         {
             var cf = new ConnectionFactory();


### PR DESCRIPTION
Update api docs with regards `Connection.MaxMessageSize` and `ConnectionFactory.DefaultMaxMessageSize`. 

Add a new constant called `ConnectionFactory.MaximumMaxMessageSize` for the maximum allowed value in RabbitMQ. And use a lower value for  `ConnectionFactory.DefaultMaxMessageSize` 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [X] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)


