### PR TITLE
Fix the flaky `TestConsumerRecoveryOnClientNamedQueueWithOneRecovery` test

### DIFF
--- a/projects/Test/Common/SslEnv.cs
+++ b/projects/Test/Common/SslEnv.cs
@@ -32,7 +32,7 @@
 using System;
 using System.IO;
 
-namespace Test.Integration
+namespace Test
 {
     public class SslEnv
     {

--- a/projects/Test/Integration/TestConnectionRecoveryWithoutSetup.cs
+++ b/projects/Test/Integration/TestConnectionRecoveryWithoutSetup.cs
@@ -150,6 +150,7 @@ namespace Test.Integration
         public async Task TestConsumerRecoveryOnClientNamedQueueWithOneRecovery()
         {
             const string q0 = "dotnet-client.recovery.queue1";
+            // connection #1
             using (AutorecoveringConnection c = await CreateAutorecoveringConnectionAsync())
             {
                 using (IChannel ch = await c.CreateChannelAsync())
@@ -162,17 +163,19 @@ namespace Test.Integration
                     await AssertConsumerCountAsync(ch, q1, 1);
 
                     bool queueNameChangeAfterRecoveryCalled = false;
-
                     c.QueueNameChangedAfterRecovery += (source, ea) => { queueNameChangeAfterRecoveryCalled = true; };
 
+                    // connection #2
                     await CloseAndWaitForRecoveryAsync(c);
                     await AssertConsumerCountAsync(ch, q1, 1);
                     Assert.False(queueNameChangeAfterRecoveryCalled);
 
+                    // connection #3
                     await CloseAndWaitForRecoveryAsync(c);
                     await AssertConsumerCountAsync(ch, q1, 1);
                     Assert.False(queueNameChangeAfterRecoveryCalled);
 
+                    // connection #4
                     await CloseAndWaitForRecoveryAsync(c);
                     await AssertConsumerCountAsync(ch, q1, 1);
                     Assert.False(queueNameChangeAfterRecoveryCalled);

--- a/projects/Test/SequentialIntegration/SequentialIntegration.csproj
+++ b/projects/Test/SequentialIntegration/SequentialIntegration.csproj
@@ -42,6 +42,7 @@
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
     <PackageReference Include="xunit" Version="2.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" PrivateAssets="all" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
 
 </Project>

--- a/projects/Test/SequentialIntegration/TestHeartbeats.cs
+++ b/projects/Test/SequentialIntegration/TestHeartbeats.cs
@@ -36,9 +36,9 @@ using RabbitMQ.Client;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Test.Integration
+namespace Test.SequentialIntegration
 {
-    public class TestHeartbeats : IntegrationFixture
+    public class TestHeartbeats : SequentialIntegrationFixture
     {
         private readonly TimeSpan _heartbeatTimeout = TimeSpan.FromSeconds(2);
 


### PR DESCRIPTION
This patch moves the long running tests to the `SequentialIntegration` project. The flakes are due to the time it takes to list connections when the `TestHundredsOfConnectionsWithRandomHeartbeatInterval` test is running.