### PR TITLE
Added a synchronous write loop for connections.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,9 @@ projects/Unit*/TestResult.xml
 # Vim
 .sw?
 .*.sw?
+
+
+#################
+## JetBrains Rider
+#################
+.idea/

--- a/projects/RabbitMQ.Client/client/api/ConnectionFactory.cs
+++ b/projects/RabbitMQ.Client/client/api/ConnectionFactory.cs
@@ -275,6 +275,13 @@ namespace RabbitMQ.Client
         public bool TopologyRecoveryEnabled { get; set; } = true;
 
         /// <summary>
+        /// Force writes to the socket to run on a dedicated thread instead of the thread pool. This may prevent
+        /// timeouts if a large number of blocking requests are going out simultaneously. Will become obsolete
+        /// once requests become asynchronous. Defaults to false.
+        /// </summary>
+        public bool EnableSynchronousWriteLoop { get; set; } = false;
+
+        /// <summary>
         /// Filter to include/exclude entities from topology recovery.
         /// Default filter includes all entities in topology recovery.
         /// </summary>
@@ -640,7 +647,7 @@ namespace RabbitMQ.Client
         internal IFrameHandler CreateFrameHandler(AmqpTcpEndpoint endpoint)
         {
             IFrameHandler fh = Protocols.DefaultProtocol.CreateFrameHandler(endpoint, _memoryPool, SocketFactory,
-                RequestedConnectionTimeout, SocketReadTimeout, SocketWriteTimeout);
+                RequestedConnectionTimeout, SocketReadTimeout, SocketWriteTimeout, EnableSynchronousWriteLoop);
             return ConfigureFrameHandler(fh);
         }
 

--- a/projects/RabbitMQ.Client/client/impl/IProtocolExtensions.cs
+++ b/projects/RabbitMQ.Client/client/impl/IProtocolExtensions.cs
@@ -45,9 +45,10 @@ namespace RabbitMQ.Client.Framing.Impl
             Func<AddressFamily, ITcpClient> socketFactory,
             TimeSpan connectionTimeout,
             TimeSpan readTimeout,
-            TimeSpan writeTimeout)
+            TimeSpan writeTimeout,
+            bool enableSynchronousWriteLoop)
         {
-            return new SocketFrameHandler(endpoint, socketFactory, connectionTimeout, readTimeout, writeTimeout)
+            return new SocketFrameHandler(endpoint, socketFactory, connectionTimeout, readTimeout, writeTimeout, enableSynchronousWriteLoop)
             {
                 MemoryPool = pool
             };

--- a/projects/Unit/TestConnectionFactory.cs
+++ b/projects/Unit/TestConnectionFactory.cs
@@ -162,6 +162,20 @@ namespace RabbitMQ.Client.Unit
         }
 
         [Test]
+        public void TestCreateConnectionWithSynchronousWriteLoop()
+        {
+            var cf = new ConnectionFactory
+            {
+                AutomaticRecoveryEnabled = true,
+                HostName = "localhost",
+                EnableSynchronousWriteLoop = true
+            };
+            using (IConnection conn = cf.CreateConnection()){
+                Assert.AreEqual(5672, conn.Endpoint.Port);
+            }
+        }
+
+        [Test]
         public void TestCreateConnectionUsesDefaultPort()
         {
             var cf = new ConnectionFactory


### PR DESCRIPTION
## Proposed Changes

Add an option to make the WriteLoop in the SocketFrameHandler run in its own dedicated thread. In this version (6.x) most operations are blocking (CreateModel, QueueDeclare etc...) using BlockingCell. This can create a situation where all the threadpool threads are blocked waiting for a response to a message that can't get sent because there are no threads left for the WriteLoop. See #1354 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #1354)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
