### PR TITLE
Avoid boxing in IEndpointResolverExtensions.cs

### DIFF
--- a/projects/RabbitMQ.Client/client/api/IEndpointResolverExtensions.cs
+++ b/projects/RabbitMQ.Client/client/api/IEndpointResolverExtensions.cs
@@ -71,7 +71,7 @@ namespace RabbitMQ.Client
                 }
             }
 
-            if (Object.Equals(t, default(T)) && exceptions.Count > 0)
+            if (EqualityComparer<T>.Default.Equals(t, default(T)) && exceptions.Count > 0)
             {
                 throw new AggregateException(exceptions);
             }


### PR DESCRIPTION
## Proposed Changes

Technically T can be a value type. `Object.Equals` has an overload that takes `object` therefore any struct would be boxed. To avoid it, `EqualityComparer<T>.Default.Equals` should be used.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments
