### PR TITLE
Added ability to use Issuer to receive Token Endpoint for the OAuth2ClientBuilder

### DIFF
--- a/projects/RabbitMQ.Client.OAuth2/IOAuth2Client.cs
+++ b/projects/RabbitMQ.Client.OAuth2/IOAuth2Client.cs
@@ -36,7 +36,19 @@ namespace RabbitMQ.Client.OAuth2
 {
     public interface IOAuth2Client
     {
+        /// <summary>
+        /// Request a new AccessToken from the Token Endpoint.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token for this request</param>
+        /// <returns>Token with Access and Refresh Token</returns>
         Task<IToken> RequestTokenAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Request a new AccessToken using the Refresh Token from the Token Endpoint.
+        /// </summary>
+        /// <param name="token">Token with the Refresh Token</param>
+        /// <param name="cancellationToken">Cancellation token for this request</param>
+        /// <returns>Token with Access and Refresh Token</returns>
         Task<IToken> RefreshTokenAsync(IToken token, CancellationToken cancellationToken = default);
     }
 }

--- a/projects/RabbitMQ.Client.OAuth2/PublicAPI.Shipped.txt
+++ b/projects/RabbitMQ.Client.OAuth2/PublicAPI.Shipped.txt
@@ -7,8 +7,7 @@ RabbitMQ.Client.OAuth2.IToken.HasExpired.get -> bool
 RabbitMQ.Client.OAuth2.IToken.RefreshToken.get -> string
 RabbitMQ.Client.OAuth2.OAuth2ClientBuilder
 RabbitMQ.Client.OAuth2.OAuth2ClientBuilder.AddRequestParameter(string param, string paramValue) -> RabbitMQ.Client.OAuth2.OAuth2ClientBuilder
-RabbitMQ.Client.OAuth2.OAuth2ClientBuilder.Build() -> RabbitMQ.Client.OAuth2.IOAuth2Client
-RabbitMQ.Client.OAuth2.OAuth2ClientBuilder.OAuth2ClientBuilder(string clientId, string clientSecret, System.Uri tokenEndpoint) -> void
+RabbitMQ.Client.OAuth2.OAuth2ClientBuilder.OAuth2ClientBuilder(string! clientId, string! clientSecret, System.Uri? tokenEndpoint = null, System.Uri? issuer = null) -> void
 RabbitMQ.Client.OAuth2.OAuth2ClientBuilder.SetScope(string scope) -> RabbitMQ.Client.OAuth2.OAuth2ClientBuilder
 RabbitMQ.Client.OAuth2.OAuth2ClientCredentialsProvider
 RabbitMQ.Client.OAuth2.OAuth2ClientCredentialsProvider.Name.get -> string

--- a/projects/RabbitMQ.Client.OAuth2/PublicAPI.Unshipped.txt
+++ b/projects/RabbitMQ.Client.OAuth2/PublicAPI.Unshipped.txt
@@ -10,6 +10,7 @@ RabbitMQ.Client.OAuth2.CredentialsRefresherEventSource.Stopped(string! name) -> 
 RabbitMQ.Client.OAuth2.IOAuth2Client.RefreshTokenAsync(RabbitMQ.Client.OAuth2.IToken! token, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<RabbitMQ.Client.OAuth2.IToken!>!
 RabbitMQ.Client.OAuth2.IOAuth2Client.RequestTokenAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<RabbitMQ.Client.OAuth2.IToken!>!
 RabbitMQ.Client.OAuth2.NotifyCredentialsRefreshedAsync
+RabbitMQ.Client.OAuth2.OAuth2ClientBuilder.BuildAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<RabbitMQ.Client.OAuth2.IOAuth2Client!>
 RabbitMQ.Client.OAuth2.OAuth2ClientBuilder.SetHttpClientHandler(System.Net.Http.HttpClientHandler! handler) -> RabbitMQ.Client.OAuth2.OAuth2ClientBuilder!
 RabbitMQ.Client.OAuth2.OAuth2ClientCredentialsProvider.Dispose() -> void
 RabbitMQ.Client.OAuth2.OAuth2ClientCredentialsProvider.GetCredentialsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<RabbitMQ.Client.Credentials!>!


### PR DESCRIPTION
## Proposed Changes

Added an optional overload to the constructor of the OAuth2ClientBuilder to provide an Issuer instead of the Token Endpoint. When the OAuth2Client is build (using `Build()` or `BuildAsync()`) and no Token Endpoint is provided, the Token Endpoint will be fetched from the discovery page of the Issuer (must support OpenID Connect).

In addition I added some documentation for most of the methods in OAuth2Client, IOAuth2Client and OAuth2ClientBuilder.

Initial request and discussion was started here: https://github.com/rabbitmq/rabbitmq-dotnet-client/discussions/1653

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [x] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

The retrieval of the Token Endpoint is Async, when building the client with the synchronous method (`Build()`) the request is blocked until the Endpoint is received. Because of backwards compatibility I can't refactor it. I added an Async `BuildAsync()` method which does this more correctly. When providing the Token Endpoint directly nothing will be done while building.

Feel free to suggest some better methods.

My IDE suggested changes in PublicAPI.Shipped.txt and PublicAPI.Unshipped.txt. Please check if the changes in there are correct, because these files are new to me.