### PR TITLE
Change OTel attribute messaging.operation to messaging.operation.type

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,39 @@ Here's the recommended workflow:
 If what you are going to work on is a substantial change, please first
 ask the core team for their opinion on the [RabbitMQ users mailing list][rmq-users].
 
+### Building Source
+
+It is good practice to make sure you can build the project before making any
+changes to confirm that your development environment is set up correctly.
+Verifying that the tests pass is also a good practice (see
+[RUNNING_TESTS.md](/RUNNING_TESTS.md)).
+
+All together, this looks like:
+
+* Linux
+
+```shell
+git clone --recurse-submodules https://github.com/rabbitmq/rabbitmq-dotnet-client
+cd rabbitmq-dotnet-client
+
+# On any Linux distribution with Docker installed
+./.ci/ubuntu/gha-setup.sh toxiproxy pull
+
+make build
+make test
+```
+
+* Windows
+
+Note that this will _NOT_ run toxiproxy tests.
+
+```powershell
+git clone --recurse-submodules https://github.com/rabbitmq/rabbitmq-dotnet-client
+cd rabbitmq-dotnet-client
+.\.ci\windows\gha-setup.ps1 # On Windows. Note that this installs RabbitMQ
+.\build.ps1 -RunTests:$true
+```
+
 ### Running Tests
 
 See [RUNNING_TESTS.md](/RUNNING_TESTS.md).

--- a/projects/RabbitMQ.Client/Impl/RabbitMQActivitySource.cs
+++ b/projects/RabbitMQ.Client/Impl/RabbitMQActivitySource.cs
@@ -16,6 +16,9 @@ namespace RabbitMQ.Client
         internal const string MessageId = "messaging.message.id";
         internal const string MessageConversationId = "messaging.message.conversation_id";
         internal const string MessagingOperationType = "messaging.operation.type";
+        internal const string MessagingOperationTypeSend = "send";
+        internal const string MessagingOperationTypeProcess = "process";
+        internal const string MessagingOperationTypeReceive = "receive";
         internal const string MessagingSystem = "messaging.system";
         internal const string MessagingDestination = "messaging.destination.name";
         internal const string MessagingDestinationRoutingKey = "messaging.rabbitmq.destination.routing_key";
@@ -63,14 +66,14 @@ namespace RabbitMQ.Client
 
             Activity? activity = linkedContext == default
                 ? s_publisherSource.StartRabbitMQActivity(
-                    UseRoutingKeyAsOperationName ? $"{routingKey} send" : "send",
+                    UseRoutingKeyAsOperationName ? $"{routingKey} {MessagingOperationTypeSend}" : MessagingOperationTypeSend,
                     ActivityKind.Producer)
                 : s_publisherSource.StartLinkedRabbitMQActivity(
-                    UseRoutingKeyAsOperationName ? $"{routingKey} send" : "send",
+                    UseRoutingKeyAsOperationName ? $"{routingKey} {MessagingOperationTypeSend}" : MessagingOperationTypeSend,
                     ActivityKind.Producer, linkedContext);
             if (activity != null && activity.IsAllDataRequested)
             {
-                PopulateMessagingTags("send", routingKey, exchange, 0, bodySize, activity);
+                PopulateMessagingTags(MessagingOperationTypeSend, routingKey, exchange, 0, bodySize, activity);
             }
 
             return activity;
@@ -85,12 +88,12 @@ namespace RabbitMQ.Client
             }
 
             Activity? activity = s_subscriberSource.StartRabbitMQActivity(
-                UseRoutingKeyAsOperationName ? $"{queue} receive" : "receive",
+                UseRoutingKeyAsOperationName ? $"{queue} {MessagingOperationTypeReceive}" : MessagingOperationTypeReceive,
                 ActivityKind.Consumer);
             if (activity != null && activity.IsAllDataRequested)
             {
                 activity
-                    .SetTag(MessagingOperationType, "receive")
+                    .SetTag(MessagingOperationType, MessagingOperationTypeReceive)
                     .SetTag(MessagingDestination, "amq.default");
             }
 
@@ -107,11 +110,11 @@ namespace RabbitMQ.Client
 
             // Extract the PropagationContext of the upstream parent from the message headers.
             Activity? activity = s_subscriberSource.StartLinkedRabbitMQActivity(
-                UseRoutingKeyAsOperationName ? $"{routingKey} receive" : "receive", ActivityKind.Consumer,
+                UseRoutingKeyAsOperationName ? $"{routingKey} {MessagingOperationTypeReceive}" : MessagingOperationTypeReceive, ActivityKind.Consumer,
                 ContextExtractor(readOnlyBasicProperties));
             if (activity != null && activity.IsAllDataRequested)
             {
-                PopulateMessagingTags("receive", routingKey, exchange, deliveryTag, readOnlyBasicProperties,
+                PopulateMessagingTags(MessagingOperationTypeReceive, routingKey, exchange, deliveryTag, readOnlyBasicProperties,
                     bodySize, activity);
             }
 
@@ -128,11 +131,11 @@ namespace RabbitMQ.Client
 
             // Extract the PropagationContext of the upstream parent from the message headers.
             Activity? activity = s_subscriberSource.StartLinkedRabbitMQActivity(
-                UseRoutingKeyAsOperationName ? $"{routingKey} process" : "process",
+                UseRoutingKeyAsOperationName ? $"{routingKey} {MessagingOperationTypeProcess}" : MessagingOperationTypeProcess,
                 ActivityKind.Consumer, ContextExtractor(basicProperties));
             if (activity != null && activity.IsAllDataRequested)
             {
-                PopulateMessagingTags("process", routingKey, exchange,
+                PopulateMessagingTags(MessagingOperationTypeProcess, routingKey, exchange,
                     deliveryTag, basicProperties, bodySize, activity);
             }
 

--- a/projects/RabbitMQ.Client/Impl/RabbitMQActivitySource.cs
+++ b/projects/RabbitMQ.Client/Impl/RabbitMQActivitySource.cs
@@ -63,14 +63,14 @@ namespace RabbitMQ.Client
 
             Activity? activity = linkedContext == default
                 ? s_publisherSource.StartRabbitMQActivity(
-                    UseRoutingKeyAsOperationName ? $"{routingKey} publish" : "publish",
+                    UseRoutingKeyAsOperationName ? $"{routingKey} send" : "send",
                     ActivityKind.Producer)
                 : s_publisherSource.StartLinkedRabbitMQActivity(
-                    UseRoutingKeyAsOperationName ? $"{routingKey} publish" : "publish",
+                    UseRoutingKeyAsOperationName ? $"{routingKey} send" : "send",
                     ActivityKind.Producer, linkedContext);
             if (activity != null && activity.IsAllDataRequested)
             {
-                PopulateMessagingTags("publish", routingKey, exchange, 0, bodySize, activity);
+                PopulateMessagingTags("send", routingKey, exchange, 0, bodySize, activity);
             }
 
             return activity;
@@ -128,11 +128,11 @@ namespace RabbitMQ.Client
 
             // Extract the PropagationContext of the upstream parent from the message headers.
             Activity? activity = s_subscriberSource.StartLinkedRabbitMQActivity(
-                UseRoutingKeyAsOperationName ? $"{routingKey} deliver" : "deliver",
+                UseRoutingKeyAsOperationName ? $"{routingKey} process" : "process",
                 ActivityKind.Consumer, ContextExtractor(basicProperties));
             if (activity != null && activity.IsAllDataRequested)
             {
-                PopulateMessagingTags("deliver", routingKey, exchange,
+                PopulateMessagingTags("process", routingKey, exchange,
                     deliveryTag, basicProperties, bodySize, activity);
             }
 

--- a/projects/RabbitMQ.Client/Impl/RabbitMQActivitySource.cs
+++ b/projects/RabbitMQ.Client/Impl/RabbitMQActivitySource.cs
@@ -15,7 +15,7 @@ namespace RabbitMQ.Client
         // https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/#messaging-attributes
         internal const string MessageId = "messaging.message.id";
         internal const string MessageConversationId = "messaging.message.conversation_id";
-        internal const string MessagingOperation = "messaging.operation";
+        internal const string MessagingOperationType = "messaging.operation.type";
         internal const string MessagingSystem = "messaging.system";
         internal const string MessagingDestination = "messaging.destination.name";
         internal const string MessagingDestinationRoutingKey = "messaging.rabbitmq.destination.routing_key";
@@ -90,7 +90,7 @@ namespace RabbitMQ.Client
             if (activity != null && activity.IsAllDataRequested)
             {
                 activity
-                    .SetTag(MessagingOperation, "receive")
+                    .SetTag(MessagingOperationType, "receive")
                     .SetTag(MessagingDestination, "amq.default");
             }
 
@@ -174,7 +174,7 @@ namespace RabbitMQ.Client
             ulong deliveryTag, int bodySize, Activity activity)
         {
             activity
-                .SetTag(MessagingOperation, operation)
+                .SetTag(MessagingOperationType, operation)
                 .SetTag(MessagingDestination, string.IsNullOrEmpty(exchange) ? "amq.default" : exchange)
                 .SetTag(MessagingDestinationRoutingKey, routingKey)
                 .SetTag(MessagingBodySize, bodySize);

--- a/projects/Test/SequentialIntegration/TestActivitySource.cs
+++ b/projects/Test/SequentialIntegration/TestActivitySource.cs
@@ -402,7 +402,7 @@ namespace Test.SequentialIntegration
         private void AssertActivityData(bool useRoutingKeyAsOperationName, string queueName,
             List<Activity> activityList, bool isDeliver = false)
         {
-            string childName = isDeliver ? "deliver" : "receive";
+            string childName = isDeliver ? "process" : "receive";
             Activity[] activities = activityList.ToArray();
             Assert.NotEmpty(activities);
 
@@ -418,7 +418,7 @@ namespace Test.SequentialIntegration
             }
 
             Activity sendActivity = activities.First(x =>
-                x.OperationName == (useRoutingKeyAsOperationName ? $"{queueName} publish" : "publish") &&
+                x.OperationName == (useRoutingKeyAsOperationName ? $"{queueName} send" : "send") &&
                 x.GetTagItem(RabbitMQActivitySource.MessagingDestinationRoutingKey) is string routingKeyTag &&
                 routingKeyTag == $"{queueName}");
             Activity receiveActivity = activities.Single(x =>

--- a/projects/Test/SequentialIntegration/TestOpenTelemetry.cs
+++ b/projects/Test/SequentialIntegration/TestOpenTelemetry.cs
@@ -342,7 +342,7 @@ namespace Test.SequentialIntegration
         private void AssertActivityData(bool useRoutingKeyAsOperationName, string queueName,
             List<Activity> activityList, bool isDeliver = false, string baggageGuid = null)
         {
-            string childName = isDeliver ? "deliver" : "receive";
+            string childName = isDeliver ? "process" : "receive";
             Activity[] activities = activityList.ToArray();
             Assert.NotEmpty(activities);
             foreach (var item in activities)
@@ -354,7 +354,7 @@ namespace Test.SequentialIntegration
             }
 
             Activity sendActivity = activities.First(x =>
-                x.OperationName == (useRoutingKeyAsOperationName ? $"{queueName} publish" : "publish") &&
+                x.OperationName == (useRoutingKeyAsOperationName ? $"{queueName} send" : "send") &&
                 x.GetTagItem(RabbitMQActivitySource.MessagingDestinationRoutingKey) is string routingKeyTag &&
                 routingKeyTag == $"{queueName}");
             Activity receiveActivity = activities.Single(x =>


### PR DESCRIPTION
## Proposed Changes

Update `messaging.operation` to `messaging.operation.type` to comply with OpenTelemetry Semantic Conventions for Messaging.

Addresses part of #1715.
References https://github.com/rabbitmq/rabbitmq-dotnet-client/pull/1528.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

This is a breaking change to the OpenTelemetry API, FWIW.
