### PR TITLE
Fix `TestThatDeletedQueueBindingsDontReappearOnRecovery`

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-win32:
-    runs-on: windows-2019
+    runs-on: windows-latest
     # https://github.com/NuGet/Home/issues/11548
     env:
       NUGET_CERT_REVOCATION_MODE: offline
@@ -42,7 +42,7 @@ jobs:
             projects/RabbitMQ.*/bin
   integration-win32:
     needs: build-win32
-    runs-on: windows-2019
+    runs-on: windows-latest
     # https://github.com/NuGet/Home/issues/11548
     env:
       NUGET_CERT_REVOCATION_MODE: offline
@@ -89,7 +89,7 @@ jobs:
           path: ~/AppData/Roaming/RabbitMQ/log/
   sequential-integration-win32:
     needs: build-win32
-    runs-on: windows-2019
+    runs-on: windows-latest
     # https://github.com/NuGet/Home/issues/11548
     env:
       NUGET_CERT_REVOCATION_MODE: offline

--- a/build.ps1
+++ b/build.ps1
@@ -25,7 +25,8 @@ if ($RunTests)
         dotnet test $csproj_file --environment 'RABBITMQ_LONG_RUNNING_TESTS=true' --no-restore --no-build --logger "console;verbosity=detailed"
         if ($LASTEXITCODE -ne 0)
         {
-            Write-Host "[WARNING] tests errored, exiting" -Foreground "Red"
+            Write-Host "[ERROR] tests errored, exiting" -Foreground "Red"
+            Exit 1
         }
         else
         {

--- a/projects/Test/Integration/ConnectionRecovery/TestExchangeRecovery.cs
+++ b/projects/Test/Integration/ConnectionRecovery/TestExchangeRecovery.cs
@@ -56,25 +56,29 @@ namespace Test.Integration.ConnectionRecovery
         public async Task TestExchangeToExchangeBindingRecovery()
         {
             string q = (await _channel.QueueDeclareAsync("", false, false, false)).QueueName;
-            string x1 = "amq.fanout";
-            string x2 = GenerateExchangeName();
 
-            await _channel.ExchangeDeclareAsync(x2, "fanout");
-            await _channel.ExchangeBindAsync(x1, x2, "");
-            await _channel.QueueBindAsync(q, x1, "");
+            string ex_source = GenerateExchangeName();
+            string ex_destination = GenerateExchangeName();
+
+            await _channel.ExchangeDeclareAsync(ex_source, ExchangeType.Fanout);
+            await _channel.ExchangeDeclareAsync(ex_destination, ExchangeType.Fanout);
+
+            await _channel.ExchangeBindAsync(destination: ex_destination, source: ex_source, "");
+            await _channel.QueueBindAsync(q, ex_destination, "");
 
             try
             {
                 await CloseAndWaitForRecoveryAsync();
                 Assert.True(_channel.IsOpen);
-                await _channel.BasicPublishAsync(x2, "", _encoding.GetBytes("msg"));
+                await _channel.BasicPublishAsync(ex_source, "", _encoding.GetBytes("msg"));
                 await AssertMessageCountAsync(q, 1);
             }
             finally
             {
                 await WithTemporaryChannelAsync(async ch =>
                 {
-                    await ch.ExchangeDeleteAsync(x2);
+                    await ch.ExchangeDeleteAsync(ex_source);
+                    await ch.ExchangeDeleteAsync(ex_destination);
                     await ch.QueueDeleteAsync(q);
                 });
             }


### PR DESCRIPTION
Do not use the `amq.fanout` exchange, because other tests that publish to that can lead to errors in `TestThatDeletedQueueBindingsDontReappearOnRecovery`