### PR TITLE
simplify IncomingCommand.ReturnBuffers handling

### DIFF
--- a/projects/RabbitMQ.Client/client/framing/Channel.cs
+++ b/projects/RabbitMQ.Client/client/framing/Channel.cs
@@ -143,7 +143,7 @@ namespace RabbitMQ.Client.Framing.Impl
                     }
                 case ProtocolCommandId.ConnectionUnblocked:
                     {
-                        HandleConnectionUnblocked(cmd);
+                        HandleConnectionUnblocked();
                         return Task.FromResult(true);
                     }
                 default:

--- a/projects/RabbitMQ.Client/client/impl/ChannelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ChannelBase.cs
@@ -431,17 +431,22 @@ namespace RabbitMQ.Client.Impl
              *
              * Else, the incoming command is the return of an RPC call, and must be handled.
              */
-            if (false == await DispatchCommandAsync(cmd, cancellationToken)
-                .ConfigureAwait(false))
+            try
             {
-                using (IRpcContinuation c = _continuationQueue.Next())
+                if (false == await DispatchCommandAsync(cmd, cancellationToken)
+                    .ConfigureAwait(false))
                 {
-                    await c.HandleCommandAsync(cmd)
-                        .ConfigureAwait(false);
+                    using (IRpcContinuation c = _continuationQueue.Next())
+                    {
+                        await c.HandleCommandAsync(cmd)
+                            .ConfigureAwait(false);
+                    }
                 }
             }
-
-            cmd.ReturnBuffers();
+            finally
+            {
+                cmd.ReturnBuffers();
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
## Proposed Changes
Simplifies the handling of the ReturnBuffers by calling it at one central place, instead of many places.
-> This gets rid of the try-finally(return_buffer) pattern, as it is no longer needed. If there is an exception, the buffer will not be returned, but no real harm is done. It is not an uncommon pattern.

In addition, this commit seals the Continuation types (in accordance to CA1852)

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Refactoring / performance change

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments
