### PR TITLE
change InboundFrame to a class

### DIFF
--- a/projects/RabbitMQ.Client/client/api/ReadonlyBasicProperties.cs
+++ b/projects/RabbitMQ.Client/client/api/ReadonlyBasicProperties.cs
@@ -84,6 +84,11 @@ namespace RabbitMQ.Client
 
         public ReadOnlyBasicProperties(ReadOnlySpan<byte> span)
         {
+            if (span.IsEmpty)
+            {
+                return;
+            }
+
             int offset = 2;
             ref readonly byte bits = ref span[0];
             if (bits.IsBitSet(BasicProperties.ContentTypeBit)) { offset += WireFormatting.ReadShortstr(span.Slice(offset), out _contentType); }

--- a/projects/RabbitMQ.Client/client/impl/IFrameHandler.cs
+++ b/projects/RabbitMQ.Client/client/impl/IFrameHandler.cs
@@ -61,12 +61,12 @@ namespace RabbitMQ.Client.Impl
         ///<summary>Read a frame from the underlying
         ///transport. Returns null if the read operation timed out
         ///(see Timeout property).</summary>
-        ValueTask<InboundFrame> ReadFrameAsync(CancellationToken cancellationToken);
+        ValueTask ReadFrameAsync(InboundFrame frame, CancellationToken cancellationToken);
 
         ///<summary>Try to synchronously read a frame from the underlying transport.
         ///Returns false if connection buffer contains insufficient data.
         ///</summary>
-        bool TryReadFrame(out InboundFrame frame);
+        bool TryReadFrame(InboundFrame frame);
 
         Task SendProtocolHeaderAsync(CancellationToken cancellationToken);
 

--- a/projects/RabbitMQ.Client/client/impl/ISession.cs
+++ b/projects/RabbitMQ.Client/client/impl/ISession.cs
@@ -74,7 +74,7 @@ namespace RabbitMQ.Client.Impl
 
         void Close(ShutdownEventArgs reason, bool notify);
 
-        Task<bool> HandleFrameAsync(InboundFrame frame, CancellationToken cancellationToken);
+        Task HandleFrameAsync(InboundFrame frame, CancellationToken cancellationToken);
 
         void Notify();
 

--- a/projects/RabbitMQ.Client/client/impl/MainSession.cs
+++ b/projects/RabbitMQ.Client/client/impl/MainSession.cs
@@ -54,7 +54,7 @@ namespace RabbitMQ.Client.Impl
         {
         }
 
-        public override Task<bool> HandleFrameAsync(InboundFrame frame, CancellationToken cancellationToken)
+        public override Task HandleFrameAsync(InboundFrame frame, CancellationToken cancellationToken)
         {
             if (_closing)
             {
@@ -76,7 +76,7 @@ namespace RabbitMQ.Client.Impl
 
                 // Either a non-method frame, or not what we were looking
                 // for. Ignore it - we're quiescing.
-                return Task.FromResult(true);
+                return Task.CompletedTask;
             }
 
             return base.HandleFrameAsync(frame, cancellationToken);

--- a/projects/RabbitMQ.Client/client/impl/Session.cs
+++ b/projects/RabbitMQ.Client/client/impl/Session.cs
@@ -46,17 +46,16 @@ namespace RabbitMQ.Client.Impl
             _assembler = new CommandAssembler(maxBodyLength);
         }
 
-        public override async Task<bool> HandleFrameAsync(InboundFrame frame, CancellationToken cancellationToken)
+        public override Task HandleFrameAsync(InboundFrame frame, CancellationToken cancellationToken)
         {
-            bool shallReturnFramePayload = _assembler.HandleFrame(in frame, out IncomingCommand cmd);
+            _assembler.HandleFrame(frame, out IncomingCommand cmd);
 
-            if (!cmd.IsEmpty)
+            if (cmd.IsEmpty)
             {
-                await CommandReceived.Invoke(cmd, cancellationToken)
-                    .ConfigureAwait(false);
+                return Task.CompletedTask;
             }
 
-            return shallReturnFramePayload;
+            return CommandReceived.Invoke(cmd, cancellationToken);
         }
     }
 }

--- a/projects/RabbitMQ.Client/client/impl/SessionBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/SessionBase.cs
@@ -118,7 +118,7 @@ namespace RabbitMQ.Client.Impl
             }
         }
 
-        public abstract Task<bool> HandleFrameAsync(InboundFrame frame, CancellationToken cancellationToken);
+        public abstract Task HandleFrameAsync(InboundFrame frame, CancellationToken cancellationToken);
 
         public void Notify()
         {

--- a/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
+++ b/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
@@ -278,16 +278,16 @@ namespace RabbitMQ.Client.Impl
             }
         }
 
-        public ValueTask<InboundFrame> ReadFrameAsync(CancellationToken mainLoopCancellationToken)
+        public ValueTask ReadFrameAsync(InboundFrame frame, CancellationToken mainLoopCancellationToken)
         {
             return InboundFrame.ReadFromPipeAsync(_pipeReader,
-                _amqpTcpEndpoint.MaxInboundMessageBodySize, mainLoopCancellationToken);
+                _amqpTcpEndpoint.MaxInboundMessageBodySize, frame, mainLoopCancellationToken);
         }
 
-        public bool TryReadFrame(out InboundFrame frame)
+        public bool TryReadFrame(InboundFrame frame)
         {
             return InboundFrame.TryReadFrameFromPipe(_pipeReader,
-                _amqpTcpEndpoint.MaxInboundMessageBodySize, out frame);
+                _amqpTcpEndpoint.MaxInboundMessageBodySize, frame);
         }
 
         public async Task SendProtocolHeaderAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
## Proposed Changes

Changes the InboundFrame to a class instead of a readonly struct. There's only ever one frame active per connection, hence it can be a class that is allocated once and then reused.

benefits
- Simplifies handling of the type, as classes are easier to handle than struct (e.g. avoid struct copies, async incompatibilities around `in`).
- Most likely improves performance very slightly, but unable to provide evidence, as it's within the error margin.
- Simplifies handling of the rented memory, as the array can now be nulled out

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Performance / Simplification change

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments
There's a bugfix in here as well, if wanted, I can submit that separately. see my comments.