### PR TITLE
Use default value for `RabbitMQActivitySource.UseRoutingKeyAsOperationName`

### DIFF
--- a/projects/RabbitMQ.Client.OpenTelemetry/TraceProviderBuilderExtensions.cs
+++ b/projects/RabbitMQ.Client.OpenTelemetry/TraceProviderBuilderExtensions.cs
@@ -12,7 +12,6 @@ namespace OpenTelemetry.Trace
     {
         public static TracerProviderBuilder AddRabbitMQInstrumentation(this TracerProviderBuilder builder)
         {
-            RabbitMQActivitySource.UseRoutingKeyAsOperationName = true;
             RabbitMQActivitySource.ContextExtractor = OpenTelemetryContextExtractor;
             RabbitMQActivitySource.ContextInjector = OpenTelemetryContextInjector;
             builder.AddSource("RabbitMQ.Client.*");


### PR DESCRIPTION
The default is `true`, anyway. No need to set it here.

Pointed out by @Kielex in this comment:
https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/1533#issuecomment-2152344587