### PR TITLE
Enable `rabbitmq-client` event logging when tests are verbose

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/Frame.cs
+++ b/projects/RabbitMQ.Client/client/impl/Frame.cs
@@ -254,9 +254,10 @@ namespace RabbitMQ.Client.Impl
             }
         }
 
-        internal static async ValueTask<InboundFrame> ReadFromPipeAsync(PipeReader reader, uint maxMessageSize, CancellationToken cancellationToken)
+        internal static async ValueTask<InboundFrame> ReadFromPipeAsync(PipeReader reader, uint maxMessageSize,
+            CancellationToken mainLoopCancellationToken)
         {
-            ReadResult result = await reader.ReadAsync(cancellationToken)
+            ReadResult result = await reader.ReadAsync(mainLoopCancellationToken)
                .ConfigureAwait(false);
 
             ReadOnlySequence<byte> buffer = result.Buffer;
@@ -270,7 +271,7 @@ namespace RabbitMQ.Client.Impl
                 reader.AdvanceTo(buffer.Start, buffer.End);
 
                 // Not enough data, read a bit more
-                result = await reader.ReadAsync(cancellationToken)
+                result = await reader.ReadAsync(mainLoopCancellationToken)
                    .ConfigureAwait(false);
 
                 MaybeThrowEndOfStream(result, buffer);

--- a/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
+++ b/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
@@ -278,9 +278,9 @@ namespace RabbitMQ.Client.Impl
             }
         }
 
-        public ValueTask<InboundFrame> ReadFrameAsync(CancellationToken cancellationToken)
+        public ValueTask<InboundFrame> ReadFrameAsync(CancellationToken mainLoopCancellationToken)
         {
-            return InboundFrame.ReadFromPipeAsync(_pipeReader, _amqpTcpEndpoint.MaxMessageSize, cancellationToken);
+            return InboundFrame.ReadFromPipeAsync(_pipeReader, _amqpTcpEndpoint.MaxMessageSize, mainLoopCancellationToken);
         }
 
         public bool TryReadFrame(out InboundFrame frame)

--- a/projects/RabbitMQ.Client/client/logging/ESLog.cs
+++ b/projects/RabbitMQ.Client/client/logging/ESLog.cs
@@ -29,13 +29,15 @@
 //  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
+using System;
+
 namespace RabbitMQ.Client.Logging
 {
     internal static class ESLog
     {
         public static void Info(string message)
         {
-            Logging.RabbitMqClientEventSource.Log.Info(message);
+            RabbitMqClientEventSource.Log.Info(message);
         }
 
         public static void Info(string message, params object[] args)
@@ -46,7 +48,7 @@ namespace RabbitMQ.Client.Logging
 
         public static void Warn(string message)
         {
-            Logging.RabbitMqClientEventSource.Log.Warn(message);
+            RabbitMqClientEventSource.Log.Warn(message);
         }
 
         public static void Warn(string message, params object[] args)
@@ -55,12 +57,12 @@ namespace RabbitMQ.Client.Logging
             Warn(msg);
         }
 
-        public static void Error(string message, System.Exception ex)
+        public static void Error(string message, Exception ex)
         {
-            Logging.RabbitMqClientEventSource.Log.Error(message, ex);
+            RabbitMqClientEventSource.Log.Error(message, ex);
         }
 
-        public static void Error(string message, System.Exception ex, params object[] args)
+        public static void Error(string message, Exception ex, params object[] args)
         {
             string msg = string.Format(message, args);
             Error(msg, ex);

--- a/projects/RabbitMQ.Client/client/logging/RabbitMqClientEventSource.Counters.cs
+++ b/projects/RabbitMQ.Client/client/logging/RabbitMqClientEventSource.Counters.cs
@@ -29,93 +29,63 @@
 //  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
 //---------------------------------------------------------------------------
 
-using System;
 using System.Diagnostics.Tracing;
 using System.Threading;
 
 namespace RabbitMQ.Client.Logging
 {
-#nullable enable
     internal sealed partial class RabbitMqClientEventSource
     {
-        private static int ConnectionsOpened;
-        private static int ConnectionsClosed;
-        private static int ChannelsOpened;
-        private static int ChannelsClosed;
-        private static long BytesSent;
-        private static long BytesReceived;
-        private static long CommandsSent;
-        private static long CommandsReceived;
+        private static int s_connectionsOpened;
+        private static int s_connectionsClosed;
+        private static int s_channelsOpened;
+        private static int s_channelsClosed;
+        private static long s_bytesSent;
+        private static long s_bytesReceived;
+        private static long s_commandsSent;
+        private static long s_commandsReceived;
 
-#if NET6_0_OR_GREATER
-        private PollingCounter? _connectionOpenedCounter;
-        private PollingCounter? _openConnectionCounter;
-        private PollingCounter? _channelOpenedCounter;
-        private PollingCounter? _openChannelCounter;
-        private IncrementingPollingCounter? _bytesSentCounter;
-        private IncrementingPollingCounter? _bytesReceivedCounter;
-        private IncrementingPollingCounter? _commandSentCounter;
-        private IncrementingPollingCounter? _commandReceivedCounter;
-
-        protected override void OnEventCommand(EventCommandEventArgs command)
-        {
-            if (command.Command == EventCommand.Enable)
-            {
-                _connectionOpenedCounter ??= new PollingCounter("total-connections-opened", this, () => ConnectionsOpened) { DisplayName = "Total connections opened" };
-                _openConnectionCounter ??= new PollingCounter("current-open-connections", this, () => ConnectionsOpened - ConnectionsClosed) { DisplayName = "Current open connections count" };
-
-                _channelOpenedCounter ??= new PollingCounter("total-channels-opened", this, () => ChannelsOpened) { DisplayName = "Total channels opened" };
-                _openChannelCounter ??= new PollingCounter("current-open-channels", this, () => ChannelsOpened - ChannelsClosed) { DisplayName = "Current open channels count" };
-
-                _bytesSentCounter ??= new IncrementingPollingCounter("bytes-sent-rate", this, () => Interlocked.Read(ref BytesSent)) { DisplayName = "Byte sending rate", DisplayUnits = "B", DisplayRateTimeScale = new TimeSpan(0, 0, 1) };
-                _bytesReceivedCounter ??= new IncrementingPollingCounter("bytes-received-rate", this, () => Interlocked.Read(ref BytesReceived)) { DisplayName = "Byte receiving rate", DisplayUnits = "B", DisplayRateTimeScale = new TimeSpan(0, 0, 1) };
-
-                _commandSentCounter ??= new IncrementingPollingCounter("AMQP-method-sent-rate", this, () => Interlocked.Read(ref CommandsSent)) { DisplayName = "AMQP method sending rate", DisplayUnits = "B", DisplayRateTimeScale = new TimeSpan(0, 0, 1) };
-                _commandReceivedCounter ??= new IncrementingPollingCounter("AMQP-method-received-rate", this, () => Interlocked.Read(ref CommandsReceived)) { DisplayName = "AMQP method receiving rate", DisplayUnits = "B", DisplayRateTimeScale = new TimeSpan(0, 0, 1) };
-            }
-        }
-#endif
         [NonEvent]
         public void ConnectionOpened()
         {
-            Interlocked.Increment(ref ConnectionsOpened);
+            Interlocked.Increment(ref s_connectionsOpened);
         }
 
         [NonEvent]
         public void ConnectionClosed()
         {
-            Interlocked.Increment(ref ConnectionsClosed);
+            Interlocked.Increment(ref s_connectionsClosed);
         }
 
         [NonEvent]
         public void ChannelOpened()
         {
-            Interlocked.Increment(ref ChannelsOpened);
+            Interlocked.Increment(ref s_channelsOpened);
         }
 
         [NonEvent]
         public void ChannelClosed()
         {
-            Interlocked.Increment(ref ChannelsClosed);
+            Interlocked.Increment(ref s_channelsClosed);
         }
 
         [NonEvent]
         public void DataReceived(int byteCount)
         {
-            Interlocked.Add(ref BytesReceived, byteCount);
+            Interlocked.Add(ref s_bytesReceived, byteCount);
         }
 
         [NonEvent]
         public void CommandSent(int byteCount)
         {
-            Interlocked.Increment(ref CommandsSent);
-            Interlocked.Add(ref BytesSent, byteCount);
+            Interlocked.Increment(ref s_commandsSent);
+            Interlocked.Add(ref s_bytesSent, byteCount);
         }
 
         [NonEvent]
         public void CommandReceived()
         {
-            Interlocked.Increment(ref CommandsReceived);
+            Interlocked.Increment(ref s_commandsReceived);
         }
     }
 }

--- a/projects/Test/Common/IntegrationFixture.cs
+++ b/projects/Test/Common/IntegrationFixture.cs
@@ -57,6 +57,8 @@ namespace Test
         private Exception _connectionRecoveryException;
         private Exception _channelCallbackException;
 
+        private readonly TestOutputWriterEventListener _eventListener = null;
+
         protected readonly RabbitMQCtl _rabbitMQCtl;
 
         protected ConnectionFactory _connFactory;
@@ -127,6 +129,7 @@ namespace Test
             if (IsVerbose)
             {
                 Console.SetOut(new TestOutputWriter(output, _testDisplayName));
+                _eventListener = new TestOutputWriterEventListener(output);
             }
         }
 
@@ -188,6 +191,7 @@ namespace Test
             }
             finally
             {
+                _eventListener?.Dispose();
                 _channel?.Dispose();
                 _conn?.Dispose();
                 _channel = null;

--- a/projects/Test/Common/TestOutputWriterEventListener.cs
+++ b/projects/Test/Common/TestOutputWriterEventListener.cs
@@ -1,0 +1,122 @@
+﻿// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2020 VMware, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       https://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v2.0:
+//
+//---------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//  Copyright (c) 2007-2020 VMware, Inc.  All rights reserved.
+//---------------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.Tracing;
+using Xunit.Abstractions;
+
+namespace Test
+{
+    internal class TestOutputWriterEventListener : EventListener
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly bool _initialized = false;
+        private ConcurrentQueue<EventSource> _eventSources;
+
+        public TestOutputWriterEventListener(ITestOutputHelper output)
+        {
+            _output = output;
+            _initialized = true;
+            foreach (EventSource eventSource in _eventSources)
+            {
+                MaybeEnableEvents(eventSource);
+            }
+        }
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            lock (this)
+            {
+                if (_eventSources == null)
+                {
+                    _eventSources = new ConcurrentQueue<EventSource>();
+                }
+
+                _eventSources.Enqueue(eventSource);
+            }
+
+            // If initialization is already done, we can enable EventSource right away.
+            // This will take care of all EventSources created after initialization is done.
+            if (_initialized)
+            {
+                MaybeEnableEvents(eventSource);
+            }
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            try
+            {
+#if NET6_0_OR_GREATER
+                if (eventData.Payload.Count > 0)
+                {
+                    string payloadName = eventData.PayloadNames[0];
+                    object payload = eventData.Payload[0];
+                    _output.WriteLine("{0}|{1}|{2}|{3}",
+                        eventData.TimeStamp, eventData.Level, payloadName, payload);
+                }
+                else
+                {
+                    _output.WriteLine("{0}|{1}", eventData.TimeStamp, eventData.Level);
+                }
+#else
+                if (eventData.Payload.Count > 0)
+                {
+                    string payloadName = eventData.PayloadNames[0];
+                    object payload = eventData.Payload[0];
+                    _output.WriteLine("{0}|{1}|{2}",
+                        eventData.Level, payloadName, payload);
+                }
+                else
+                {
+                    _output.WriteLine("{1}", eventData.Level);
+                }
+#endif
+            }
+            catch (InvalidOperationException)
+            {
+                /*
+                 * Note:
+                 * This exception can be thrown if there is no running test.
+                 */
+            }
+        }
+
+        private void MaybeEnableEvents(EventSource eventSource)
+        {
+            if (eventSource.Name == "rabbitmq-client")
+            {
+                EnableEvents(eventSource, EventLevel.LogAlways);
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Fix event ID issue by duplicating Error Event 3 code for each target framework.
* Fix strange null reference exception by not using `??=` lazy init.