### PR TITLE
Clarify Unix Time units in AmqpTimestamp

### DIFF
--- a/projects/RabbitMQ.Client/client/api/AmqpTimestamp.cs
+++ b/projects/RabbitMQ.Client/client/api/AmqpTimestamp.cs
@@ -56,14 +56,14 @@ namespace RabbitMQ.Client
         /// <summary>
         /// Construct an <see cref="AmqpTimestamp"/>.
         /// </summary>
-        /// <param name="unixTime">Unix time.</param>
+        /// <param name="unixTime">Unix time in seconds.</param>
         public AmqpTimestamp(long unixTime) : this()
         {
             UnixTime = unixTime;
         }
 
         /// <summary>
-        /// Unix time.
+        /// Unix time in seconds.
         /// </summary>
         public long UnixTime { get; }
 


### PR DESCRIPTION
## Proposed Changes

This improves the documentation of `AmqpTimestamp` to specify that Unix Time is in seconds. This is in the [AMQP 0.9.1 spec](https://www.rabbitmq.com/resources/specs/amqp0-9-1.pdf) at section 4,2.5.4, but having it in the code documentation makes it nicer to work with.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [x] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
