### PR TITLE
Fix exception when refreshing oauth2 token

### DIFF
--- a/projects/RabbitMQ.Client.OAuth2/OAuth2Client.cs
+++ b/projects/RabbitMQ.Client.OAuth2/OAuth2Client.cs
@@ -309,11 +309,6 @@ namespace RabbitMQ.Client.OAuth2
             Dictionary<string, string> dict = BuildRequestParameters();
             dict[GRANT_TYPE] = REFRESH_TOKEN;
 
-            if (_scope != null)
-            {
-                dict.Add(SCOPE, _scope);
-            }
-
             if (token.RefreshToken != null)
             {
                 dict.Add(REFRESH_TOKEN, token.RefreshToken);


### PR DESCRIPTION
## Proposed Changes

This fixes a small bug that happens when refreshing the OAuth2 access token from the OAuth backchannel provider. The dictionary key "scope" in BuildRefreshParameters is already set in BuildRequestParameters and therefore this throws an exception.

## Types of Changes

- [x] Bug fix (has no issue associated with it)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Before being added to the dictionary, _scope undergoes two different checks: Nullability and string.IsNullOrEmpty in the two aforementioned methods. I do not know if this is intentional or not.
