### PR TITLE
Only add `x-dotnet-pub-seq-no` when tracking enabled

### DIFF
--- a/projects/RabbitMQ.Client/CreateChannelOptions.cs
+++ b/projects/RabbitMQ.Client/CreateChannelOptions.cs
@@ -30,7 +30,6 @@
 //---------------------------------------------------------------------------
 
 using System.Threading.RateLimiting;
-using RabbitMQ.Client.Impl;
 
 namespace RabbitMQ.Client
 {
@@ -46,6 +45,11 @@ namespace RabbitMQ.Client
 
         /// <summary>
         /// Should this library track publisher confirmations for you? Defaults to <c>false</c>
+        ///
+        /// When enabled, the <see cref="Constants.PublishSequenceNumberHeader" /> header will be
+        /// added to every published message, and will contain the message's publish sequence number.
+        /// If the broker then sends a <c>basic.return</c> response for the message, this library can
+        /// then correctly handle the message.
         /// </summary>
         public bool PublisherConfirmationTrackingEnabled { get; set; } = false;
 

--- a/projects/RabbitMQ.Client/CreateChannelOptions.cs
+++ b/projects/RabbitMQ.Client/CreateChannelOptions.cs
@@ -40,6 +40,14 @@ namespace RabbitMQ.Client
     {
         /// <summary>
         /// Enable or disable publisher confirmations on this channel. Defaults to <c>false</c>
+        ///
+        /// Note that, if this is enabled, and <see cref="PublisherConfirmationTrackingEnabled"/> is <b>not</b>
+        /// enabled, the broker may send a <c>basic.return</c> response if a message is published with <c>mandatory: true</c>
+        /// and the broker can't route the message. This response will not, however, contain the publish sequence number
+        /// for the message, so it is difficult to correlate the response to the correct message. Users of this library
+        /// could add the <see cref="Constants.PublishSequenceNumberHeader"/> header with the value returned by
+        /// <see cref="IChannel.GetNextPublishSequenceNumberAsync(System.Threading.CancellationToken)"/> to allow correlation
+        /// of the response with the correct message.
         /// </summary>
         public bool PublisherConfirmationsEnabled { get; set; } = false;
 

--- a/projects/RabbitMQ.Client/Impl/Channel.BasicPublish.cs
+++ b/projects/RabbitMQ.Client/Impl/Channel.BasicPublish.cs
@@ -215,7 +215,7 @@ namespace RabbitMQ.Client.Impl
 
             void MaybeAddPublishSequenceNumberToHeaders(IDictionary<string, object?> headers)
             {
-                if (_publisherConfirmationsEnabled)
+                if (_publisherConfirmationsEnabled && _publisherConfirmationTrackingEnabled)
                 {
                     byte[] publishSequenceNumberBytes = new byte[8];
                     NetworkOrderSerializer.WriteUInt64(ref publishSequenceNumberBytes.GetStart(), publishSequenceNumber);

--- a/projects/RabbitMQ.Client/Impl/Channel.PublisherConfirms.cs
+++ b/projects/RabbitMQ.Client/Impl/Channel.PublisherConfirms.cs
@@ -228,7 +228,7 @@ namespace RabbitMQ.Client.Impl
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void HandleReturn(BasicReturnEventArgs basicReturnEvent)
         {
-            if (_publisherConfirmationsEnabled)
+            if (_publisherConfirmationsEnabled && _publisherConfirmationTrackingEnabled)
             {
                 ulong publishSequenceNumber = 0;
                 IReadOnlyBasicProperties props = basicReturnEvent.BasicProperties;


### PR DESCRIPTION
If a user only enables publisher confirms for a channel, but _NOT_ automatic tracking, it will be up to them to correlate a `basic.return` with a sequence number.