### PR TITLE
Follow up to trimming changes for 6.x

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,6 +49,8 @@ jobs:
         run: dotnet build --no-restore --verbosity=normal
       - name: Test
         run: ./.ci/gha-run-tests.ps1
+      - name: AotTest
+        run: ./projects/AotCompatibility.TestApp/test-aot-compatibility.ps1
 
   build:
     name: build/test on ubuntu-latest

--- a/RabbitMQDotNetClient.sln
+++ b/RabbitMQDotNetClient.sln
@@ -20,6 +20,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TestApplications", "TestApp
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OAuth2", "projects\TestApplications\OAuth2\OAuth2.csproj", "{07E203AC-9E4B-4BED-9445-E2B45E10E412}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AotCompatibility.TestApp", "projects\AotCompatibility.TestApp\AotCompatibility.TestApp.csproj", "{0B79BD0B-B35D-4626-ABCC-023B6726A531}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -46,6 +48,10 @@ Global
 		{07E203AC-9E4B-4BED-9445-E2B45E10E412}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{07E203AC-9E4B-4BED-9445-E2B45E10E412}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{07E203AC-9E4B-4BED-9445-E2B45E10E412}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0B79BD0B-B35D-4626-ABCC-023B6726A531}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0B79BD0B-B35D-4626-ABCC-023B6726A531}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0B79BD0B-B35D-4626-ABCC-023B6726A531}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0B79BD0B-B35D-4626-ABCC-023B6726A531}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/projects/AotCompatibility.TestApp/AotCompatibility.TestApp.csproj
+++ b/projects/AotCompatibility.TestApp/AotCompatibility.TestApp.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- When targeting net7.0+, this can be updated to PublishAot. -->
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <TrimmerRootAssembly Include="RabbitMQ.Client" />
+    <TrimmerRootAssembly Update="@(TrimmerRootAssembly)" Path="..\%(Identity)\%(Identity).csproj" />
+    <ProjectReference Include="@(TrimmerRootAssembly->'%(Path)')" />
+  </ItemGroup>
+
+</Project>

--- a/projects/AotCompatibility.TestApp/Program.cs
+++ b/projects/AotCompatibility.TestApp/Program.cs
@@ -1,0 +1,4 @@
+// publishing this app ensures all of the code in the referenced
+// assemblies are trim/AOT compatible.
+
+Console.WriteLine("Hello, World!");

--- a/projects/AotCompatibility.TestApp/test-aot-compatibility.ps1
+++ b/projects/AotCompatibility.TestApp/test-aot-compatibility.ps1
@@ -1,0 +1,59 @@
+$DebugPreference = "Continue"
+$ErrorActionPreference = 'Stop'
+# Set-PSDebug -Strict -Trace 1
+Set-PSDebug -Off
+Set-StrictMode -Version 'Latest' -ErrorAction 'Stop' -Verbose
+
+New-Variable -Name rootDirectory  -Option Constant -Value $PSScriptRoot
+Write-Host "[INFO] rootDirectory: $rootDirectory"
+
+$runtime = $IsWindows ? "win-x64" : ($IsMacOS ? "macos-x64" : "linux-x64")
+$app = $IsWindows ? "./AotCompatibility.TestApp.exe" : "./AotCompatibility.TestApp"
+
+$publishOutput = dotnet publish --runtime=$runtime $rootDirectory/AotCompatibility.TestApp.csproj -nodeReuse:false '/p:UseSharedCompilation=false' '/p:Configuration=Release'
+
+$actualWarningCount = 0
+
+foreach ($line in $($publishOutput -split "`r`n"))
+{
+    if (($line -like "*analysis warning IL*") -or ($line -like "*analysis error IL*"))
+    {
+        Write-Host $line
+        $actualWarningCount += 1
+    }
+}
+
+Write-Host "Actual warning count is:", $actualWarningCount
+$expectedWarningCount = 0
+
+if ($LastExitCode -ne 0)
+{
+    Write-Error -ErrorAction Continue -Message "[ERROR] error while publishing AotCompatibility Test App, LastExitCode is $LastExitCode"
+    Write-Error -ErrorAction Continue -Message $publishOutput
+}
+
+Push-Location "$rootDirectory/bin/Release/net6.0/$runtime"
+try
+{
+    Write-Host "[INFO] executing: $app"
+    $app
+    Write-Host "[INFO] finished executing test app"
+
+    if ($LastExitCode -ne 0)
+    {
+        Write-Error -ErrorAction Continue -Message "[ERROR] there was an error while executing AotCompatibility Test App. LastExitCode is: $LastExitCode"
+    }
+}
+finally
+{
+    Pop-Location
+}
+
+$exitCode = 0
+if ($actualWarningCount -ne $expectedWarningCount)
+{
+    $exitCode = 1
+    Write-Error -ErrorAction Continue -Message "Actual warning count: $actualWarningCount is not as expected, which is: $expectedWarningCount"
+}
+
+Exit $exitCode

--- a/projects/RabbitMQ.Client/RabbitMQ.Client.csproj
+++ b/projects/RabbitMQ.Client/RabbitMQ.Client.csproj
@@ -5,8 +5,6 @@
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <EnableTrimAnalyzer Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</EnableTrimAnalyzer>
-    <IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
     <AssemblyTitle>RabbitMQ Client Library for .NET</AssemblyTitle>
     <Authors>VMware</Authors>
     <Company>VMware, Inc. or its affiliates.</Company>

--- a/projects/RabbitMQ.Client/client/api/ICredentialsRefresher.cs
+++ b/projects/RabbitMQ.Client/client/api/ICredentialsRefresher.cs
@@ -31,6 +31,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
 using System.Timers;
 
@@ -54,16 +55,12 @@ namespace RabbitMQ.Client
         [Event(2)]
         public void Unregistered(string name) => WriteEvent(2, "UnRegistered", name);
         [Event(3)]
-#if NET6_0_OR_GREATER
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "Parameters to this method are primitive and are trimmer safe")]
-#endif
         public void ScheduledTimer(string name, double interval) => WriteEvent(3, "ScheduledTimer", name, interval);
         [Event(4)]
         public void TriggeredTimer(string name) => WriteEvent(4, "TriggeredTimer", name);
         [Event(5)]
-#if NET6_0_OR_GREATER
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "Parameters to this method are primitive and are trimmer safe")]
-#endif
         public void RefreshedCredentials(string name, bool succesfully) => WriteEvent(5, "RefreshedCredentials", name, succesfully);
         [Event(6)]
         public void AlreadyRegistered(string name) => WriteEvent(6, "AlreadyRegistered", name);

--- a/projects/RabbitMQ.Client/client/logging/RabbitMqClientEventSource.cs
+++ b/projects/RabbitMQ.Client/client/logging/RabbitMqClientEventSource.cs
@@ -30,6 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
 
 namespace RabbitMQ.Client.Logging
@@ -66,19 +67,14 @@ namespace RabbitMQ.Client.Logging
         public void Error(string message, RabbitMqExceptionDetail ex)
         {
             if (IsEnabled())
-            {
-#if NET6_0_OR_GREATER
                 WriteExceptionEvent(message, ex);
+        }
 
-                [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The properties are preserved with the DynamicallyAccessedMembers attribute.")]
-                void WriteExceptionEvent<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(string message, T ex)
-                {
-                    WriteEvent(3, message, ex);
-                }
-#else
-                WriteEvent(3, message, ex);
-#endif
-            }
+        [NonEvent]
+        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The properties are preserved with the DynamicallyAccessedMembers attribute.")]
+        private void WriteExceptionEvent<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(string message, T ex)
+        {
+            WriteEvent(3, message, ex);
         }
 
         [NonEvent]

--- a/projects/RabbitMQ.Client/util/TrimmingAttributes.cs
+++ b/projects/RabbitMQ.Client/util/TrimmingAttributes.cs
@@ -1,0 +1,253 @@
+﻿// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2020 VMware, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       https://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v2.0:
+//
+//---------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
+//---------------------------------------------------------------------------
+
+// taken from https://devblogs.microsoft.com/dotnet/creating-aot-compatible-libraries/#approach-2-define-the-attributes-internally
+
+namespace System.Diagnostics.CodeAnalysis
+{
+#if !NET5_0_OR_GREATER
+    /// <summary>
+    /// Suppresses reporting of a specific rule violation, allowing multiple suppressions on a
+    /// single code artifact.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="UnconditionalSuppressMessageAttribute"/> is different than
+    /// <see cref="SuppressMessageAttribute"/> in that it doesn't have a
+    /// <see cref="ConditionalAttribute"/>. So it is always preserved in the compiled assembly.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = true)]
+    internal sealed class UnconditionalSuppressMessageAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnconditionalSuppressMessageAttribute"/>
+        /// class, specifying the category of the tool and the identifier for an analysis rule.
+        /// </summary>
+        /// <param name="category">The category for the attribute.</param>
+        /// <param name="checkId">The identifier of the analysis rule the attribute applies to.</param>
+        public UnconditionalSuppressMessageAttribute(string category, string checkId)
+        {
+            Category = category;
+            CheckId = checkId;
+        }
+
+        /// <summary>
+        /// Gets the category identifying the classification of the attribute.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="Category"/> property describes the tool or tool analysis category
+        /// for which a message suppression attribute applies.
+        /// </remarks>
+        public string Category { get; }
+
+        /// <summary>
+        /// Gets the identifier of the analysis tool rule to be suppressed.
+        /// </summary>
+        /// <remarks>
+        /// Concatenated together, the <see cref="Category"/> and <see cref="CheckId"/>
+        /// properties form a unique check identifier.
+        /// </remarks>
+        public string CheckId { get; }
+
+        /// <summary>
+        /// Gets or sets the scope of the code that is relevant for the attribute.
+        /// </summary>
+        /// <remarks>
+        /// The Scope property is an optional argument that specifies the metadata scope for which
+        /// the attribute is relevant.
+        /// </remarks>
+        public string Scope { get; set; }
+
+        /// <summary>
+        /// Gets or sets a fully qualified path that represents the target of the attribute.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="Target"/> property is an optional argument identifying the analysis target
+        /// of the attribute. An example value is "System.IO.Stream.ctor():System.Void".
+        /// Because it is fully qualified, it can be long, particularly for targets such as parameters.
+        /// The analysis tool user interface should be capable of automatically formatting the parameter.
+        /// </remarks>
+        public string Target { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional argument expanding on exclusion criteria.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="MessageId "/> property is an optional argument that specifies additional
+        /// exclusion where the literal metadata target is not sufficiently precise. For example,
+        /// the <see cref="UnconditionalSuppressMessageAttribute"/> cannot be applied within a method,
+        /// and it may be desirable to suppress a violation against a statement in the method that will
+        /// give a rule violation, but not against all statements in the method.
+        /// </remarks>
+        public string MessageId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the justification for suppressing the code analysis message.
+        /// </summary>
+        public string Justification { get; set; }
+    }
+
+    /// <summary>
+    /// Indicates that certain members on a specified <see cref="Type"/> are accessed dynamically,
+    /// for example through <see cref="System.Reflection"/>.
+    /// </summary>
+    /// <remarks>
+    /// This allows tools to understand which members are being accessed during the execution
+    /// of a program.
+    ///
+    /// This attribute is valid on members whose type is <see cref="Type"/> or <see cref="string"/>.
+    ///
+    /// When this attribute is applied to a location of type <see cref="string"/>, the assumption is
+    /// that the string represents a fully qualified type name.
+    ///
+    /// When this attribute is applied to a class, interface, or struct, the members specified
+    /// can be accessed dynamically on <see cref="Type"/> instances returned from calling
+    /// <see cref="object.GetType"/> on instances of that class, interface, or struct.
+    ///
+    /// If the attribute is applied to a method it's treated as a special case and it implies
+    /// the attribute should be applied to the "this" parameter of the method. As such the attribute
+    /// should only be used on instance methods of types assignable to System.Type (or string, but no methods
+    /// will use it there).
+    /// </remarks>
+    [AttributeUsage(
+        AttributeTargets.Field | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter |
+        AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Method |
+        AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct,
+        Inherited = false)]
+    internal sealed class DynamicallyAccessedMembersAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicallyAccessedMembersAttribute"/> class
+        /// with the specified member types.
+        /// </summary>
+        /// <param name="memberTypes">The types of members dynamically accessed.</param>
+        public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes)
+        {
+            MemberTypes = memberTypes;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="DynamicallyAccessedMemberTypes"/> which specifies the type
+        /// of members dynamically accessed.
+        /// </summary>
+        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+    }
+
+    /// <summary>
+    /// Specifies the types of members that are dynamically accessed.
+    ///
+    /// This enumeration has a <see cref="FlagsAttribute"/> attribute that allows a
+    /// bitwise combination of its member values.
+    /// </summary>
+    [Flags]
+    internal enum DynamicallyAccessedMemberTypes
+    {
+        /// <summary>
+        /// Specifies no members.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Specifies the default, parameterless public constructor.
+        /// </summary>
+        PublicParameterlessConstructor = 0x0001,
+
+        /// <summary>
+        /// Specifies all public constructors.
+        /// </summary>
+        PublicConstructors = 0x0002 | PublicParameterlessConstructor,
+
+        /// <summary>
+        /// Specifies all non-public constructors.
+        /// </summary>
+        NonPublicConstructors = 0x0004,
+
+        /// <summary>
+        /// Specifies all public methods.
+        /// </summary>
+        PublicMethods = 0x0008,
+
+        /// <summary>
+        /// Specifies all non-public methods.
+        /// </summary>
+        NonPublicMethods = 0x0010,
+
+        /// <summary>
+        /// Specifies all public fields.
+        /// </summary>
+        PublicFields = 0x0020,
+
+        /// <summary>
+        /// Specifies all non-public fields.
+        /// </summary>
+        NonPublicFields = 0x0040,
+
+        /// <summary>
+        /// Specifies all public nested types.
+        /// </summary>
+        PublicNestedTypes = 0x0080,
+
+        /// <summary>
+        /// Specifies all non-public nested types.
+        /// </summary>
+        NonPublicNestedTypes = 0x0100,
+
+        /// <summary>
+        /// Specifies all public properties.
+        /// </summary>
+        PublicProperties = 0x0200,
+
+        /// <summary>
+        /// Specifies all non-public properties.
+        /// </summary>
+        NonPublicProperties = 0x0400,
+
+        /// <summary>
+        /// Specifies all public events.
+        /// </summary>
+        PublicEvents = 0x0800,
+
+        /// <summary>
+        /// Specifies all non-public events.
+        /// </summary>
+        NonPublicEvents = 0x1000,
+
+        /// <summary>
+        /// Specifies all interfaces implemented by the type.
+        /// </summary>
+        Interfaces = 0x2000,
+
+        /// <summary>
+        /// Specifies all members.
+        /// </summary>
+        All = ~None
+    }
+#endif
+}

--- a/projects/Unit/Helper/DebugUtil.cs
+++ b/projects/Unit/Helper/DebugUtil.cs
@@ -34,7 +34,7 @@ using System.Collections;
 using System.IO;
 using System.Reflection;
 
-namespace RabbitMQ.Util
+namespace RabbitMQ.Client.Unit
 {
     ///<summary>Miscellaneous debugging and development utilities.</summary>
     ///<remarks>

--- a/projects/Unit/TestContentHeaderCodec.cs
+++ b/projects/Unit/TestContentHeaderCodec.cs
@@ -34,7 +34,6 @@ using System;
 using NUnit.Framework;
 
 using RabbitMQ.Client.Impl;
-using RabbitMQ.Util;
 
 namespace RabbitMQ.Client.Unit
 {

--- a/projects/Unit/TestMethodArgumentCodec.cs
+++ b/projects/Unit/TestMethodArgumentCodec.cs
@@ -36,7 +36,6 @@ using System.Text;
 using NUnit.Framework;
 
 using RabbitMQ.Client.Impl;
-using RabbitMQ.Util;
 
 namespace RabbitMQ.Client.Unit
 {

--- a/projects/Unit/WireFormattingFixture.cs
+++ b/projects/Unit/WireFormattingFixture.cs
@@ -30,11 +30,8 @@
 //---------------------------------------------------------------------------
 
 using System;
-using System.IO;
 
 using NUnit.Framework;
-
-using RabbitMQ.Util;
 
 namespace RabbitMQ.Client.Unit
 {


### PR DESCRIPTION
## Proposed Changes

The allows the 6.x library to be used in trimmed and native AOT'd applications without any warnings.

Since the 6.x branch doesn't target net6.0+, it only targets netstandard2.0 and net462, the #if NET6_0_OR_GREATER checks don't do anything.

To resolve this issue, and copy the trimming attributes into this library following the recommendation at https://devblogs.microsoft.com/dotnet/creating-aot-compatible-libraries/#approach-2-define-the-attributes-internally. This allows the library to apply the attributes without targeting net6.0+.

Also moving DebugUtil to the test project - porting #1009 from the main branch.

Contributes to #1410

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

cc @lukebakken 