### PR TITLE
Expose DispatchConsumersAsync as a readonly from ConnectionFactory to IConnection

### DIFF
--- a/projects/RabbitMQ.Client/PublicAPI.Shipped.txt
+++ b/projects/RabbitMQ.Client/PublicAPI.Shipped.txt
@@ -511,6 +511,7 @@ RabbitMQ.Client.IConnection.Endpoint.get -> RabbitMQ.Client.AmqpTcpEndpoint
 RabbitMQ.Client.IConnection.FrameMax.get -> uint
 RabbitMQ.Client.IConnection.Heartbeat.get -> System.TimeSpan
 RabbitMQ.Client.IConnection.IsOpen.get -> bool
+RabbitMQ.Client.IConnection.DispatchConsumersAsync.get -> bool
 RabbitMQ.Client.IConnection.Protocol.get -> RabbitMQ.Client.IProtocol
 RabbitMQ.Client.IConnection.QueueNameChangedAfterRecovery -> System.EventHandler<RabbitMQ.Client.Events.QueueNameChangedAfterRecoveryEventArgs>
 RabbitMQ.Client.IConnection.RecoveringConsumer -> System.EventHandler<RabbitMQ.Client.Events.RecoveringConsumerEventArgs>

--- a/projects/RabbitMQ.Client/client/api/IConnection.cs
+++ b/projects/RabbitMQ.Client/client/api/IConnection.cs
@@ -127,6 +127,11 @@ namespace RabbitMQ.Client
         IEnumerable<ShutdownReportEntry> ShutdownReport { get; }
 
         /// <summary>
+        /// Returns if connection is set to use asynchronous consumer dispatcher/>.
+        /// </summary>
+        public bool DispatchConsumersAsync { get; }
+
+        /// <summary>
         /// Application-specific connection name, will be displayed in the management UI
         /// if RabbitMQ server supports it. This value doesn't have to be unique and cannot
         /// be used as a connection identifier, e.g. in HTTP API requests.
@@ -236,5 +241,8 @@ namespace RabbitMQ.Client
         /// </summary>
         /// <param name="cancellationToken">Cancellation token</param>
         Task<IChannel> CreateChannelAsync(CancellationToken cancellationToken = default);
+
+
+        
     }
 }

--- a/projects/RabbitMQ.Client/client/api/IConnection.cs
+++ b/projects/RabbitMQ.Client/client/api/IConnection.cs
@@ -242,7 +242,5 @@ namespace RabbitMQ.Client
         /// <param name="cancellationToken">Cancellation token</param>
         Task<IChannel> CreateChannelAsync(CancellationToken cancellationToken = default);
 
-
-        
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.cs
@@ -176,6 +176,8 @@ namespace RabbitMQ.Client.Framing.Impl
 
         public IProtocol Protocol => Endpoint.Protocol;
 
+        public bool DispatchConsumersAsync => _config.DispatchConsumersAsync;
+
         public async ValueTask<RecoveryAwareChannel> CreateNonRecoveringChannelAsync(CancellationToken cancellationToken)
         {
             ISession session = InnerConnection.CreateSession();

--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -101,6 +101,8 @@ namespace RabbitMQ.Client.Framing.Impl
         public int LocalPort => _frameHandler.LocalPort;
         public int RemotePort => _frameHandler.RemotePort;
 
+        public bool DispatchConsumersAsync => _config.DispatchConsumersAsync;
+
         public IDictionary<string, object?>? ServerProperties { get; private set; }
 
         public IEnumerable<ShutdownReportEntry> ShutdownReport => _shutdownReport;


### PR DESCRIPTION
## Proposed Changes

Expose `DispatchConsumersAsync` property from internal `_config.DispatchConsumersAsync` to a read only property on `IConnection` interface, described in #1610.

Creating a consumer that receive a `IConnection` from dependency injection, without touch on `IConnectionFactory`, understand if connection will use **async** or **sync** dispatch is important to validate and help a developer to configure `ConnectionFactory` right. 

It will enable to create a validation that avoids starting a consumer who never dispatches messages to user code because the connection is defined with synchronous dispatch and consumer is asynchronous or vice versa.

## Types of Changes

Promote a hidden property defined on constructor to expose as a part of IConnection Interface.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [X] All tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in related repositories

