### PR TITLE
Make `ReadonlyBasicProperties` a class.

### DIFF
--- a/projects/Benchmarks/ConsumerDispatching/ConsumerDispatcher.cs
+++ b/projects/Benchmarks/ConsumerDispatching/ConsumerDispatcher.cs
@@ -19,7 +19,7 @@ namespace RabbitMQ.Benchmarks
         protected readonly ulong _deliveryTag = 500UL;
         protected readonly string _exchange = "Exchange";
         protected readonly string _routingKey = "RoutingKey";
-        protected readonly ReadOnlyBasicProperties _properties = new ReadOnlyBasicProperties();
+        protected readonly ReadOnlyBasicProperties _properties = null;
         protected readonly byte[] _body = new byte[512];
 
         public ConsumerDispatcherBase()

--- a/projects/RabbitMQ.Client/PublicAPI.Shipped.txt
+++ b/projects/RabbitMQ.Client/PublicAPI.Shipped.txt
@@ -681,7 +681,6 @@ RabbitMQ.Client.ReadOnlyBasicProperties.IsUserIdPresent() -> bool
 RabbitMQ.Client.ReadOnlyBasicProperties.MessageId.get -> string
 RabbitMQ.Client.ReadOnlyBasicProperties.Persistent.get -> bool
 RabbitMQ.Client.ReadOnlyBasicProperties.Priority.get -> byte
-RabbitMQ.Client.ReadOnlyBasicProperties.ReadOnlyBasicProperties() -> void
 RabbitMQ.Client.ReadOnlyBasicProperties.ReadOnlyBasicProperties(System.ReadOnlySpan<byte> span) -> void
 RabbitMQ.Client.ReadOnlyBasicProperties.ReplyTo.get -> string
 RabbitMQ.Client.ReadOnlyBasicProperties.ReplyToAddress.get -> RabbitMQ.Client.PublicationAddress

--- a/projects/RabbitMQ.Client/client/api/ReadonlyBasicProperties.cs
+++ b/projects/RabbitMQ.Client/client/api/ReadonlyBasicProperties.cs
@@ -39,7 +39,7 @@ namespace RabbitMQ.Client
     /// <summary>
     /// AMQP specification content header properties for content class "basic"
     /// </summary>
-    public class ReadOnlyBasicProperties : IReadOnlyBasicProperties
+    public sealed class ReadOnlyBasicProperties : IReadOnlyBasicProperties
     {
         private readonly string? _contentType;
         private readonly string? _contentEncoding;

--- a/projects/RabbitMQ.Client/client/api/ReadonlyBasicProperties.cs
+++ b/projects/RabbitMQ.Client/client/api/ReadonlyBasicProperties.cs
@@ -39,7 +39,7 @@ namespace RabbitMQ.Client
     /// <summary>
     /// AMQP specification content header properties for content class "basic"
     /// </summary>
-    public readonly struct ReadOnlyBasicProperties : IReadOnlyBasicProperties
+    public class ReadOnlyBasicProperties : IReadOnlyBasicProperties
     {
         private readonly string? _contentType;
         private readonly string? _contentEncoding;
@@ -83,7 +83,6 @@ namespace RabbitMQ.Client
         }
 
         public ReadOnlyBasicProperties(ReadOnlySpan<byte> span)
-            : this()
         {
             int offset = 2;
             ref readonly byte bits = ref span[0];

--- a/projects/RabbitMQ.Client/client/impl/ConsumerDispatching/ConsumerDispatcherChannelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ConsumerDispatching/ConsumerDispatcherChannelBase.cs
@@ -259,7 +259,7 @@ namespace RabbitMQ.Client.ConsumerDispatching
             public readonly bool Redelivered;
             public readonly string? Exchange;
             public readonly string? RoutingKey;
-            public readonly ReadOnlyBasicProperties BasicProperties;
+            public readonly ReadOnlyBasicProperties? BasicProperties;
             public readonly RentedMemory Body;
             public readonly ShutdownEventArgs? Reason;
             public readonly WorkType WorkType;


### PR DESCRIPTION
Follow-up to #1601

https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/1601#issuecomment-2171885716

cc @bollhals