### PR TITLE
Fix Timer leakage in TimerBasedCredentialRefresher ...

### DIFF
--- a/projects/RabbitMQ.Client/client/api/ICredentialsRefresher.cs
+++ b/projects/RabbitMQ.Client/client/api/ICredentialsRefresher.cs
@@ -76,7 +76,7 @@ namespace RabbitMQ.Client
         private readonly IDictionary<ICredentialsProvider, TimerRegistration> _registrations =
             new Dictionary<ICredentialsProvider, TimerRegistration>();
         private readonly object _lockObj = new();
-        
+
         public ICredentialsProvider Register(ICredentialsProvider provider, ICredentialsRefresher.NotifyCredentialRefreshedAsync callback)
         {
             if (!provider.ValidUntil.HasValue || provider.ValidUntil.Value.Equals(TimeSpan.Zero))
@@ -96,7 +96,7 @@ namespace RabbitMQ.Client
                 registration = new TimerRegistration(_lockObj, callback);
                 _registrations.Add(provider, registration);
                 registration.ScheduleTimer(provider);
-                
+
                 TimerBasedCredentialRefresherEventSource.Log.Registered(provider.Name);
             }
 
@@ -110,13 +110,13 @@ namespace RabbitMQ.Client
                 if (_registrations.TryGetValue(provider, out var registration))
                 {
                     _registrations.Remove(provider);
-                    
+
                     TimerBasedCredentialRefresherEventSource.Log.Unregistered(provider.Name);
                     registration.Dispose();
                     return true;
-                }                
+                }
             }
-            
+
             return false;
         }
 
@@ -126,7 +126,7 @@ namespace RabbitMQ.Client
             private readonly object _lockObj;
             private System.Timers.Timer? _timer;
             private bool _disposed;
-            
+
             public ICredentialsRefresher.NotifyCredentialRefreshedAsync Callback { get; set; }
 
             public TimerRegistration(object lockObj, ICredentialsRefresher.NotifyCredentialRefreshedAsync callback)
@@ -145,7 +145,7 @@ namespace RabbitMQ.Client
                 {
                     throw new InvalidOperationException("Registration already disposed");
                 }
-                
+
                 var newTimer = new Timer();
                 newTimer.Interval = provider.ValidUntil.Value.TotalMilliseconds * (1.0 - 1 / 3.0);
                 newTimer.Elapsed += (o, e) =>
@@ -161,7 +161,7 @@ namespace RabbitMQ.Client
                                 // We were waiting and the registration has been disposed in meanwhile
                                 return;
                             }
-                
+
                             provider.Refresh();
                             ScheduleTimer(provider);
                             Callback.Invoke(provider.Password != null);
@@ -171,7 +171,7 @@ namespace RabbitMQ.Client
                         {
                             Callback.Invoke(false);
                             TimerBasedCredentialRefresherEventSource.Log.RefreshedCredentials(provider.Name, false);
-                        }                        
+                        }
                     }
                 };
                 newTimer.Enabled = true;
@@ -179,14 +179,14 @@ namespace RabbitMQ.Client
                 TimerBasedCredentialRefresherEventSource.Log.ScheduledTimer(provider.Name, newTimer.Interval);
                 _timer = newTimer;
             }
-            
+
             public void Dispose()
             {
                 if (_disposed)
                 {
                     throw new InvalidOperationException("registration already disposed");
                 }
-        
+
                 try
                 {
                     _timer?.Stop();
@@ -200,7 +200,7 @@ namespace RabbitMQ.Client
             }
 
         }
-        
+
     }
 
     class NoOpCredentialsRefresher : ICredentialsRefresher

--- a/projects/RabbitMQ.Client/client/api/ICredentialsRefresher.cs
+++ b/projects/RabbitMQ.Client/client/api/ICredentialsRefresher.cs
@@ -107,7 +107,7 @@ namespace RabbitMQ.Client
         {
             lock (_lockObj)
             {
-                if (_registrations.Remove(provider, out var registration)) 
+                if (_registrations.Remove(provider, out var registration))
                 {
                     TimerBasedCredentialRefresherEventSource.Log.Unregistered(provider.Name);
                     registration.Dispose();

--- a/projects/RabbitMQ.Client/client/api/ICredentialsRefresher.cs
+++ b/projects/RabbitMQ.Client/client/api/ICredentialsRefresher.cs
@@ -107,7 +107,8 @@ namespace RabbitMQ.Client
         {
             lock (_lockObj)
             {
-                if (_registrations.Remove(provider, out var registration)) {
+                if (_registrations.Remove(provider, out var registration)) 
+                {
                     TimerBasedCredentialRefresherEventSource.Log.Unregistered(provider.Name);
                     registration.Dispose();
                     return true;

--- a/projects/RabbitMQ.Client/client/api/ICredentialsRefresher.cs
+++ b/projects/RabbitMQ.Client/client/api/ICredentialsRefresher.cs
@@ -30,8 +30,8 @@
 //---------------------------------------------------------------------------
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
 using System.Threading.Tasks;
 using System.Timers;

--- a/projects/Test/Unit/TestTimerBasedCredentialRefresher.cs
+++ b/projects/Test/Unit/TestTimerBasedCredentialRefresher.cs
@@ -161,7 +161,8 @@ namespace Test.Unit
 
             using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
             {
-                using (CancellationTokenRegistration ctr = cts.Token.Register(() => { tcs1.TrySetCanceled(); tcs2.TrySetCanceled(); })) {
+                using (CancellationTokenRegistration ctr = cts.Token.Register(() => { tcs1.TrySetCanceled(); tcs2.TrySetCanceled(); }))
+                {
                     var credentialsProvider = new MockCredentialsProvider(_testOutputHelper, TimeSpan.FromSeconds(1));
 
                     Task cb1(bool arg)


### PR DESCRIPTION
... by maintaining only one registration across all connection recoveries

## Proposed Changes

Replaced registrations in TimerBasedCredentialRefresher by custom class to maintain only one registration across Connection recovery. Callback will be updated for the registration on each subsequent Register call.

Since multiple dictionary operations are now required to be atomic, locking is now done via a helper object for each TimerBasedCredentialRefresher instance and passed to the registration to check if it has been disposed yet by the Unregister method.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #1639 )
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

CLA will be an issue within my company which I cannot promise will be resolved in a few days (this has been an issue earlier with another CLA which also isn't finally resolved yet). Unfortunately I'm not able to make decisions on behalf of my company.

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CLA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories


