### PR TITLE
make IncomingCommand a class and simplify code around it

### DIFF
--- a/projects/RabbitMQ.Client/client/RentedMemory.cs
+++ b/projects/RabbitMQ.Client/client/RentedMemory.cs
@@ -36,8 +36,6 @@ namespace RabbitMQ.Client
 {
     internal struct RentedMemory : IDisposable
     {
-        private bool _disposedValue;
-
         internal RentedMemory(byte[] rentedArray)
             : this(new ReadOnlyMemory<byte>(rentedArray), rentedArray)
         {
@@ -47,21 +45,20 @@ namespace RabbitMQ.Client
         {
             Memory = memory;
             RentedArray = rentedArray;
-            _disposedValue = false;
         }
 
-        internal readonly ReadOnlyMemory<byte> Memory;
-
-        internal readonly byte[] ToArray()
-        {
-            return Memory.ToArray();
-        }
+        internal ReadOnlyMemory<byte> Memory;
 
         internal readonly int Size => Memory.Length;
 
         internal readonly ReadOnlySpan<byte> Span => Memory.Span;
 
-        internal readonly byte[] RentedArray;
+        internal byte[] RentedArray;
+
+        internal readonly byte[] ToArray()
+        {
+            return Memory.ToArray();
+        }
 
         internal readonly ReadOnlyMemory<byte> CopyToMemory()
         {
@@ -70,14 +67,11 @@ namespace RabbitMQ.Client
 
         public void Dispose()
         {
-            if (!_disposedValue)
+            if (RentedArray != null)
             {
-                if (RentedArray != null)
-                {
-                    ArrayPool<byte>.Shared.Return(RentedArray);
-                }
-
-                _disposedValue = true;
+                ArrayPool<byte>.Shared.Return(RentedArray);
+                RentedArray = default;
+                Memory = default;
             }
         }
     }

--- a/projects/RabbitMQ.Client/client/framing/Channel.cs
+++ b/projects/RabbitMQ.Client/client/framing/Channel.cs
@@ -88,17 +88,17 @@ namespace RabbitMQ.Client.Framing.Impl
                     }
                 case ProtocolCommandId.BasicAck:
                     {
-                        HandleBasicAck(in cmd);
+                        HandleBasicAck(cmd);
                         return Task.FromResult(true);
                     }
                 case ProtocolCommandId.BasicNack:
                     {
-                        HandleBasicNack(in cmd);
+                        HandleBasicNack(cmd);
                         return Task.FromResult(true);
                     }
                 case ProtocolCommandId.BasicReturn:
                     {
-                        HandleBasicReturn(in cmd);
+                        HandleBasicReturn(cmd);
                         return Task.FromResult(true);
                     }
                 case ProtocolCommandId.ChannelClose:
@@ -118,7 +118,7 @@ namespace RabbitMQ.Client.Framing.Impl
                     }
                 case ProtocolCommandId.ConnectionBlocked:
                     {
-                        HandleConnectionBlocked(in cmd);
+                        HandleConnectionBlocked(cmd);
                         return Task.FromResult(true);
                     }
                 case ProtocolCommandId.ConnectionClose:
@@ -143,7 +143,7 @@ namespace RabbitMQ.Client.Framing.Impl
                     }
                 case ProtocolCommandId.ConnectionUnblocked:
                     {
-                        HandleConnectionUnblocked(in cmd);
+                        HandleConnectionUnblocked(cmd);
                         return Task.FromResult(true);
                     }
                 default:

--- a/projects/RabbitMQ.Client/client/impl/IncomingCommand.cs
+++ b/projects/RabbitMQ.Client/client/impl/IncomingCommand.cs
@@ -48,7 +48,7 @@ namespace RabbitMQ.Client.Impl
 
         public RentedMemory TakeoverBody()
         {
-            var body = Body;
+            RentedMemory body = Body;
             Body = default;
             return body;
         }

--- a/projects/RabbitMQ.Client/client/impl/Session.cs
+++ b/projects/RabbitMQ.Client/client/impl/Session.cs
@@ -48,7 +48,7 @@ namespace RabbitMQ.Client.Impl
 
         public override Task HandleFrameAsync(InboundFrame frame, CancellationToken cancellationToken)
         {
-            var cmd = _assembler.HandleFrame(frame);
+            IncomingCommand cmd = _assembler.HandleFrame(frame);
             if (cmd is null)
             {
                 return Task.CompletedTask;

--- a/projects/RabbitMQ.Client/client/impl/Session.cs
+++ b/projects/RabbitMQ.Client/client/impl/Session.cs
@@ -48,9 +48,8 @@ namespace RabbitMQ.Client.Impl
 
         public override Task HandleFrameAsync(InboundFrame frame, CancellationToken cancellationToken)
         {
-            _assembler.HandleFrame(frame, out IncomingCommand cmd);
-
-            if (cmd.IsEmpty)
+            var cmd = _assembler.HandleFrame(frame);
+            if (cmd is null)
             {
                 return Task.CompletedTask;
             }


### PR DESCRIPTION
## Proposed Changes

Similar to the frame one, there's also just one Command at a time. So it can be allocated once and updated throughout the lifetime. 
This way it can be changed to a class instead of struct, and thus avoids all the complexity of the struct handling especially with the async code.

Slight performance increase as well.

| Method              | Mean     | Error   | StdDev  | Ratio | Gen0      | Allocated | Alloc Ratio |
|-------------------- |---------:|--------:|--------:|------:|----------:|----------:|------------:|
| Pr_Publish_Hello_World | 275.2 ms | 5.50 ms | 8.57 ms |  1.00 | 1000.0000 |   5.85 MB |        1.00 |
| Main_Publish_Hello_World | 279.8 ms | 5.55 ms | 11.47 ms |  1.00 | 1000.0000 |   5.84 MB |        1.00 |

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Performance / simplification

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

I've changed a few things along the way
