### PR TITLE
docs: update badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ## RabbitMQ .NET Client
 
-[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/33srpo7owl1h3y4e?svg=true)](https://ci.appveyor.com/project/rabbitmq/rabbitmq-dotnet-client)
-![GitHub Actions (Linux)](https://github.com/rabbitmq/rabbitmq-dotnet-client/workflows/Build%20(Linux)/badge.svg)
+![GitHub Actions rabbitmq-dotnet-client](https://github.com/rabbitmq/rabbitmq-dotnet-client/actions/workflows/main.yaml/badge.svg)
 ![CodeQL](https://github.com/rabbitmq/rabbitmq-dotnet-client/workflows/CodeQL/badge.svg)
 
 This repository contains source code of the [RabbitMQ .NET client](https://www.rabbitmq.com/dotnet.html).


### PR DESCRIPTION
## Proposed Changes

Seemed the AppVeyor is not used now? so try to remove AppVeyor badge
Update Github Actions linux build badge with a valid one

Redenered view(https://github.com/WeihanLi/rabbitmq-dotnet-client/tree/patch-1):
![image](https://github.com/rabbitmq/rabbitmq-dotnet-client/assets/7604648/18e13ab6-b9e7-42b3-aa13-148f59d53ba2)


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [x] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
