### PR TITLE
Fix #1429

### DIFF
--- a/projects/RabbitMQ.Client/client/api/IChannelExtensions.cs
+++ b/projects/RabbitMQ.Client/client/api/IChannelExtensions.cs
@@ -208,7 +208,7 @@ namespace RabbitMQ.Client
         public static ValueTask ExchangeDeclareAsync(this IChannel channel, string exchange, string type, bool durable = false, bool autoDelete = false,
             IDictionary<string, object> arguments = null)
         {
-            return channel.ExchangeDeclareAsync(exchange, type, durable, autoDelete, arguments);
+            return channel.ExchangeDeclareAsync(exchange, type, false, durable, autoDelete, arguments);
         }
 
         /// <summary>

--- a/projects/Test/Unit/APIApproval.Approve.verified.txt
+++ b/projects/Test/Unit/APIApproval.Approve.verified.txt
@@ -850,6 +850,8 @@ namespace RabbitMQ.Client
     {
         public TimerBasedCredentialRefresherEventSource() { }
         public static RabbitMQ.Client.TimerBasedCredentialRefresherEventSource Log { get; }
+        [System.Diagnostics.Tracing.Event(6)]
+        public void AlreadyRegistered(string name) { }
         [System.Diagnostics.Tracing.Event(5)]
         public void RefreshedCredentials(string name, bool succesfully) { }
         [System.Diagnostics.Tracing.Event(1)]


### PR DESCRIPTION
* Add test that demonstrates the failure in rabbitmq/rabbitmq-dotnet-client#1429
* Refactor OAuth2 tests to use Async API
* Fix issue by allowing multiple registrations of the same ICredentialsProvider instance

Fixes #1429 