### PR TITLE
Replace ReadOnlyBasicProperties with IReadOnlyBasicProperties

### DIFF
--- a/projects/Benchmarks/ConsumerDispatching/AsyncBasicConsumerFake.cs
+++ b/projects/Benchmarks/ConsumerDispatching/AsyncBasicConsumerFake.cs
@@ -18,8 +18,7 @@ namespace RabbitMQ.Benchmarks
             _autoResetEvent = autoResetEvent;
         }
 
-        public Task HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange,
-            string routingKey,
+        public Task HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey,
             IReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
         {
             if (Interlocked.Increment(ref _current) == Count)
@@ -30,8 +29,7 @@ namespace RabbitMQ.Benchmarks
             return Task.CompletedTask;
         }
 
-        Task IBasicConsumer.HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered,
-            string exchange, string routingKey,
+        Task IBasicConsumer.HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey,
             IReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
         {
             if (Interlocked.Increment(ref _current) == Count)

--- a/projects/Benchmarks/ConsumerDispatching/AsyncBasicConsumerFake.cs
+++ b/projects/Benchmarks/ConsumerDispatching/AsyncBasicConsumerFake.cs
@@ -18,8 +18,9 @@ namespace RabbitMQ.Benchmarks
             _autoResetEvent = autoResetEvent;
         }
 
-        public Task HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey,
-            ReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
+        public Task HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange,
+            string routingKey,
+            IReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
         {
             if (Interlocked.Increment(ref _current) == Count)
             {
@@ -29,8 +30,9 @@ namespace RabbitMQ.Benchmarks
             return Task.CompletedTask;
         }
 
-        Task IBasicConsumer.HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey,
-            ReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
+        Task IBasicConsumer.HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered,
+            string exchange, string routingKey,
+            IReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
         {
             if (Interlocked.Increment(ref _current) == Count)
             {

--- a/projects/RabbitMQ.Client/PublicAPI.Shipped.txt
+++ b/projects/RabbitMQ.Client/PublicAPI.Shipped.txt
@@ -62,7 +62,7 @@ override RabbitMQ.Client.AmqpTimestamp.GetHashCode() -> int
 override RabbitMQ.Client.AmqpTimestamp.ToString() -> string
 override RabbitMQ.Client.Events.AsyncEventingBasicConsumer.HandleBasicCancelOk(string consumerTag) -> System.Threading.Tasks.Task
 override RabbitMQ.Client.Events.AsyncEventingBasicConsumer.HandleBasicConsumeOk(string consumerTag) -> System.Threading.Tasks.Task
-override RabbitMQ.Client.Events.AsyncEventingBasicConsumer.HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, RabbitMQ.Client.ReadOnlyBasicProperties properties, System.ReadOnlyMemory<byte> body) -> System.Threading.Tasks.Task
+override RabbitMQ.Client.Events.AsyncEventingBasicConsumer.HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, RabbitMQ.Client.IReadOnlyBasicProperties properties, System.ReadOnlyMemory<byte> body) -> System.Threading.Tasks.Task
 override RabbitMQ.Client.Events.AsyncEventingBasicConsumer.HandleChannelShutdown(object channel, RabbitMQ.Client.ShutdownEventArgs reason) -> System.Threading.Tasks.Task
 override RabbitMQ.Client.Events.EventingBasicConsumer.HandleBasicCancelOk(string consumerTag) -> void
 override RabbitMQ.Client.Events.EventingBasicConsumer.HandleBasicConsumeOk(string consumerTag) -> void
@@ -117,12 +117,12 @@ RabbitMQ.Client.BasicCredentialsProvider.Refresh() -> void
 RabbitMQ.Client.BasicCredentialsProvider.UserName.get -> string
 RabbitMQ.Client.BasicCredentialsProvider.ValidUntil.get -> System.TimeSpan?
 RabbitMQ.Client.BasicGetResult
-RabbitMQ.Client.BasicGetResult.BasicGetResult(ulong deliveryTag, bool redelivered, string exchange, string routingKey, uint messageCount, in RabbitMQ.Client.ReadOnlyBasicProperties basicProperties, System.ReadOnlyMemory<byte> body) -> void
+RabbitMQ.Client.BasicGetResult.BasicGetResult(ulong deliveryTag, bool redelivered, string exchange, string routingKey, uint messageCount, RabbitMQ.Client.IReadOnlyBasicProperties basicProperties, System.ReadOnlyMemory<byte> body) -> void
 RabbitMQ.Client.BasicProperties
 RabbitMQ.Client.BasicProperties.AppId.get -> string
 RabbitMQ.Client.BasicProperties.AppId.set -> void
 RabbitMQ.Client.BasicProperties.BasicProperties() -> void
-RabbitMQ.Client.BasicProperties.BasicProperties(RabbitMQ.Client.ReadOnlyBasicProperties input) -> void
+RabbitMQ.Client.BasicProperties.BasicProperties(RabbitMQ.Client.IReadOnlyBasicProperties input) -> void
 RabbitMQ.Client.BasicProperties.ClearAppId() -> void
 RabbitMQ.Client.BasicProperties.ClearClusterId() -> void
 RabbitMQ.Client.BasicProperties.ClearContentEncoding() -> void
@@ -292,11 +292,11 @@ RabbitMQ.Client.Events.BaseExceptionEventArgs.BaseExceptionEventArgs(System.Coll
 RabbitMQ.Client.Events.BasicAckEventArgs
 RabbitMQ.Client.Events.BasicAckEventArgs.BasicAckEventArgs(ulong deliveryTag, bool multiple) -> void
 RabbitMQ.Client.Events.BasicDeliverEventArgs
-RabbitMQ.Client.Events.BasicDeliverEventArgs.BasicDeliverEventArgs(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, in RabbitMQ.Client.ReadOnlyBasicProperties properties, System.ReadOnlyMemory<byte> body) -> void
+RabbitMQ.Client.Events.BasicDeliverEventArgs.BasicDeliverEventArgs(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, RabbitMQ.Client.IReadOnlyBasicProperties properties, System.ReadOnlyMemory<byte> body) -> void
 RabbitMQ.Client.Events.BasicNackEventArgs
 RabbitMQ.Client.Events.BasicNackEventArgs.BasicNackEventArgs(ulong deliveryTag, bool multiple, bool requeue) -> void
 RabbitMQ.Client.Events.BasicReturnEventArgs
-RabbitMQ.Client.Events.BasicReturnEventArgs.BasicReturnEventArgs(ushort replyCode, string replyText, string exchange, string routingKey, RabbitMQ.Client.ReadOnlyBasicProperties basicProperties, System.ReadOnlyMemory<byte> body) -> void
+RabbitMQ.Client.Events.BasicReturnEventArgs.BasicReturnEventArgs(ushort replyCode, string replyText, string exchange, string routingKey, RabbitMQ.Client.IReadOnlyBasicProperties basicProperties, System.ReadOnlyMemory<byte> body) -> void
 RabbitMQ.Client.Events.CallbackExceptionEventArgs
 RabbitMQ.Client.Events.CallbackExceptionEventArgs.CallbackExceptionEventArgs(System.Collections.Generic.IDictionary<string, object> detail, System.Exception exception) -> void
 RabbitMQ.Client.Events.ConnectionBlockedEventArgs
@@ -413,7 +413,7 @@ RabbitMQ.Client.IAsyncBasicConsumer.ConsumerCancelled -> RabbitMQ.Client.Events.
 RabbitMQ.Client.IAsyncBasicConsumer.HandleBasicCancel(string consumerTag) -> System.Threading.Tasks.Task
 RabbitMQ.Client.IAsyncBasicConsumer.HandleBasicCancelOk(string consumerTag) -> System.Threading.Tasks.Task
 RabbitMQ.Client.IAsyncBasicConsumer.HandleBasicConsumeOk(string consumerTag) -> System.Threading.Tasks.Task
-RabbitMQ.Client.IAsyncBasicConsumer.HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, RabbitMQ.Client.ReadOnlyBasicProperties properties, System.ReadOnlyMemory<byte> body) -> System.Threading.Tasks.Task
+RabbitMQ.Client.IAsyncBasicConsumer.HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, RabbitMQ.Client.IReadOnlyBasicProperties properties, System.ReadOnlyMemory<byte> body) -> System.Threading.Tasks.Task
 RabbitMQ.Client.IAsyncBasicConsumer.HandleChannelShutdown(object channel, RabbitMQ.Client.ShutdownEventArgs reason) -> System.Threading.Tasks.Task
 RabbitMQ.Client.IAuthMechanism
 RabbitMQ.Client.IAuthMechanism.handleChallenge(byte[] challenge, RabbitMQ.Client.ConnectionConfig config) -> byte[]
@@ -766,7 +766,7 @@ RabbitMQ.Client.TopologyRecoveryFilter.QueueFilter.get -> System.Func<RabbitMQ.C
 RabbitMQ.Client.TopologyRecoveryFilter.QueueFilter.set -> void
 RabbitMQ.Client.TopologyRecoveryFilter.TopologyRecoveryFilter() -> void
 readonly RabbitMQ.Client.AmqpTimestamp.UnixTime -> long
-readonly RabbitMQ.Client.BasicGetResult.BasicProperties -> RabbitMQ.Client.ReadOnlyBasicProperties
+readonly RabbitMQ.Client.BasicGetResult.BasicProperties -> RabbitMQ.Client.IReadOnlyBasicProperties
 readonly RabbitMQ.Client.BasicGetResult.Body -> System.ReadOnlyMemory<byte>
 readonly RabbitMQ.Client.BasicGetResult.DeliveryTag -> ulong
 readonly RabbitMQ.Client.BasicGetResult.Exchange -> string
@@ -798,7 +798,7 @@ readonly RabbitMQ.Client.Events.BaseExceptionEventArgs.Detail -> System.Collecti
 readonly RabbitMQ.Client.Events.BaseExceptionEventArgs.Exception -> System.Exception
 readonly RabbitMQ.Client.Events.BasicAckEventArgs.DeliveryTag -> ulong
 readonly RabbitMQ.Client.Events.BasicAckEventArgs.Multiple -> bool
-readonly RabbitMQ.Client.Events.BasicDeliverEventArgs.BasicProperties -> RabbitMQ.Client.ReadOnlyBasicProperties
+readonly RabbitMQ.Client.Events.BasicDeliverEventArgs.BasicProperties -> RabbitMQ.Client.IReadOnlyBasicProperties
 readonly RabbitMQ.Client.Events.BasicDeliverEventArgs.Body -> System.ReadOnlyMemory<byte>
 readonly RabbitMQ.Client.Events.BasicDeliverEventArgs.ConsumerTag -> string
 readonly RabbitMQ.Client.Events.BasicDeliverEventArgs.DeliveryTag -> ulong
@@ -808,7 +808,7 @@ readonly RabbitMQ.Client.Events.BasicDeliverEventArgs.RoutingKey -> string
 readonly RabbitMQ.Client.Events.BasicNackEventArgs.DeliveryTag -> ulong
 readonly RabbitMQ.Client.Events.BasicNackEventArgs.Multiple -> bool
 readonly RabbitMQ.Client.Events.BasicNackEventArgs.Requeue -> bool
-readonly RabbitMQ.Client.Events.BasicReturnEventArgs.BasicProperties -> RabbitMQ.Client.ReadOnlyBasicProperties
+readonly RabbitMQ.Client.Events.BasicReturnEventArgs.BasicProperties -> RabbitMQ.Client.IReadOnlyBasicProperties
 readonly RabbitMQ.Client.Events.BasicReturnEventArgs.Body -> System.ReadOnlyMemory<byte>
 readonly RabbitMQ.Client.Events.BasicReturnEventArgs.Exchange -> string
 readonly RabbitMQ.Client.Events.BasicReturnEventArgs.ReplyCode -> ushort
@@ -863,7 +863,7 @@ static readonly RabbitMQ.Client.PublicationAddress.PSEUDO_URI_PARSER -> System.T
 virtual RabbitMQ.Client.AsyncDefaultBasicConsumer.HandleBasicCancel(string consumerTag) -> System.Threading.Tasks.Task
 virtual RabbitMQ.Client.AsyncDefaultBasicConsumer.HandleBasicCancelOk(string consumerTag) -> System.Threading.Tasks.Task
 virtual RabbitMQ.Client.AsyncDefaultBasicConsumer.HandleBasicConsumeOk(string consumerTag) -> System.Threading.Tasks.Task
-virtual RabbitMQ.Client.AsyncDefaultBasicConsumer.HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, RabbitMQ.Client.ReadOnlyBasicProperties properties, System.ReadOnlyMemory<byte> body) -> System.Threading.Tasks.Task
+virtual RabbitMQ.Client.AsyncDefaultBasicConsumer.HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, RabbitMQ.Client.IReadOnlyBasicProperties properties, System.ReadOnlyMemory<byte> body) -> System.Threading.Tasks.Task
 virtual RabbitMQ.Client.AsyncDefaultBasicConsumer.HandleChannelShutdown(object channel, RabbitMQ.Client.ShutdownEventArgs reason) -> System.Threading.Tasks.Task
 virtual RabbitMQ.Client.AsyncDefaultBasicConsumer.OnCancel(params string[] consumerTags) -> System.Threading.Tasks.Task
 virtual RabbitMQ.Client.DefaultBasicConsumer.HandleBasicCancel(string consumerTag) -> void
@@ -882,7 +882,7 @@ virtual RabbitMQ.Client.TcpClientAdapter.ReceiveTimeout.get -> System.TimeSpan
 virtual RabbitMQ.Client.TcpClientAdapter.ReceiveTimeout.set -> void
 ~const RabbitMQ.Client.RabbitMQActivitySource.PublisherSourceName = "RabbitMQ.Client.Publisher" -> string
 ~const RabbitMQ.Client.RabbitMQActivitySource.SubscriberSourceName = "RabbitMQ.Client.Subscriber" -> string
-~override RabbitMQ.Client.Events.EventingBasicConsumer.HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, RabbitMQ.Client.ReadOnlyBasicProperties properties, System.ReadOnlyMemory<byte> body) -> System.Threading.Tasks.Task
+~override RabbitMQ.Client.Events.EventingBasicConsumer.HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, RabbitMQ.Client.IReadOnlyBasicProperties properties, System.ReadOnlyMemory<byte> body) -> System.Threading.Tasks.Task
 ~RabbitMQ.Client.AmqpTcpEndpoint.AmqpTcpEndpoint(string hostName, int portOrMinusOne, RabbitMQ.Client.SslOption ssl, uint maxInboundMessageBodySize) -> void
 ~RabbitMQ.Client.ConnectionFactory.CreateConnectionAsync(RabbitMQ.Client.IEndpointResolver endpointResolver, string clientProvidedName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<RabbitMQ.Client.IConnection>
 ~RabbitMQ.Client.ConnectionFactory.CreateConnectionAsync(string clientProvidedName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<RabbitMQ.Client.IConnection>
@@ -891,7 +891,7 @@ virtual RabbitMQ.Client.TcpClientAdapter.ReceiveTimeout.set -> void
 ~RabbitMQ.Client.ConnectionFactory.CreateConnectionAsync(System.Collections.Generic.IEnumerable<string> hostnames, string clientProvidedName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<RabbitMQ.Client.IConnection>
 ~RabbitMQ.Client.ConnectionFactory.CreateConnectionAsync(System.Collections.Generic.IEnumerable<string> hostnames, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<RabbitMQ.Client.IConnection>
 ~RabbitMQ.Client.ConnectionFactory.CreateConnectionAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<RabbitMQ.Client.IConnection>
-~RabbitMQ.Client.IBasicConsumer.HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, RabbitMQ.Client.ReadOnlyBasicProperties properties, System.ReadOnlyMemory<byte> body) -> System.Threading.Tasks.Task
+~RabbitMQ.Client.IBasicConsumer.HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, RabbitMQ.Client.IReadOnlyBasicProperties properties, System.ReadOnlyMemory<byte> body) -> System.Threading.Tasks.Task
 ~RabbitMQ.Client.IChannel.BasicCancelAsync(string consumerTag, bool noWait = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 ~RabbitMQ.Client.IChannel.BasicConsumeAsync(string queue, bool autoAck, string consumerTag, bool noLocal, bool exclusive, System.Collections.Generic.IDictionary<string, object> arguments, RabbitMQ.Client.IBasicConsumer consumer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string>
 ~RabbitMQ.Client.IChannel.BasicGetAsync(string queue, bool autoAck, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<RabbitMQ.Client.BasicGetResult>
@@ -960,5 +960,5 @@ virtual RabbitMQ.Client.TcpClientAdapter.ReceiveTimeout.set -> void
 ~static RabbitMQ.Client.RabbitMQActivitySource.ContextExtractor.set -> void
 ~static RabbitMQ.Client.RabbitMQActivitySource.ContextInjector.get -> System.Action<System.Diagnostics.Activity, System.Collections.Generic.IDictionary<string, object>>
 ~static RabbitMQ.Client.RabbitMQActivitySource.ContextInjector.set -> void
-~virtual RabbitMQ.Client.DefaultBasicConsumer.HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, RabbitMQ.Client.ReadOnlyBasicProperties properties, System.ReadOnlyMemory<byte> body) -> System.Threading.Tasks.Task
+~virtual RabbitMQ.Client.DefaultBasicConsumer.HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, RabbitMQ.Client.IReadOnlyBasicProperties properties, System.ReadOnlyMemory<byte> body) -> System.Threading.Tasks.Task
 

--- a/projects/RabbitMQ.Client/PublicAPI.Unshipped.txt
+++ b/projects/RabbitMQ.Client/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
-RabbitMQ.Client.BasicProperties.BasicProperties(RabbitMQ.Client.ReadOnlyBasicProperties! input) -> void
+RabbitMQ.Client.BasicProperties.BasicProperties(RabbitMQ.Client.IReadOnlyBasicProperties! input) -> void
 RabbitMQ.Client.IConnection.DispatchConsumersAsyncEnabled.get -> bool

--- a/projects/RabbitMQ.Client/client/api/AsyncDefaultBasicConsumer.cs
+++ b/projects/RabbitMQ.Client/client/api/AsyncDefaultBasicConsumer.cs
@@ -112,7 +112,7 @@ namespace RabbitMQ.Client
             bool redelivered,
             string exchange,
             string routingKey,
-            ReadOnlyBasicProperties properties,
+            IReadOnlyBasicProperties properties,
             ReadOnlyMemory<byte> body)
         {
             // Nothing to do here.
@@ -166,8 +166,9 @@ namespace RabbitMQ.Client
             throw new InvalidOperationException("Should never be called. Enable 'DispatchConsumersAsync'.");
         }
 
-        Task IBasicConsumer.HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey,
-            ReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
+        Task IBasicConsumer.HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered,
+            string exchange, string routingKey,
+            IReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
         {
             throw new InvalidOperationException("Should never be called. Enable 'DispatchConsumersAsync'.");
         }

--- a/projects/RabbitMQ.Client/client/api/BasicGetResult.cs
+++ b/projects/RabbitMQ.Client/client/api/BasicGetResult.cs
@@ -50,7 +50,7 @@ namespace RabbitMQ.Client
         /// <param name="basicProperties">The Basic-class content header properties for the message.</param>
         /// <param name="body">The body</param>
         public BasicGetResult(ulong deliveryTag, bool redelivered, string exchange, string routingKey,
-            uint messageCount, in ReadOnlyBasicProperties basicProperties, ReadOnlyMemory<byte> body)
+            uint messageCount, IReadOnlyBasicProperties basicProperties, ReadOnlyMemory<byte> body)
         {
             DeliveryTag = deliveryTag;
             Redelivered = redelivered;
@@ -64,7 +64,7 @@ namespace RabbitMQ.Client
         /// <summary>
         /// Retrieves the Basic-class content header properties for this message.
         /// </summary>
-        public readonly ReadOnlyBasicProperties BasicProperties;
+        public readonly IReadOnlyBasicProperties BasicProperties;
 
         /// <summary>
         /// Retrieves the body of this message.

--- a/projects/RabbitMQ.Client/client/api/BasicProperties.cs
+++ b/projects/RabbitMQ.Client/client/api/BasicProperties.cs
@@ -85,7 +85,7 @@ namespace RabbitMQ.Client
         {
         }
 
-        public BasicProperties(ReadOnlyBasicProperties input)
+        public BasicProperties(IReadOnlyBasicProperties input)
         {
             ContentType = input.ContentType;
             ContentEncoding = input.ContentEncoding;

--- a/projects/RabbitMQ.Client/client/api/DefaultBasicConsumer.cs
+++ b/projects/RabbitMQ.Client/client/api/DefaultBasicConsumer.cs
@@ -153,7 +153,7 @@ namespace RabbitMQ.Client
             bool redelivered,
             string exchange,
             string routingKey,
-            ReadOnlyBasicProperties properties,
+            IReadOnlyBasicProperties properties,
             ReadOnlyMemory<byte> body)
         {
             // Nothing to do here.

--- a/projects/RabbitMQ.Client/client/api/IAsyncBasicConsumer.cs
+++ b/projects/RabbitMQ.Client/client/api/IAsyncBasicConsumer.cs
@@ -51,7 +51,7 @@ namespace RabbitMQ.Client
             bool redelivered,
             string exchange,
             string routingKey,
-            ReadOnlyBasicProperties properties,
+            IReadOnlyBasicProperties properties,
             ReadOnlyMemory<byte> body);
 
         /// <summary>

--- a/projects/RabbitMQ.Client/client/api/IBasicConsumer.cs
+++ b/projects/RabbitMQ.Client/client/api/IBasicConsumer.cs
@@ -94,7 +94,7 @@ namespace RabbitMQ.Client
             bool redelivered,
             string exchange,
             string routingKey,
-            ReadOnlyBasicProperties properties,
+            IReadOnlyBasicProperties properties,
             ReadOnlyMemory<byte> body);
 
         /// <summary>

--- a/projects/RabbitMQ.Client/client/events/AsyncEventingBasicConsumer.cs
+++ b/projects/RabbitMQ.Client/client/events/AsyncEventingBasicConsumer.cs
@@ -76,8 +76,9 @@ namespace RabbitMQ.Client.Events
         }
 
         ///<summary>Fires the Received event.</summary>
-        public override Task HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey,
-            ReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
+        public override Task HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered,
+            string exchange, string routingKey,
+            IReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
         {
             var deliverEventArgs = new BasicDeliverEventArgs(consumerTag, deliveryTag, redelivered, exchange, routingKey, properties, body);
             // No need to call base, it's empty.

--- a/projects/RabbitMQ.Client/client/events/AsyncEventingBasicConsumer.cs
+++ b/projects/RabbitMQ.Client/client/events/AsyncEventingBasicConsumer.cs
@@ -76,8 +76,7 @@ namespace RabbitMQ.Client.Events
         }
 
         ///<summary>Fires the Received event.</summary>
-        public override Task HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered,
-            string exchange, string routingKey,
+        public override Task HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey,
             IReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
         {
             var deliverEventArgs = new BasicDeliverEventArgs(consumerTag, deliveryTag, redelivered, exchange, routingKey, properties, body);

--- a/projects/RabbitMQ.Client/client/events/BasicDeliverEventArgs.cs
+++ b/projects/RabbitMQ.Client/client/events/BasicDeliverEventArgs.cs
@@ -44,7 +44,7 @@ namespace RabbitMQ.Client.Events
             bool redelivered,
             string exchange,
             string routingKey,
-            in ReadOnlyBasicProperties properties,
+            IReadOnlyBasicProperties properties,
             ReadOnlyMemory<byte> body) : base()
         {
             ConsumerTag = consumerTag;
@@ -57,7 +57,7 @@ namespace RabbitMQ.Client.Events
         }
 
         ///<summary>The content header of the message.</summary>
-        public readonly ReadOnlyBasicProperties BasicProperties;
+        public readonly IReadOnlyBasicProperties BasicProperties;
 
         ///<summary>The message body.</summary>
         public readonly ReadOnlyMemory<byte> Body;

--- a/projects/RabbitMQ.Client/client/events/BasicReturnEventArgs.cs
+++ b/projects/RabbitMQ.Client/client/events/BasicReturnEventArgs.cs
@@ -42,7 +42,7 @@ namespace RabbitMQ.Client.Events
             string replyText,
             string exchange,
             string routingKey,
-            ReadOnlyBasicProperties basicProperties,
+            IReadOnlyBasicProperties basicProperties,
             ReadOnlyMemory<byte> body) : base()
         {
             ReplyCode = replyCode;
@@ -54,7 +54,7 @@ namespace RabbitMQ.Client.Events
         }
 
         ///<summary>The content header of the message.</summary>
-        public readonly ReadOnlyBasicProperties BasicProperties;
+        public readonly IReadOnlyBasicProperties BasicProperties;
 
         ///<summary>The message body.</summary>
         public readonly ReadOnlyMemory<byte> Body;

--- a/projects/RabbitMQ.Client/client/events/EventingBasicConsumer.cs
+++ b/projects/RabbitMQ.Client/client/events/EventingBasicConsumer.cs
@@ -86,8 +86,9 @@ namespace RabbitMQ.Client.Events
         /// Accessing the body at a later point is unsafe as its memory can
         /// be already released.
         /// </remarks>
-        public override async Task HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey,
-            ReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
+        public override async Task HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered,
+            string exchange, string routingKey,
+            IReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
         {
             BasicDeliverEventArgs eventArgs = new BasicDeliverEventArgs(consumerTag, deliveryTag, redelivered, exchange, routingKey, properties, body);
             using (Activity activity = RabbitMQActivitySource.SubscriberHasListeners ? RabbitMQActivitySource.Deliver(eventArgs) : default)

--- a/projects/RabbitMQ.Client/client/events/EventingBasicConsumer.cs
+++ b/projects/RabbitMQ.Client/client/events/EventingBasicConsumer.cs
@@ -86,8 +86,7 @@ namespace RabbitMQ.Client.Events
         /// Accessing the body at a later point is unsafe as its memory can
         /// be already released.
         /// </remarks>
-        public override async Task HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered,
-            string exchange, string routingKey,
+        public override async Task HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey,
             IReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
         {
             BasicDeliverEventArgs eventArgs = new BasicDeliverEventArgs(consumerTag, deliveryTag, redelivered, exchange, routingKey, properties, body);

--- a/projects/RabbitMQ.Client/client/impl/ConsumerDispatching/ConsumerDispatcherChannelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ConsumerDispatching/ConsumerDispatcherChannelBase.cs
@@ -69,7 +69,7 @@ namespace RabbitMQ.Client.ConsumerDispatching
         }
 
         public ValueTask HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered,
-            string exchange, string routingKey, ReadOnlyBasicProperties basicProperties, RentedMemory body,
+            string exchange, string routingKey, IReadOnlyBasicProperties basicProperties, RentedMemory body,
             CancellationToken cancellationToken)
         {
             if (false == _disposed && false == _quiesce)
@@ -234,7 +234,7 @@ namespace RabbitMQ.Client.ConsumerDispatching
             public readonly bool Redelivered;
             public readonly string? Exchange;
             public readonly string? RoutingKey;
-            public readonly ReadOnlyBasicProperties? BasicProperties;
+            public readonly IReadOnlyBasicProperties? BasicProperties;
             public readonly RentedMemory Body;
             public readonly ShutdownEventArgs? Reason;
             public readonly WorkType WorkType;
@@ -256,7 +256,7 @@ namespace RabbitMQ.Client.ConsumerDispatching
             }
 
             private WorkStruct(IBasicConsumer consumer, string consumerTag, ulong deliveryTag, bool redelivered,
-                string exchange, string routingKey, ReadOnlyBasicProperties basicProperties, RentedMemory body)
+                string exchange, string routingKey, IReadOnlyBasicProperties basicProperties, RentedMemory body)
             {
                 WorkType = WorkType.Deliver;
                 Consumer = consumer;
@@ -291,7 +291,7 @@ namespace RabbitMQ.Client.ConsumerDispatching
             }
 
             public static WorkStruct CreateDeliver(IBasicConsumer consumer, string consumerTag, ulong deliveryTag, bool redelivered,
-                string exchange, string routingKey, ReadOnlyBasicProperties basicProperties, RentedMemory body)
+                string exchange, string routingKey, IReadOnlyBasicProperties basicProperties, RentedMemory body)
             {
                 return new WorkStruct(consumer, consumerTag, deliveryTag, redelivered,
                     exchange, routingKey, basicProperties, body);

--- a/projects/RabbitMQ.Client/client/impl/ConsumerDispatching/FallbackConsumer.cs
+++ b/projects/RabbitMQ.Client/client/impl/ConsumerDispatching/FallbackConsumer.cs
@@ -37,8 +37,7 @@ namespace RabbitMQ.Client.ConsumerDispatching
             ESLog.Info($"Unhandled {nameof(IBasicConsumer.HandleBasicConsumeOk)} for tag {consumerTag}");
         }
 
-        Task IBasicConsumer.HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered,
-            string exchange, string routingKey,
+        Task IBasicConsumer.HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey,
             IReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
         {
             ESLog.Info($"Unhandled {nameof(IBasicConsumer.HandleBasicDeliverAsync)} for tag {consumerTag}");
@@ -68,8 +67,7 @@ namespace RabbitMQ.Client.ConsumerDispatching
             return Task.CompletedTask;
         }
 
-        Task IAsyncBasicConsumer.HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered,
-            string exchange, string routingKey,
+        Task IAsyncBasicConsumer.HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey,
             IReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
         {
             return ((IBasicConsumer)this).HandleBasicDeliverAsync(consumerTag, deliveryTag, redelivered, exchange, routingKey, properties, body);

--- a/projects/RabbitMQ.Client/client/impl/ConsumerDispatching/FallbackConsumer.cs
+++ b/projects/RabbitMQ.Client/client/impl/ConsumerDispatching/FallbackConsumer.cs
@@ -37,8 +37,9 @@ namespace RabbitMQ.Client.ConsumerDispatching
             ESLog.Info($"Unhandled {nameof(IBasicConsumer.HandleBasicConsumeOk)} for tag {consumerTag}");
         }
 
-        Task IBasicConsumer.HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey,
-            ReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
+        Task IBasicConsumer.HandleBasicDeliverAsync(string consumerTag, ulong deliveryTag, bool redelivered,
+            string exchange, string routingKey,
+            IReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
         {
             ESLog.Info($"Unhandled {nameof(IBasicConsumer.HandleBasicDeliverAsync)} for tag {consumerTag}");
             return Task.CompletedTask;
@@ -67,8 +68,9 @@ namespace RabbitMQ.Client.ConsumerDispatching
             return Task.CompletedTask;
         }
 
-        Task IAsyncBasicConsumer.HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey,
-            ReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
+        Task IAsyncBasicConsumer.HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered,
+            string exchange, string routingKey,
+            IReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
         {
             return ((IBasicConsumer)this).HandleBasicDeliverAsync(consumerTag, deliveryTag, redelivered, exchange, routingKey, properties, body);
         }

--- a/projects/RabbitMQ.Client/client/impl/ConsumerDispatching/IConsumerDispatcher.cs
+++ b/projects/RabbitMQ.Client/client/impl/ConsumerDispatching/IConsumerDispatcher.cs
@@ -51,7 +51,7 @@ namespace RabbitMQ.Client.ConsumerDispatching
                             bool redelivered,
                             string exchange,
                             string routingKey,
-                            ReadOnlyBasicProperties basicProperties,
+                            IReadOnlyBasicProperties basicProperties,
                             RentedMemory body,
                             CancellationToken cancellationToken);
 

--- a/projects/RabbitMQ.Client/client/impl/EmptyBasicProperty.cs
+++ b/projects/RabbitMQ.Client/client/impl/EmptyBasicProperty.cs
@@ -6,9 +6,9 @@ using RabbitMQ.Client.Impl;
 namespace RabbitMQ.Client.client.impl
 {
 #nullable enable
-    internal readonly struct EmptyBasicProperty : IReadOnlyBasicProperties, IAmqpHeader
+    internal sealed class EmptyBasicProperty : IReadOnlyBasicProperties, IAmqpHeader
     {
-        internal static readonly EmptyBasicProperty Empty;
+        internal static EmptyBasicProperty Empty => new EmptyBasicProperty();
 
         ushort IAmqpHeader.ProtocolClassId => ClassConstants.Basic;
 

--- a/projects/RabbitMQ.Client/client/impl/RabbitMQActivitySource.cs
+++ b/projects/RabbitMQ.Client/client/impl/RabbitMQActivitySource.cs
@@ -99,7 +99,7 @@ namespace RabbitMQ.Client
         }
 
         internal static Activity Receive(string routingKey, string exchange, ulong deliveryTag,
-            in ReadOnlyBasicProperties readOnlyBasicProperties, int bodySize)
+            IReadOnlyBasicProperties readOnlyBasicProperties, int bodySize)
         {
             if (!s_subscriberSource.HasListeners())
             {
@@ -160,7 +160,7 @@ namespace RabbitMQ.Client
         }
 
         private static void PopulateMessagingTags(string operation, string routingKey, string exchange,
-            ulong deliveryTag, in ReadOnlyBasicProperties readOnlyBasicProperties, int bodySize, Activity activity)
+            ulong deliveryTag, IReadOnlyBasicProperties readOnlyBasicProperties, int bodySize, Activity activity)
         {
             PopulateMessagingTags(operation, routingKey, exchange, deliveryTag, bodySize, activity);
 

--- a/projects/Test/Common/TestConnectionRecoveryBase.cs
+++ b/projects/Test/Common/TestConnectionRecoveryBase.cs
@@ -320,7 +320,7 @@ namespace Test
                 bool redelivered,
                 string exchange,
                 string routingKey,
-                ReadOnlyBasicProperties properties,
+                IReadOnlyBasicProperties properties,
                 ReadOnlyMemory<byte> body)
             {
                 try

--- a/projects/Test/Integration/TestAsyncConsumer.cs
+++ b/projects/Test/Integration/TestAsyncConsumer.cs
@@ -778,7 +778,7 @@ namespace Test.Integration
             }
 
             public override async Task HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered,
-                string exchange, string routingKey, ReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
+                string exchange, string routingKey, IReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
             {
                 _output.WriteLine("[ERROR] {0} HandleBasicDeliver {1}", _logPrefix, consumerTag);
                 await base.HandleBasicDeliver(consumerTag, deliveryTag, redelivered, exchange, routingKey, properties, body);

--- a/projects/Test/Integration/TestAsyncConsumerExceptions.cs
+++ b/projects/Test/Integration/TestAsyncConsumerExceptions.cs
@@ -134,7 +134,7 @@ namespace Test.Integration
                 bool redelivered,
                 string exchange,
                 string routingKey,
-                ReadOnlyBasicProperties properties,
+                IReadOnlyBasicProperties properties,
                 ReadOnlyMemory<byte> body)
             {
                 return Task.FromException(TestException);

--- a/projects/Test/Integration/TestConsumerExceptions.cs
+++ b/projects/Test/Integration/TestConsumerExceptions.cs
@@ -58,7 +58,7 @@ namespace Test.Integration
                 bool redelivered,
                 string exchange,
                 string routingKey,
-                ReadOnlyBasicProperties properties,
+                IReadOnlyBasicProperties properties,
                 ReadOnlyMemory<byte> body)
             {
                 throw new Exception("oops");

--- a/projects/Test/Integration/TestConsumerOperationDispatch.cs
+++ b/projects/Test/Integration/TestConsumerOperationDispatch.cs
@@ -86,7 +86,7 @@ namespace Test.Integration
 
             public override Task HandleBasicDeliverAsync(string consumerTag,
                 ulong deliveryTag, bool redelivered, string exchange, string routingKey,
-                ReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
+                IReadOnlyBasicProperties properties, ReadOnlyMemory<byte> body)
             {
                 // we test concurrent dispatch from the moment basic.delivery is returned.
                 // delivery tags have guaranteed ordering and we verify that it is preserved

--- a/projects/Test/Integration/TestMainLoop.cs
+++ b/projects/Test/Integration/TestMainLoop.cs
@@ -57,12 +57,12 @@ namespace Test.Integration
             public FaultyConsumer(IChannel channel) : base(channel) { }
 
             public override Task HandleBasicDeliverAsync(string consumerTag,
-                                               ulong deliveryTag,
-                                               bool redelivered,
-                                               string exchange,
-                                               string routingKey,
-                                               ReadOnlyBasicProperties properties,
-                                               ReadOnlyMemory<byte> body)
+                ulong deliveryTag,
+                bool redelivered,
+                string exchange,
+                string routingKey,
+                IReadOnlyBasicProperties properties,
+                ReadOnlyMemory<byte> body)
             {
                 throw new Exception("I am a bad consumer");
             }


### PR DESCRIPTION
## Proposed Changes

After ReadOnlyBasicProperties was changed to a class, we can use IReadOnlyBasicProperties without boxing problems to simplify unit testing.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #1630)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

(not all tests pass on my system, some fail for networking issues).

## Further Comments
This is mostly an automated change via ReSharper to replace the individual ``ReadOnlyBasicProperties`` with ``IReadOnlyBasicProperties`` 