### PR TITLE
Remove two unnecessary `.Cast<>()` usages

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/AsyncEventingWrapper.cs
+++ b/projects/RabbitMQ.Client/client/impl/AsyncEventingWrapper.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Threading.Tasks;
 using RabbitMQ.Client.Events;
 
@@ -55,7 +54,7 @@ namespace RabbitMQ.Client.Impl
 
         private readonly async Task InternalInvoke(Delegate[] handlers, object sender, T parameter)
         {
-            foreach (AsyncEventHandler<T> action in handlers.Cast<AsyncEventHandler<T>>())
+            foreach (AsyncEventHandler<T> action in handlers)
             {
                 try
                 {

--- a/projects/RabbitMQ.Client/client/impl/EventingWrapper.cs
+++ b/projects/RabbitMQ.Client/client/impl/EventingWrapper.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 
 namespace RabbitMQ.Client.Impl
 {
@@ -53,7 +52,7 @@ namespace RabbitMQ.Client.Impl
                 _handlers = handlers;
             }
 
-            foreach (EventHandler<T> action in handlers.Cast<EventHandler<T>>())
+            foreach (EventHandler<T> action in handlers)
             {
                 try
                 {


### PR DESCRIPTION
Noticed by @paulomorgado in #1233