### PR TITLE
remove CancellationTokenSource from DispatcherChannelBase

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/ConsumerDispatching/AsyncConsumerDispatcher.cs
+++ b/projects/RabbitMQ.Client/client/impl/ConsumerDispatching/AsyncConsumerDispatcher.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading;
 using System.Threading.Tasks;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Impl;
@@ -14,11 +13,11 @@ namespace RabbitMQ.Client.ConsumerDispatching
         {
         }
 
-        protected override async Task ProcessChannelAsync(CancellationToken token)
+        protected override async Task ProcessChannelAsync()
         {
             try
             {
-                while (await _reader.WaitToReadAsync(token).ConfigureAwait(false))
+                while (await _reader.WaitToReadAsync().ConfigureAwait(false))
                 {
                     while (_reader.TryRead(out WorkStruct work))
                     {
@@ -54,7 +53,7 @@ namespace RabbitMQ.Client.ConsumerDispatching
             }
             catch (OperationCanceledException)
             {
-                if (false == token.IsCancellationRequested)
+                if (false == _reader.Completion.IsCompleted)
                 {
                     throw;
                 }

--- a/projects/RabbitMQ.Client/client/impl/ConsumerDispatching/ConsumerDispatcher.cs
+++ b/projects/RabbitMQ.Client/client/impl/ConsumerDispatching/ConsumerDispatcher.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading;
 using System.Threading.Tasks;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Impl;
@@ -14,11 +13,11 @@ namespace RabbitMQ.Client.ConsumerDispatching
         {
         }
 
-        protected override async Task ProcessChannelAsync(CancellationToken token)
+        protected override async Task ProcessChannelAsync()
         {
             try
             {
-                while (await _reader.WaitToReadAsync(token).ConfigureAwait(false))
+                while (await _reader.WaitToReadAsync().ConfigureAwait(false))
                 {
                     while (_reader.TryRead(out WorkStruct work))
                     {
@@ -60,7 +59,7 @@ namespace RabbitMQ.Client.ConsumerDispatching
             }
             catch (OperationCanceledException)
             {
-                if (false == token.IsCancellationRequested)
+                if (false == _reader.Completion.IsCompleted)
                 {
                     throw;
                 }


### PR DESCRIPTION
## Proposed Changes

This change removes the CancellationTokenSource form the DispatcherChannelBase added in #1347.

Justification:
- Shutting down the Dispatcher stops correctly without the CTS.
  - There's one difference, which is that it now finishes already enqueued work before fully stopping. (But it is what it used to be in 6.x, so technically this would be a revert to what it used to be)
  - For me at least, it's what I would expect to happen when I shut it down. Leaving work unfinished and undetectable (as there is no indication anywhere for it) sounds wrong to me.
- Side improvement is that it safes an allocation as well as the Threading.Channels is now able to cache some instance, thus avoiding even more allocations.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Performance change

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments