### PR TITLE
Make session events async

### DIFF
--- a/projects/RabbitMQ.Client/client/api/IChannelExtensions.cs
+++ b/projects/RabbitMQ.Client/client/api/IChannelExtensions.cs
@@ -238,7 +238,7 @@ namespace RabbitMQ.Client
         /// <param name="replyText">The reply text.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <remarks>
-        /// The method behaves in the same way as Close(), with the only
+        /// The method behaves in the same way as CloseAsync(), with the only
         /// difference that the channel is closed with the given channel
         /// close code and message.
         /// <para>

--- a/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recovery.cs
+++ b/projects/RabbitMQ.Client/client/impl/AutorecoveringConnection.Recovery.cs
@@ -126,7 +126,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
         /// <summary>
         /// Async cancels the main recovery loop and will block until the loop finishes, or the timeout
-        /// expires, to prevent Close operations overlapping with recovery operations.
+        /// expires, to prevent CloseAsync operations overlapping with recovery operations.
         /// </summary>
         private async ValueTask StopRecoveryLoopAsync(CancellationToken cancellationToken)
         {

--- a/projects/RabbitMQ.Client/client/impl/Connection.Receive.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.Receive.cs
@@ -228,7 +228,7 @@ namespace RabbitMQ.Client.Framing.Impl
             if (SetCloseReason(hpe.ShutdownReason))
             {
                 await OnShutdownAsync(hpe.ShutdownReason).ConfigureAwait(false);
-                await _session0.SetSessionClosingAsync(false)
+                await _session0.SetSessionClosingAsync(false, mainLoopCancellationToken)
                     .ConfigureAwait(false);
                 try
                 {

--- a/projects/RabbitMQ.Client/client/impl/Connection.cs
+++ b/projects/RabbitMQ.Client/client/impl/Connection.cs
@@ -332,7 +332,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
                 await OnShutdownAsync(reason)
                     .ConfigureAwait(false);
-                await _session0.SetSessionClosingAsync(false)
+                await _session0.SetSessionClosingAsync(false, cancellationToken)
                     .ConfigureAwait(false);
 
                 try
@@ -411,7 +411,7 @@ namespace RabbitMQ.Client.Framing.Impl
             }
         }
 
-        internal async Task ClosedViaPeerAsync(ShutdownEventArgs reason)
+        internal async Task ClosedViaPeerAsync(ShutdownEventArgs reason, CancellationToken cancellationToken)
         {
             if (false == SetCloseReason(reason))
             {
@@ -424,7 +424,7 @@ namespace RabbitMQ.Client.Framing.Impl
 
             await OnShutdownAsync(reason)
                 .ConfigureAwait(false);
-            await _session0.SetSessionClosingAsync(true)
+            await _session0.SetSessionClosingAsync(true, cancellationToken)
                 .ConfigureAwait(false);
             MaybeTerminateMainloopAndStopHeartbeatTimers(cancelMainLoop: true);
         }
@@ -436,9 +436,11 @@ namespace RabbitMQ.Client.Framing.Impl
             _closed = true;
             MaybeStopHeartbeatTimers();
 
-            await _frameHandler.CloseAsync(cancellationToken).ConfigureAwait(false);
+            await _frameHandler.CloseAsync(cancellationToken)
+                .ConfigureAwait(false);
             _channel0.SetCloseReason(CloseReason!);
-            _channel0.FinishClose();
+            await _channel0.FinishCloseAsync(cancellationToken)
+                .ConfigureAwait(false);
             RabbitMqClientEventSource.Log.ConnectionClosed();
         }
 

--- a/projects/RabbitMQ.Client/client/impl/ISession.cs
+++ b/projects/RabbitMQ.Client/client/impl/ISession.cs
@@ -32,6 +32,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Framing.Impl;
 
 namespace RabbitMQ.Client.Impl
@@ -68,15 +69,15 @@ namespace RabbitMQ.Client.Impl
         ///<summary>
         /// Multicast session shutdown event.
         ///</summary>
-        event EventHandler<ShutdownEventArgs> SessionShutdown;
+        event AsyncEventHandler<ShutdownEventArgs> SessionShutdownAsync;
 
-        void Close(ShutdownEventArgs reason);
+        Task CloseAsync(ShutdownEventArgs reason, CancellationToken cancellationToken);
 
-        void Close(ShutdownEventArgs reason, bool notify);
+        Task CloseAsync(ShutdownEventArgs reason, bool notify, CancellationToken cancellationToken);
 
         Task HandleFrameAsync(InboundFrame frame, CancellationToken cancellationToken);
 
-        void Notify();
+        Task NotifyAsync(CancellationToken cancellationToken);
 
         ValueTask TransmitAsync<T>(in T cmd, CancellationToken cancellationToken) where T : struct, IOutgoingAmqpMethod;
 

--- a/projects/RabbitMQ.Client/client/impl/MainSession.cs
+++ b/projects/RabbitMQ.Client/client/impl/MainSession.cs
@@ -82,38 +82,10 @@ namespace RabbitMQ.Client.Impl
             return base.HandleFrameAsync(frame, cancellationToken);
         }
 
-        ///<summary> Set channel 0 as quiescing </summary>
-        ///<remarks>
-        /// Method should be idempotent. Cannot use base.Close
-        /// method call because that would prevent us from
-        /// sending/receiving Close/CloseOk commands
-        ///</remarks>
-        public void SetSessionClosing(bool closeIsServerInitiated)
+        public async Task SetSessionClosingAsync(bool closeIsServerInitiated, CancellationToken cancellationToken)
         {
-            if (_closingSemaphore.Wait(InternalConstants.DefaultConnectionAbortTimeout))
-            {
-                try
-                {
-                    if (false == _closing)
-                    {
-                        _closing = true;
-                        _closeIsServerInitiated = closeIsServerInitiated;
-                    }
-                }
-                finally
-                {
-                    _closingSemaphore.Release();
-                }
-            }
-            else
-            {
-                throw new InvalidOperationException("couldn't enter semaphore");
-            }
-        }
-
-        public async Task SetSessionClosingAsync(bool closeIsServerInitiated)
-        {
-            if (await _closingSemaphore.WaitAsync(InternalConstants.DefaultConnectionAbortTimeout).ConfigureAwait(false))
+            if (await _closingSemaphore.WaitAsync(InternalConstants.DefaultConnectionAbortTimeout, cancellationToken)
+                    .ConfigureAwait(false))
             {
                 try
                 {

--- a/projects/RabbitMQ.Client/client/impl/SessionManager.cs
+++ b/projects/RabbitMQ.Client/client/impl/SessionManager.cs
@@ -30,6 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using RabbitMQ.Client.Exceptions;
 using RabbitMQ.Client.Framing.Impl;
 using RabbitMQ.Util;
@@ -77,13 +78,13 @@ namespace RabbitMQ.Client.Impl
 
                 ISession session = new Session(_connection,
                     (ushort)channelNumber, _maxInboundMessageBodySize);
-                session.SessionShutdown += HandleSessionShutdown;
+                session.SessionShutdownAsync += HandleSessionShutdownAsync;
                 _sessionMap[channelNumber] = session;
                 return session;
             }
         }
 
-        private void HandleSessionShutdown(object? sender, ShutdownEventArgs reason)
+        private Task HandleSessionShutdownAsync(object? sender, ShutdownEventArgs reason)
         {
             lock (_sessionMap)
             {
@@ -91,6 +92,7 @@ namespace RabbitMQ.Client.Impl
                 _sessionMap.Remove(session.ChannelNumber);
                 _ints.Free(session.ChannelNumber);
             }
+            return Task.CompletedTask;
         }
 
         public ISession Lookup(int number)

--- a/projects/Test/Integration/TestChannelShutdown.cs
+++ b/projects/Test/Integration/TestChannelShutdown.cs
@@ -55,10 +55,10 @@ namespace Test.Integration
                 tcs.SetResult(true);
             };
 
-            Assert.False(autorecoveringChannel.ConsumerDispatcher.IsShutdown, "dispatcher should NOT be shut down before Close");
+            Assert.False(autorecoveringChannel.ConsumerDispatcher.IsShutdown, "dispatcher should NOT be shut down before CloseAsync");
             await _channel.CloseAsync();
             await WaitAsync(tcs, TimeSpan.FromSeconds(5), "channel shutdown");
-            Assert.True(autorecoveringChannel.ConsumerDispatcher.IsShutdown, "dispatcher should be shut down after Close");
+            Assert.True(autorecoveringChannel.ConsumerDispatcher.IsShutdown, "dispatcher should be shut down after CloseAsync");
         }
     }
 }

--- a/projects/Test/Integration/TestConnectionShutdown.cs
+++ b/projects/Test/Integration/TestConnectionShutdown.cs
@@ -156,10 +156,10 @@ namespace Test.Integration
             {
                 tcs.SetResult(true);
             };
-            Assert.False(m.ConsumerDispatcher.IsShutdown, "dispatcher should NOT be shut down before Close");
+            Assert.False(m.ConsumerDispatcher.IsShutdown, "dispatcher should NOT be shut down before CloseAsync");
             await _conn.CloseAsync();
             await WaitAsync(tcs, TimeSpan.FromSeconds(3), "channel shutdown");
-            Assert.True(m.ConsumerDispatcher.IsShutdown, "dispatcher should be shut down after Close");
+            Assert.True(m.ConsumerDispatcher.IsShutdown, "dispatcher should be shut down after CloseAsync");
         }
 
         [Fact]


### PR DESCRIPTION
## Proposed Changes

Follow through on discussion in https://github.com/rabbitmq/rabbitmq-dotnet-client/pull/1675#issuecomment-2352522663

@lukebakken mentioned his [original intent was to make the events async across the board](https://github.com/rabbitmq/rabbitmq-dotnet-client/pull/1675#issuecomment-2354340236) but stopped.

This PR would align the session API surface

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
