### PR TITLE
Remove in from async methods

### DIFF
--- a/RUNNING_TESTS.md
+++ b/RUNNING_TESTS.md
@@ -32,7 +32,7 @@ Tests can be run from Visual Studio using the XUnit Test Adapter.  Note that it
 may take some time for the adapter to discover tests in the assemblies.
 
 The test suite assumes there's a RabbitMQ node running locally with all
-defaults, and the tests will need to be able to run commands against the
+defaults, incl. the management plugin, and the tests will need to be able to run commands against the
 [`rabbitmqctl`](https://www.rabbitmq.com/rabbitmqctl.8.html) tool for that node.
 Two options to accomplish this are covered below.
 

--- a/projects/Benchmarks/ConsumerDispatching/AsyncBasicConsumerFake.cs
+++ b/projects/Benchmarks/ConsumerDispatching/AsyncBasicConsumerFake.cs
@@ -19,7 +19,7 @@ namespace RabbitMQ.Benchmarks
         }
 
         public Task HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey,
-            in ReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
+            ReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
         {
             if (Interlocked.Increment(ref _current) == Count)
             {

--- a/projects/RabbitMQ.Client/PublicAPI.Shipped.txt
+++ b/projects/RabbitMQ.Client/PublicAPI.Shipped.txt
@@ -62,7 +62,7 @@ override RabbitMQ.Client.AmqpTimestamp.GetHashCode() -> int
 override RabbitMQ.Client.AmqpTimestamp.ToString() -> string
 override RabbitMQ.Client.Events.AsyncEventingBasicConsumer.HandleBasicCancelOk(string consumerTag) -> System.Threading.Tasks.Task
 override RabbitMQ.Client.Events.AsyncEventingBasicConsumer.HandleBasicConsumeOk(string consumerTag) -> System.Threading.Tasks.Task
-override RabbitMQ.Client.Events.AsyncEventingBasicConsumer.HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, in RabbitMQ.Client.ReadOnlyBasicProperties properties, System.ReadOnlyMemory<byte> body) -> System.Threading.Tasks.Task
+override RabbitMQ.Client.Events.AsyncEventingBasicConsumer.HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, RabbitMQ.Client.ReadOnlyBasicProperties properties, System.ReadOnlyMemory<byte> body) -> System.Threading.Tasks.Task
 override RabbitMQ.Client.Events.AsyncEventingBasicConsumer.HandleChannelShutdown(object channel, RabbitMQ.Client.ShutdownEventArgs reason) -> System.Threading.Tasks.Task
 override RabbitMQ.Client.Events.EventingBasicConsumer.HandleBasicCancelOk(string consumerTag) -> void
 override RabbitMQ.Client.Events.EventingBasicConsumer.HandleBasicConsumeOk(string consumerTag) -> void
@@ -413,7 +413,7 @@ RabbitMQ.Client.IAsyncBasicConsumer.ConsumerCancelled -> RabbitMQ.Client.Events.
 RabbitMQ.Client.IAsyncBasicConsumer.HandleBasicCancel(string consumerTag) -> System.Threading.Tasks.Task
 RabbitMQ.Client.IAsyncBasicConsumer.HandleBasicCancelOk(string consumerTag) -> System.Threading.Tasks.Task
 RabbitMQ.Client.IAsyncBasicConsumer.HandleBasicConsumeOk(string consumerTag) -> System.Threading.Tasks.Task
-RabbitMQ.Client.IAsyncBasicConsumer.HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, in RabbitMQ.Client.ReadOnlyBasicProperties properties, System.ReadOnlyMemory<byte> body) -> System.Threading.Tasks.Task
+RabbitMQ.Client.IAsyncBasicConsumer.HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, RabbitMQ.Client.ReadOnlyBasicProperties properties, System.ReadOnlyMemory<byte> body) -> System.Threading.Tasks.Task
 RabbitMQ.Client.IAsyncBasicConsumer.HandleChannelShutdown(object channel, RabbitMQ.Client.ShutdownEventArgs reason) -> System.Threading.Tasks.Task
 RabbitMQ.Client.IAuthMechanism
 RabbitMQ.Client.IAuthMechanism.handleChallenge(byte[] challenge, RabbitMQ.Client.ConnectionConfig config) -> byte[]
@@ -845,7 +845,7 @@ static RabbitMQ.Client.Events.CallbackExceptionEventArgs.Build(System.Exception 
 static RabbitMQ.Client.ExchangeType.All() -> System.Collections.Generic.ICollection<string>
 static RabbitMQ.Client.IChannelExtensions.BasicPublishAsync(this RabbitMQ.Client.IChannel channel, RabbitMQ.Client.CachedString exchange, RabbitMQ.Client.CachedString routingKey, System.ReadOnlyMemory<byte> body = default(System.ReadOnlyMemory<byte>), bool mandatory = false) -> System.Threading.Tasks.ValueTask
 static RabbitMQ.Client.IChannelExtensions.BasicPublishAsync(this RabbitMQ.Client.IChannel channel, string exchange, string routingKey, System.ReadOnlyMemory<byte> body = default(System.ReadOnlyMemory<byte>), bool mandatory = false) -> System.Threading.Tasks.ValueTask
-static RabbitMQ.Client.IChannelExtensions.BasicPublishAsync<T>(this RabbitMQ.Client.IChannel channel, RabbitMQ.Client.PublicationAddress addr, in T basicProperties, System.ReadOnlyMemory<byte> body) -> System.Threading.Tasks.ValueTask
+static RabbitMQ.Client.IChannelExtensions.BasicPublishAsync<T>(this RabbitMQ.Client.IChannel channel, RabbitMQ.Client.PublicationAddress addr, T basicProperties, System.ReadOnlyMemory<byte> body) -> System.Threading.Tasks.ValueTask
 static RabbitMQ.Client.PublicationAddress.Parse(string uriLikeString) -> RabbitMQ.Client.PublicationAddress
 static RabbitMQ.Client.PublicationAddress.TryParse(string uriLikeString, out RabbitMQ.Client.PublicationAddress result) -> bool
 static RabbitMQ.Client.QueueDeclareOk.implicit operator string(RabbitMQ.Client.QueueDeclareOk declareOk) -> string
@@ -864,7 +864,7 @@ static readonly RabbitMQ.Client.PublicationAddress.PSEUDO_URI_PARSER -> System.T
 virtual RabbitMQ.Client.AsyncDefaultBasicConsumer.HandleBasicCancel(string consumerTag) -> System.Threading.Tasks.Task
 virtual RabbitMQ.Client.AsyncDefaultBasicConsumer.HandleBasicCancelOk(string consumerTag) -> System.Threading.Tasks.Task
 virtual RabbitMQ.Client.AsyncDefaultBasicConsumer.HandleBasicConsumeOk(string consumerTag) -> System.Threading.Tasks.Task
-virtual RabbitMQ.Client.AsyncDefaultBasicConsumer.HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, in RabbitMQ.Client.ReadOnlyBasicProperties properties, System.ReadOnlyMemory<byte> body) -> System.Threading.Tasks.Task
+virtual RabbitMQ.Client.AsyncDefaultBasicConsumer.HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, RabbitMQ.Client.ReadOnlyBasicProperties properties, System.ReadOnlyMemory<byte> body) -> System.Threading.Tasks.Task
 virtual RabbitMQ.Client.AsyncDefaultBasicConsumer.HandleChannelShutdown(object channel, RabbitMQ.Client.ShutdownEventArgs reason) -> System.Threading.Tasks.Task
 virtual RabbitMQ.Client.AsyncDefaultBasicConsumer.OnCancel(params string[] consumerTags) -> System.Threading.Tasks.Task
 virtual RabbitMQ.Client.DefaultBasicConsumer.HandleBasicCancel(string consumerTag) -> void

--- a/projects/RabbitMQ.Client/client/api/AsyncDefaultBasicConsumer.cs
+++ b/projects/RabbitMQ.Client/client/api/AsyncDefaultBasicConsumer.cs
@@ -112,7 +112,7 @@ namespace RabbitMQ.Client
             bool redelivered,
             string exchange,
             string routingKey,
-            in ReadOnlyBasicProperties properties,
+            ReadOnlyBasicProperties properties,
             ReadOnlyMemory<byte> body)
         {
             // Nothing to do here.

--- a/projects/RabbitMQ.Client/client/api/IAsyncBasicConsumer.cs
+++ b/projects/RabbitMQ.Client/client/api/IAsyncBasicConsumer.cs
@@ -51,7 +51,7 @@ namespace RabbitMQ.Client
             bool redelivered,
             string exchange,
             string routingKey,
-            in ReadOnlyBasicProperties properties,
+            ReadOnlyBasicProperties properties,
             ReadOnlyMemory<byte> body);
 
         /// <summary>

--- a/projects/RabbitMQ.Client/client/api/IChannelExtensions.cs
+++ b/projects/RabbitMQ.Client/client/api/IChannelExtensions.cs
@@ -88,7 +88,7 @@ namespace RabbitMQ.Client
         /// <remarks>
         /// The publication occurs with mandatory=false and immediate=false.
         /// </remarks>
-        public static ValueTask BasicPublishAsync<T>(this IChannel channel, PublicationAddress addr, in T basicProperties,
+        public static ValueTask BasicPublishAsync<T>(this IChannel channel, PublicationAddress addr, T basicProperties,
             ReadOnlyMemory<byte> body)
             where T : IReadOnlyBasicProperties, IAmqpHeader
         {

--- a/projects/RabbitMQ.Client/client/events/AsyncEventingBasicConsumer.cs
+++ b/projects/RabbitMQ.Client/client/events/AsyncEventingBasicConsumer.cs
@@ -77,7 +77,7 @@ namespace RabbitMQ.Client.Events
 
         ///<summary>Fires the Received event.</summary>
         public override Task HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey,
-            in ReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
+            ReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
         {
             var deliverEventArgs = new BasicDeliverEventArgs(consumerTag, deliveryTag, redelivered, exchange, routingKey, properties, body);
             // No need to call base, it's empty.

--- a/projects/RabbitMQ.Client/client/impl/ConsumerDispatching/ConsumerDispatcherChannelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ConsumerDispatching/ConsumerDispatcherChannelBase.cs
@@ -74,7 +74,7 @@ namespace RabbitMQ.Client.ConsumerDispatching
         }
 
         public ValueTask HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered,
-            string exchange, string routingKey, in ReadOnlyBasicProperties basicProperties, RentedMemory body,
+            string exchange, string routingKey, ReadOnlyBasicProperties basicProperties, RentedMemory body,
             CancellationToken cancellationToken)
         {
             if (false == _disposed && false == _quiesce)
@@ -281,7 +281,7 @@ namespace RabbitMQ.Client.ConsumerDispatching
             }
 
             private WorkStruct(IBasicConsumer consumer, string consumerTag, ulong deliveryTag, bool redelivered,
-                string exchange, string routingKey, in ReadOnlyBasicProperties basicProperties, RentedMemory body)
+                string exchange, string routingKey, ReadOnlyBasicProperties basicProperties, RentedMemory body)
             {
                 WorkType = WorkType.Deliver;
                 Consumer = consumer;
@@ -316,7 +316,7 @@ namespace RabbitMQ.Client.ConsumerDispatching
             }
 
             public static WorkStruct CreateDeliver(IBasicConsumer consumer, string consumerTag, ulong deliveryTag, bool redelivered,
-                string exchange, string routingKey, in ReadOnlyBasicProperties basicProperties, RentedMemory body)
+                string exchange, string routingKey, ReadOnlyBasicProperties basicProperties, RentedMemory body)
             {
                 return new WorkStruct(consumer, consumerTag, deliveryTag, redelivered,
                     exchange, routingKey, basicProperties, body);

--- a/projects/RabbitMQ.Client/client/impl/ConsumerDispatching/FallbackConsumer.cs
+++ b/projects/RabbitMQ.Client/client/impl/ConsumerDispatching/FallbackConsumer.cs
@@ -68,7 +68,7 @@ namespace RabbitMQ.Client.ConsumerDispatching
         }
 
         Task IAsyncBasicConsumer.HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey,
-            in ReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
+            ReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
         {
             return ((IBasicConsumer)this).HandleBasicDeliverAsync(consumerTag, deliveryTag, redelivered, exchange, routingKey, properties, body);
         }

--- a/projects/RabbitMQ.Client/client/impl/ConsumerDispatching/IConsumerDispatcher.cs
+++ b/projects/RabbitMQ.Client/client/impl/ConsumerDispatching/IConsumerDispatcher.cs
@@ -51,7 +51,7 @@ namespace RabbitMQ.Client.ConsumerDispatching
                             bool redelivered,
                             string exchange,
                             string routingKey,
-                            in ReadOnlyBasicProperties basicProperties,
+                            ReadOnlyBasicProperties basicProperties,
                             RentedMemory body,
                             CancellationToken cancellationToken);
 

--- a/projects/Test/Integration/TestAsyncConsumer.cs
+++ b/projects/Test/Integration/TestAsyncConsumer.cs
@@ -761,11 +761,11 @@ namespace Test.Integration
                 return base.HandleBasicConsumeOk(consumerTag);
             }
 
-            public override Task HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered,
-                string exchange, string routingKey, in ReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
+            public override async Task HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered,
+                string exchange, string routingKey, ReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
             {
                 _output.WriteLine("[ERROR] {0} HandleBasicDeliver {1}", _logPrefix, consumerTag);
-                return base.HandleBasicDeliver(consumerTag, deliveryTag, redelivered, exchange, routingKey, properties, body);
+                await base.HandleBasicDeliver(consumerTag, deliveryTag, redelivered, exchange, routingKey, properties, body);
             }
 
             public override Task HandleChannelShutdown(object channel, ShutdownEventArgs reason)

--- a/projects/Test/Integration/TestAsyncConsumerExceptions.cs
+++ b/projects/Test/Integration/TestAsyncConsumerExceptions.cs
@@ -134,7 +134,7 @@ namespace Test.Integration
                 bool redelivered,
                 string exchange,
                 string routingKey,
-                in ReadOnlyBasicProperties properties,
+                ReadOnlyBasicProperties properties,
                 ReadOnlyMemory<byte> body)
             {
                 return Task.FromException(TestException);


### PR DESCRIPTION
## Proposed Changes

Remove the ``in`` modifier from async methods.
Mentioned the management plugin in the test documentation.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [x] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Some tests in SequentialIntegration fail locally with timeouts, e.g.  `` Test.SequentialIntegration.TestConnectionRecovery.TestShutdownEventHandlersRecoveryOnConnectionAfterDelayedServerRestart [FAIL]``, the tests all time out.
These fail with the main branch too on my system, this does not appear to be related. Not sure what's wrong there.

I added a short addendum to the RUNNING_TESTS.md that it requires the management plugin, which is not strictly part of the default package, it needs to be enabled (at least on windows).