### PR TITLE
fix some quick wins

### DIFF
--- a/projects/RabbitMQ.Client/client/RentedMemory.cs
+++ b/projects/RabbitMQ.Client/client/RentedMemory.cs
@@ -68,23 +68,17 @@ namespace RabbitMQ.Client
             return new ReadOnlyMemory<byte>(Memory.ToArray());
         }
 
-        private void Dispose(bool disposing)
+        public void Dispose()
         {
             if (!_disposedValue)
             {
-                if (disposing && RentedArray != null)
+                if (RentedArray != null)
                 {
                     ArrayPool<byte>.Shared.Return(RentedArray);
                 }
 
                 _disposedValue = true;
             }
-        }
-
-        public void Dispose()
-        {
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
         }
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/ChannelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ChannelBase.cs
@@ -1069,10 +1069,7 @@ namespace RabbitMQ.Client.Impl
 
             try
             {
-                var cmd = new BasicPublishMemory(
-                    Encoding.UTF8.GetBytes(exchange),
-                    Encoding.UTF8.GetBytes(routingKey),
-                    mandatory, default);
+                var cmd = new BasicPublish(exchange, routingKey, mandatory, default);
                 using Activity sendActivity = RabbitMQActivitySource.PublisherHasListeners
                     ? RabbitMQActivitySource.Send(routingKey, exchange, body.Length)
                     : default;


### PR DESCRIPTION
## Proposed Changes

Fixes 2 easy cases of allocations.
1) `GC.SuppressFinalize(this);` for a struct is useless and boxes the struct allocating the box.
2) `BasicPublishMemory` is only useful if you already have a memory, encoding it on the fly is worse than using `BasicPublish` instead.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Performance change

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments