### PR TITLE
Consistently use `Task` or `ValueTask` in APIs

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.cs
@@ -183,7 +183,7 @@ namespace RabbitMQ.Client.Framing.Impl
         public override string ToString()
             => $"AutorecoveringConnection({InnerConnection.Id},{Endpoint},{GetHashCode()})";
 
-        internal Task CloseFrameHandlerAsync()
+        internal ValueTask CloseFrameHandlerAsync()
         {
             return InnerConnection.FrameHandler.CloseAsync(CancellationToken.None);
         }

--- a/projects/RabbitMQ.Client/client/impl/IFrameHandler.cs
+++ b/projects/RabbitMQ.Client/client/impl/IFrameHandler.cs
@@ -54,7 +54,7 @@ namespace RabbitMQ.Client.Impl
         ///<summary>Socket write timeout. System.Threading.Timeout.InfiniteTimeSpan signals "infinity".</summary>
         TimeSpan WriteTimeout { set; }
 
-        Task CloseAsync(CancellationToken cancellationToken);
+        ValueTask CloseAsync(CancellationToken cancellationToken);
 
         ///<summary>Read a frame from the underlying
         ///transport. Returns null if the read operation timed out
@@ -66,7 +66,7 @@ namespace RabbitMQ.Client.Impl
         ///</summary>
         bool TryReadFrame(InboundFrame frame);
 
-        Task SendProtocolHeaderAsync(CancellationToken cancellationToken);
+        ValueTask SendProtocolHeaderAsync(CancellationToken cancellationToken);
 
         ValueTask WriteAsync(RentedMemory frames, CancellationToken cancellationToken);
     }

--- a/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
+++ b/projects/RabbitMQ.Client/client/impl/SocketFrameHandler.cs
@@ -157,7 +157,7 @@ namespace RabbitMQ.Client.Impl
             return socketFrameHandler;
         }
 
-        public async Task CloseAsync(CancellationToken cancellationToken)
+        public async ValueTask CloseAsync(CancellationToken cancellationToken)
         {
             if (_closed)
             {
@@ -216,7 +216,7 @@ namespace RabbitMQ.Client.Impl
                 _amqpTcpEndpoint.MaxInboundMessageBodySize, frame);
         }
 
-        public async Task SendProtocolHeaderAsync(CancellationToken cancellationToken)
+        public async ValueTask SendProtocolHeaderAsync(CancellationToken cancellationToken)
         {
             await _pipeWriter.WriteAsync(Amqp091ProtocolHeader, cancellationToken)
                 .ConfigureAwait(false);

--- a/projects/Test/Integration/TestConnectionShutdown.cs
+++ b/projects/Test/Integration/TestConnectionShutdown.cs
@@ -100,13 +100,13 @@ namespace Test.Integration
             };
 
             var c = (AutorecoveringConnection)_conn;
-            Task frameHandlerCloseTask = c.CloseFrameHandlerAsync();
+            ValueTask frameHandlerCloseTask = c.CloseFrameHandlerAsync();
 
             try
             {
                 _conn.Dispose();
                 await WaitAsync(tcs, WaitSpan, "channel shutdown");
-                await frameHandlerCloseTask.WaitAsync(WaitSpan);
+                await frameHandlerCloseTask.AsTask().WaitAsync(WaitSpan);
             }
             finally
             {


### PR DESCRIPTION
Fixes #1645

* Start with `IFrameHandler` as pointed out by @danielmarbach
