### PR TITLE
Enable long running tests

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -68,9 +68,9 @@ jobs:
         id: install-start-rabbitmq
         run: .\.ci\windows\gha-setup.ps1
       - name: Async Integration Tests
-        run: dotnet test --environment "RABBITMQ_RABBITMQCTL_PATH=${{ steps.install-start-rabbitmq.outputs.path }}" --environment 'RABBITMQ_LONG_RUNNING_TESTS=false' "${{ github.workspace }}\projects\Test\AsyncIntegration\AsyncIntegration.csproj" --no-restore --no-build --logger 'console;verbosity=detailed'
+        run: dotnet test --environment "RABBITMQ_RABBITMQCTL_PATH=${{ steps.install-start-rabbitmq.outputs.path }}" --environment 'RABBITMQ_LONG_RUNNING_TESTS=true' "${{ github.workspace }}\projects\Test\AsyncIntegration\AsyncIntegration.csproj" --no-restore --no-build --logger 'console;verbosity=detailed'
       - name: Integration Tests
-        run: dotnet test --environment "RABBITMQ_RABBITMQCTL_PATH=${{ steps.install-start-rabbitmq.outputs.path }}" --environment 'RABBITMQ_LONG_RUNNING_TESTS=false' --environment 'PASSWORD=grapefruit' --environment SSL_CERTS_DIR="${{ github.workspace }}\.ci\certs" "${{ github.workspace }}\projects\Test\Integration\Integration.csproj" --no-restore --no-build --logger 'console;verbosity=detailed'
+        run: dotnet test --environment "RABBITMQ_RABBITMQCTL_PATH=${{ steps.install-start-rabbitmq.outputs.path }}" --environment 'RABBITMQ_LONG_RUNNING_TESTS=true' --environment 'PASSWORD=grapefruit' --environment SSL_CERTS_DIR="${{ github.workspace }}\.ci\certs" "${{ github.workspace }}\projects\Test\Integration\Integration.csproj" --no-restore --no-build --logger 'console;verbosity=detailed'
       - name: Maybe upload RabbitMQ logs
         if: failure()
         uses: actions/upload-artifact@v3
@@ -179,7 +179,7 @@ jobs:
         run: |
             dotnet test \
                 --environment "RABBITMQ_RABBITMQCTL_PATH=DOCKER:${{ steps.start-rabbitmq.outputs.id }}" \
-                --environment 'RABBITMQ_LONG_RUNNING_TESTS=false' \
+                --environment 'RABBITMQ_LONG_RUNNING_TESTS=true' \
                 --environment 'PASSWORD=grapefruit' \
                 --environment SSL_CERTS_DIR="${{ github.workspace }}/.ci/certs" \
                 "${{ github.workspace }}/projects/Test/Integration/Integration.csproj" --no-restore --no-build --logger 'console;verbosity=detailed'

--- a/projects/Test/Integration/TestHeartbeats.cs
+++ b/projects/Test/Integration/TestHeartbeats.cs
@@ -114,7 +114,7 @@ namespace Test.Integration
                         cf.RequestedHeartbeat = TimeSpan.FromSeconds(n);
                         cf.AutomaticRecoveryEnabled = false;
 
-                        IConnection conn = cf.CreateConnection($"_testDisplayName:{i}");
+                        IConnection conn = cf.CreateConnection($"{_testDisplayName}:{i}");
                         conns.Add(conn);
                         IChannel ch = conn.CreateChannel();
                         conn.ConnectionShutdown += (sender, evt) =>


### PR DESCRIPTION
They do not run _THAT_ long. TLS tests are already enabled in GHA.

Fixes #1157