### PR TITLE
Ensure tests that interact with RabbitMQ do not run in parallel

### DIFF
--- a/projects/Unit/TestAmqpTcpEndpointParsing.cs
+++ b/projects/Unit/TestAmqpTcpEndpointParsing.cs
@@ -30,12 +30,10 @@
 //---------------------------------------------------------------------------
 
 using System;
-
 using Xunit;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestAmqpTcpEndpointParsing
     {
         [Fact]

--- a/projects/Unit/TestAmqpUri.cs
+++ b/projects/Unit/TestAmqpUri.cs
@@ -30,7 +30,6 @@
 //---------------------------------------------------------------------------
 
 using System;
-
 using Xunit;
 
 namespace RabbitMQ.Client.Unit

--- a/projects/Unit/TestAsyncConsumer.cs
+++ b/projects/Unit/TestAsyncConsumer.cs
@@ -34,13 +34,13 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-
 using RabbitMQ.Client.Events;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
+    [Collection("IntegrationFixture")]
     public class TestAsyncConsumer
     {
         private readonly ITestOutputHelper _output;

--- a/projects/Unit/TestAsyncConsumerExceptions.cs
+++ b/projects/Unit/TestAsyncConsumerExceptions.cs
@@ -32,9 +32,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-
 using RabbitMQ.Client.Events;
-
 using Xunit;
 using Xunit.Abstractions;
 

--- a/projects/Unit/TestAuth.cs
+++ b/projects/Unit/TestAuth.cs
@@ -30,15 +30,13 @@
 //---------------------------------------------------------------------------
 
 using RabbitMQ.Client.Exceptions;
-
 using Xunit;
 
 namespace RabbitMQ.Client.Unit
 {
-
+    [Collection("IntegrationFixture")]
     public class TestAuth
     {
-
         [Fact]
         public void TestAuthFailure()
         {
@@ -60,4 +58,3 @@ namespace RabbitMQ.Client.Unit
         }
     }
 }
-

--- a/projects/Unit/TestBasicGet.cs
+++ b/projects/Unit/TestBasicGet.cs
@@ -30,7 +30,6 @@
 //---------------------------------------------------------------------------
 
 using RabbitMQ.Client.Exceptions;
-
 using Xunit;
 using Xunit.Abstractions;
 

--- a/projects/Unit/TestBasicProperties.cs
+++ b/projects/Unit/TestBasicProperties.cs
@@ -34,9 +34,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-
 using RabbitMQ.Client.Events;
-
 using Xunit;
 
 namespace RabbitMQ.Client.Unit

--- a/projects/Unit/TestBasicPublish.cs
+++ b/projects/Unit/TestBasicPublish.cs
@@ -1,14 +1,45 @@
+// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2020 VMware, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       https://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v2.0:
+//
+//---------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//  Copyright (c) 2011-2020 VMware, Inc. or its affiliates.  All rights reserved.
+//---------------------------------------------------------------------------
+
 using System;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-
 using RabbitMQ.Client.Events;
 using Xunit;
 using Xunit.Sdk;
 
 namespace RabbitMQ.Client.Unit
 {
+    [Collection("IntegrationFixture")]
     public class TestBasicPublish
     {
         [Fact]

--- a/projects/Unit/TestBlockingCell.cs
+++ b/projects/Unit/TestBlockingCell.cs
@@ -31,9 +31,7 @@
 
 using System;
 using System.Threading;
-
 using RabbitMQ.Util;
-
 using Xunit;
 
 namespace RabbitMQ.Client.Unit

--- a/projects/Unit/TestChannelAllocation.cs
+++ b/projects/Unit/TestChannelAllocation.cs
@@ -31,14 +31,13 @@
 
 using System;
 using System.Collections.Generic;
-
 using RabbitMQ.Client.Impl;
-
 using Xunit;
 
 namespace RabbitMQ.Client.Unit
 {
-    public class TestIChannelAllocation : IDisposable
+    [Collection("IntegrationFixture")]
+    public class TestChannelAllocation : IDisposable
     {
         public const int CHANNEL_COUNT = 100;
 
@@ -49,14 +48,12 @@ namespace RabbitMQ.Client.Unit
             return ((AutorecoveringChannel)channel).ChannelNumber;
         }
 
-        public TestIChannelAllocation()
+        public TestChannelAllocation()
         {
             _c = new ConnectionFactory().CreateConnection();
-
         }
 
         public void Dispose() => _c.Close();
-
 
         [Fact]
         public void AllocateInOrder()
@@ -108,6 +105,5 @@ namespace RabbitMQ.Client.Unit
             foreach (IChannel channel in channels)
                 Assert.Equal(k++, ChannelNumber(channel));
         }
-
     }
 }

--- a/projects/Unit/TestChannelShutdown.cs
+++ b/projects/Unit/TestChannelShutdown.cs
@@ -31,15 +31,12 @@
 
 using System;
 using System.Threading;
-
 using RabbitMQ.Client.Impl;
-
 using Xunit;
 using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestChannelShutdown : IntegrationFixture
     {
         public TestChannelShutdown(ITestOutputHelper output) : base(output)

--- a/projects/Unit/TestChannelSoftErrors.cs
+++ b/projects/Unit/TestChannelSoftErrors.cs
@@ -31,7 +31,6 @@
 
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Exceptions;
-
 using Xunit;
 using Xunit.Abstractions;
 

--- a/projects/Unit/TestConcurrentAccessWithSharedConnection.cs
+++ b/projects/Unit/TestConcurrentAccessWithSharedConnection.cs
@@ -33,13 +33,11 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-
 using Xunit;
 using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestConcurrentAccessWithSharedConnection : IntegrationFixture
     {
         internal const int Threads = 32;

--- a/projects/Unit/TestConnectionBlocked.cs
+++ b/projects/Unit/TestConnectionBlocked.cs
@@ -33,7 +33,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using RabbitMQ.Client.Events;
-
 using Xunit;
 using Xunit.Abstractions;
 

--- a/projects/Unit/TestConnectionFactory.cs
+++ b/projects/Unit/TestConnectionFactory.cs
@@ -30,14 +30,11 @@
 //---------------------------------------------------------------------------
 
 using System.Collections.Generic;
-
 using RabbitMQ.Client.Exceptions;
-
 using Xunit;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestConnectionFactory
     {
         [Fact]

--- a/projects/Unit/TestConnectionFactoryContinuationTimeout.cs
+++ b/projects/Unit/TestConnectionFactoryContinuationTimeout.cs
@@ -30,7 +30,6 @@
 //---------------------------------------------------------------------------
 
 using System;
-
 using Xunit;
 using Xunit.Abstractions;
 

--- a/projects/Unit/TestConnectionRecovery.cs
+++ b/projects/Unit/TestConnectionRecovery.cs
@@ -38,7 +38,6 @@ using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Exceptions;
 using RabbitMQ.Client.Framing.Impl;
 using RabbitMQ.Client.Impl;
-
 using Xunit;
 using Xunit.Abstractions;
 

--- a/projects/Unit/TestConnectionShutdown.cs
+++ b/projects/Unit/TestConnectionShutdown.cs
@@ -38,7 +38,6 @@ using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestConnectionShutdown : IntegrationFixture
     {
         public TestConnectionShutdown(ITestOutputHelper output) : base(output)

--- a/projects/Unit/TestConsumer.cs
+++ b/projects/Unit/TestConsumer.cs
@@ -1,15 +1,44 @@
+// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2020 VMware, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       https://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v2.0:
+//
+//---------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
+//---------------------------------------------------------------------------
+
 using System;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-
 using RabbitMQ.Client.Events;
-
 using Xunit;
 
 namespace RabbitMQ.Client.Unit
 {
-
+    [Collection("IntegrationFixture")]
     public class TestConsumer
     {
         [Fact]

--- a/projects/Unit/TestConsumerCancelNotify.cs
+++ b/projects/Unit/TestConsumerCancelNotify.cs
@@ -31,15 +31,12 @@
 
 using System.Linq;
 using System.Threading;
-
 using RabbitMQ.Client.Events;
-
 using Xunit;
 using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestConsumerCancelNotify : IntegrationFixture
     {
         protected readonly object lockObject = new object();

--- a/projects/Unit/TestConsumerCount.cs
+++ b/projects/Unit/TestConsumerCount.cs
@@ -30,7 +30,6 @@
 //---------------------------------------------------------------------------
 
 using RabbitMQ.Client.Events;
-
 using Xunit;
 using Xunit.Abstractions;
 

--- a/projects/Unit/TestConsumerExceptions.cs
+++ b/projects/Unit/TestConsumerExceptions.cs
@@ -31,13 +31,11 @@
 
 using System;
 using System.Threading;
-
 using Xunit;
 using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestConsumerExceptions : IntegrationFixture
     {
         private class ConsumerFailingOnDelivery : DefaultBasicConsumer

--- a/projects/Unit/TestConsumerOperationDispatch.cs
+++ b/projects/Unit/TestConsumerOperationDispatch.cs
@@ -32,15 +32,12 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
-
 using RabbitMQ.Client.Events;
-
 using Xunit;
 using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestConsumerOperationDispatch : IntegrationFixture
     {
         public TestConsumerOperationDispatch(ITestOutputHelper output) : base(output)

--- a/projects/Unit/TestContentHeaderCodec.cs
+++ b/projects/Unit/TestContentHeaderCodec.cs
@@ -31,12 +31,10 @@
 
 using System;
 using System.Collections.Generic;
-
 using Xunit;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestContentHeaderCodec
     {
         private void Check(ReadOnlyMemory<byte> actual, ReadOnlyMemory<byte> expected)

--- a/projects/Unit/TestEventingConsumer.cs
+++ b/projects/Unit/TestEventingConsumer.cs
@@ -30,9 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System.Threading;
-
 using RabbitMQ.Client.Events;
-
 using Xunit;
 using Xunit.Abstractions;
 

--- a/projects/Unit/TestExceptionMessages.cs
+++ b/projects/Unit/TestExceptionMessages.cs
@@ -30,15 +30,12 @@
 //---------------------------------------------------------------------------
 
 using System;
-
 using RabbitMQ.Client.Exceptions;
-
 using Xunit;
 using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestExceptionMessages : IntegrationFixture
     {
         public TestExceptionMessages(ITestOutputHelper output) : base(output)

--- a/projects/Unit/TestExchangeDeclare.cs
+++ b/projects/Unit/TestExchangeDeclare.cs
@@ -32,13 +32,11 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
-
 using Xunit;
 using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestExchangeDeclare : IntegrationFixture
     {
         public TestExchangeDeclare(ITestOutputHelper output) : base(output)

--- a/projects/Unit/TestExtensions.cs
+++ b/projects/Unit/TestExtensions.cs
@@ -31,13 +31,11 @@
 
 using System;
 using System.Threading.Tasks;
-
 using Xunit;
 using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestExtensions : IntegrationFixture
     {
         public TestExtensions(ITestOutputHelper output) : base(output)

--- a/projects/Unit/TestFieldTableFormatting.cs
+++ b/projects/Unit/TestFieldTableFormatting.cs
@@ -32,9 +32,7 @@
 using System;
 using System.Collections;
 using System.Text;
-
 using RabbitMQ.Client.Impl;
-
 using Xunit;
 
 namespace RabbitMQ.Client.Unit

--- a/projects/Unit/TestFieldTableFormattingGeneric.cs
+++ b/projects/Unit/TestFieldTableFormattingGeneric.cs
@@ -33,14 +33,11 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Text;
-
 using RabbitMQ.Client.Impl;
-
 using Xunit;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestFieldTableFormattingGeneric : WireFormattingFixture
     {
         [Fact]

--- a/projects/Unit/TestFloodPublishing.cs
+++ b/projects/Unit/TestFloodPublishing.cs
@@ -34,9 +34,7 @@ using System.Diagnostics;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-
 using RabbitMQ.Client.Events;
-
 using Xunit;
 using Xunit.Abstractions;
 

--- a/projects/Unit/TestFrameFormatting.cs
+++ b/projects/Unit/TestFrameFormatting.cs
@@ -32,9 +32,7 @@
 using System;
 using System.Buffers;
 using System.Runtime.InteropServices;
-
 using RabbitMQ.Client.Framing.Impl;
-
 using Xunit;
 
 namespace RabbitMQ.Client.Unit

--- a/projects/Unit/TestHeartbeats.cs
+++ b/projects/Unit/TestHeartbeats.cs
@@ -33,7 +33,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
-
 using Xunit;
 using Xunit.Abstractions;
 

--- a/projects/Unit/TestIEndpointResolverExtensions.cs
+++ b/projects/Unit/TestIEndpointResolverExtensions.cs
@@ -31,7 +31,6 @@
 
 using System;
 using System.Collections.Generic;
-
 using Xunit;
 
 namespace RabbitMQ.Client.Unit

--- a/projects/Unit/TestInitialConnection.cs
+++ b/projects/Unit/TestInitialConnection.cs
@@ -30,15 +30,12 @@
 //---------------------------------------------------------------------------
 
 using System.Collections.Generic;
-
 using RabbitMQ.Client.Exceptions;
-
 using Xunit;
 using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestInitialConnection : IntegrationFixture
     {
         public TestInitialConnection(ITestOutputHelper output) : base(output)

--- a/projects/Unit/TestIntAllocator.cs
+++ b/projects/Unit/TestIntAllocator.cs
@@ -31,14 +31,11 @@
 
 using System;
 using System.Collections.Generic;
-
 using RabbitMQ.Util;
-
 using Xunit;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestIntAllocator
     {
         [Fact]
@@ -85,4 +82,3 @@ namespace RabbitMQ.Client.Unit
         }
     }
 }
-

--- a/projects/Unit/TestInvalidAck.cs
+++ b/projects/Unit/TestInvalidAck.cs
@@ -30,13 +30,11 @@
 //---------------------------------------------------------------------------
 
 using System.Threading;
-
 using Xunit;
 using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestInvalidAck : IntegrationFixture
     {
         public TestInvalidAck(ITestOutputHelper output) : base(output)

--- a/projects/Unit/TestMainLoop.cs
+++ b/projects/Unit/TestMainLoop.cs
@@ -31,15 +31,12 @@
 
 using System;
 using System.Threading;
-
 using RabbitMQ.Client.Events;
-
 using Xunit;
 using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestMainLoop : IntegrationFixture
     {
         public TestMainLoop(ITestOutputHelper output) : base(output)

--- a/projects/Unit/TestMessageCount.cs
+++ b/projects/Unit/TestMessageCount.cs
@@ -30,7 +30,6 @@
 //---------------------------------------------------------------------------
 
 using System.Threading.Tasks;
-
 using Xunit;
 using Xunit.Abstractions;
 

--- a/projects/Unit/TestMethodArgumentCodec.cs
+++ b/projects/Unit/TestMethodArgumentCodec.cs
@@ -32,14 +32,11 @@
 using System;
 using System.Collections;
 using System.Text;
-
 using RabbitMQ.Client.Impl;
-
 using Xunit;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestMethodArgumentCodec
     {
         private void Check(byte[] actual, byte[] expected)

--- a/projects/Unit/TestNetworkByteOrderSerialization.cs
+++ b/projects/Unit/TestNetworkByteOrderSerialization.cs
@@ -30,9 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
-
 using RabbitMQ.Util;
-
 using Xunit;
 
 namespace RabbitMQ.Client.Unit

--- a/projects/Unit/TestNowait.cs
+++ b/projects/Unit/TestNowait.cs
@@ -34,7 +34,6 @@ using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestNoWait : IntegrationFixture
     {
         public TestNoWait(ITestOutputHelper output) : base(output)

--- a/projects/Unit/TestPassiveDeclare.cs
+++ b/projects/Unit/TestPassiveDeclare.cs
@@ -30,15 +30,12 @@
 //---------------------------------------------------------------------------
 
 using System;
-
 using RabbitMQ.Client.Exceptions;
-
 using Xunit;
 using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestPassiveDeclare : IntegrationFixture
     {
         public TestPassiveDeclare(ITestOutputHelper output) : base(output)

--- a/projects/Unit/TestPublicationAddress.cs
+++ b/projects/Unit/TestPublicationAddress.cs
@@ -30,12 +30,10 @@
 //---------------------------------------------------------------------------
 
 using System;
-
 using Xunit;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestPublicationAddress
     {
         [Fact]

--- a/projects/Unit/TestPublishSharedChannel.cs
+++ b/projects/Unit/TestPublishSharedChannel.cs
@@ -32,12 +32,11 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-
 using Xunit;
 
 namespace RabbitMQ.Client.Unit
 {
-
+    [Collection("IntegrationFixture")]
     public class TestPublishSharedChannel
     {
         private const string QueueName = "TestPublishSharedChannel_Queue";

--- a/projects/Unit/TestPublisherConfirms.cs
+++ b/projects/Unit/TestPublisherConfirms.cs
@@ -33,15 +33,12 @@ using System;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-
 using RabbitMQ.Client.Impl;
-
 using Xunit;
 using Xunit.Abstractions;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestPublisherConfirms : IntegrationFixture
     {
         private const string QueueName = "RabbitMQ.Client.Unit.TestPublisherConfirms";

--- a/projects/Unit/TestRecoverAfterCancel.cs
+++ b/projects/Unit/TestRecoverAfterCancel.cs
@@ -32,17 +32,15 @@
 using System;
 using System.Collections.Concurrent;
 using System.Text;
-
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Impl;
-
 using Xunit;
 
 #pragma warning disable 0618
 
 namespace RabbitMQ.Client.Unit
 {
-
+    [Collection("IntegrationFixture")]
     public class TestRecoverAfterCancel : IDisposable
     {
         IConnection _connection;

--- a/projects/Unit/TestRpcContinuationQueue.cs
+++ b/projects/Unit/TestRpcContinuationQueue.cs
@@ -30,14 +30,11 @@
 //---------------------------------------------------------------------------
 
 using System;
-
 using RabbitMQ.Client.Impl;
-
 using Xunit;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestRpcContinuationQueue
     {
         [Fact]
@@ -74,6 +71,5 @@ namespace RabbitMQ.Client.Unit
                 queue.Enqueue(inputContinuation1);
             });
         }
-
     }
 }

--- a/projects/Unit/TestSsl.cs
+++ b/projects/Unit/TestSsl.cs
@@ -34,7 +34,6 @@ using System.IO;
 using System.Net.Security;
 using System.Reflection;
 using System.Security.Authentication;
-
 using Xunit;
 using Xunit.Abstractions;
 

--- a/projects/Unit/TestTcpClientAdapter.cs
+++ b/projects/Unit/TestTcpClientAdapter.cs
@@ -31,14 +31,11 @@
 
 using System.Net;
 using System.Net.Sockets;
-
 using RabbitMQ.Client.Impl;
-
 using Xunit;
 
 namespace RabbitMQ.Client.Unit
 {
-
     public class TestTcpClientAdapter
     {
         [Fact]

--- a/projects/Unit/WireFormattingFixture.cs
+++ b/projects/Unit/WireFormattingFixture.cs
@@ -30,7 +30,6 @@
 //---------------------------------------------------------------------------
 
 using System;
-
 using Xunit;
 
 namespace RabbitMQ.Client.Unit


### PR DESCRIPTION
Since there are tests that restart RabbitMQ, every test that could interact with RMQ must have this attribute on the class:

[Collection("IntegrationFixture")]

We would get random CI failures due to some tests executing that were not part of this collection.