### PR TITLE
Trimming and AOT compatibility

### DIFF
--- a/projects/RabbitMQ.Client/RabbitMQ.Client.csproj
+++ b/projects/RabbitMQ.Client/RabbitMQ.Client.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <AssemblyTitle>RabbitMQ Client Library for .NET</AssemblyTitle>
     <Authors>VMware</Authors>
     <Company>VMware, Inc. or its affiliates.</Company>

--- a/projects/RabbitMQ.Client/client/api/ICredentialsRefresher.cs
+++ b/projects/RabbitMQ.Client/client/api/ICredentialsRefresher.cs
@@ -31,6 +31,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
 namespace RabbitMQ.Client
 {
@@ -39,7 +40,7 @@ namespace RabbitMQ.Client
         ICredentialsProvider Register(ICredentialsProvider provider, NotifyCredentialRefreshed callback);
         bool Unregister(ICredentialsProvider provider);
 
-        delegate void NotifyCredentialRefreshed(bool succesfully);
+        delegate void NotifyCredentialRefreshed(bool successfully);
     }
 
     [EventSource(Name = "TimerBasedCredentialRefresher")]
@@ -52,10 +53,16 @@ namespace RabbitMQ.Client
         [Event(2)]
         public void Unregistered(string name) => WriteEvent(2, "UnRegistered", name);
         [Event(3)]
+#if NET6_0_OR_GREATER
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "Parameters to this method are primitive and are trimmer safe")]
+#endif
         public void ScheduledTimer(string name, double interval) => WriteEvent(3, "ScheduledTimer", name, interval);
         [Event(4)]
         public void TriggeredTimer(string name) => WriteEvent(4, "TriggeredTimer", name);
         [Event(5)]
+#if NET6_0_OR_GREATER
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "Parameters to this method are primitive and are trimmer safe")]
+#endif
         public void RefreshedCredentials(string name, bool succesfully) => WriteEvent(5, "RefreshedCredentials", name, succesfully);
         [Event(6)]
         public void AlreadyRegistered(string name) => WriteEvent(6, "AlreadyRegistered", name);

--- a/projects/RabbitMQ.Client/client/logging/RabbitMqExceptionDetail.cs
+++ b/projects/RabbitMQ.Client/client/logging/RabbitMqExceptionDetail.cs
@@ -60,6 +60,10 @@ namespace RabbitMQ.Client.Logging
             }
         }
 
+        // NOTE: This type is used to write EventData in RabbitMqClientEventSource.Error. To make it trim-compatible, these properties are preserved
+        // in RabbitMqClientEventSource. If RabbitMqExceptionDetail gets a property that is a complex type, we need to ensure the nested properties are
+        // preserved as well.
+
         public string Type { get; }
         public string Message { get; }
         public string StackTrace { get; }


### PR DESCRIPTION
## Proposed Changes

Allow RabbitMQ.Client to be used in trimmed and AOT'd apps with no warnings.

Resolve the trim warning coming from RabbitMqClientEventSource.Error. Preserve the properties of RabbitMqExceptionDetail and suppress the warning.

The TimerBasedCredentialRefresherEventSource has warnings as well, but these can be suppressed because the parameters are primitive. In .NET 8 these warnings no longer need to be suppressed because of https://github.com/dotnet/runtime/pull/83751.

Fix #1410

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (enabled the trim analyzer)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

