### PR TITLE
Remove StackTrace from EventSource Message

### DIFF
--- a/projects/RabbitMQ.Client/client/api/ShutdownEventArgs.cs
+++ b/projects/RabbitMQ.Client/client/api/ShutdownEventArgs.cs
@@ -123,17 +123,34 @@ namespace RabbitMQ.Client
         /// </summary>
         public string ReplyText { get; private set; }
 
-        /// <summary>
-        /// Override ToString to be useful for debugging.
-        /// </summary>
-        public override string ToString()
+        private string GetMessageCore()
         {
             return $"AMQP close-reason, initiated by {Initiator}"
                 + $", code={ReplyCode}"
                 + (ReplyText != null ? $", text='{ReplyText}'" : string.Empty)
                 + $", classId={ClassId}"
                 + $", methodId={MethodId}"
-                + (Cause != null ? $", cause={Cause}" : string.Empty)
+                + (Cause != null ? $", cause={Cause}" : string.Empty);
+        }
+
+        /// <summary>
+        /// Gets a message suitable for logging.
+        /// </summary>
+        /// <remarks>
+        /// This leaves out the full exception ToString since logging will include it separately.
+        /// </remarks>
+        internal string GetLogMessage()
+        {
+            return GetMessageCore()
+                + (_exception != null ? $", exception={_exception.Message}" : string.Empty);
+        }
+
+        /// <summary>
+        /// Override ToString to be useful for debugging.
+        /// </summary>
+        public override string ToString()
+        {
+            return GetMessageCore()
                 + (_exception != null ? $", exception={_exception}" : string.Empty);
         }
     }

--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -455,16 +455,17 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public void HandleMainLoopException(ShutdownEventArgs reason)
         {
+            string message = reason.GetLogMessage();
             if (!SetCloseReason(reason))
             {
-                LogCloseError($"Unexpected Main Loop Exception while closing: {reason}", reason.Exception);
+                LogCloseError($"Unexpected Main Loop Exception while closing: {message}", reason.Exception);
                 return;
             }
 
             _model0.MaybeSetConnectionStartException(reason.Exception);
 
             OnShutdown();
-            LogCloseError($"Unexpected connection closure: {reason}", reason.Exception);
+            LogCloseError($"Unexpected connection closure: {message}", reason.Exception);
         }
 
         public bool HardProtocolExceptionHandler(HardProtocolException hpe)


### PR DESCRIPTION
## Proposed Changes

When logging connection exception information to the EventSoruce we are putting the full exception ToString in the Message which clutters it to the users.

Instead, just put the Exception.Message in the EventSource event message. The full exception information comes in the details of the EventSource event.

Fix #1493

# Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #1493)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

cc @lukebakken 