### PR TITLE
More updates for the current OTel (OpenTelemetry) conventions

### DIFF
--- a/projects/RabbitMQ.Client/Impl/Channel.BasicPublish.cs
+++ b/projects/RabbitMQ.Client/Impl/Channel.BasicPublish.cs
@@ -62,7 +62,7 @@ namespace RabbitMQ.Client.Impl
                 var cmd = new BasicPublish(exchange, routingKey, mandatory, default);
 
                 using Activity? sendActivity = RabbitMQActivitySource.PublisherHasListeners
-                    ? RabbitMQActivitySource.Send(routingKey, exchange, body.Length)
+                    ? RabbitMQActivitySource.BasicPublish(routingKey, exchange, body.Length)
                     : default;
 
                 ulong publishSequenceNumber = 0;
@@ -117,7 +117,7 @@ namespace RabbitMQ.Client.Impl
                 var cmd = new BasicPublishMemory(exchange.Bytes, routingKey.Bytes, mandatory, default);
 
                 using Activity? sendActivity = RabbitMQActivitySource.PublisherHasListeners
-                    ? RabbitMQActivitySource.Send(routingKey.Value, exchange.Value, body.Length)
+                    ? RabbitMQActivitySource.BasicPublish(routingKey.Value, exchange.Value, body.Length)
                     : default;
 
                 ulong publishSequenceNumber = 0;

--- a/projects/RabbitMQ.Client/Impl/Channel.cs
+++ b/projects/RabbitMQ.Client/Impl/Channel.cs
@@ -918,10 +918,10 @@ namespace RabbitMQ.Client.Impl
                 BasicGetResult? result = await k;
 
                 using Activity? activity = result != null
-                    ? RabbitMQActivitySource.Receive(result.RoutingKey,
+                    ? RabbitMQActivitySource.BasicGet(result.RoutingKey,
                         result.Exchange,
                         result.DeliveryTag, result.BasicProperties, result.Body.Length)
-                    : RabbitMQActivitySource.ReceiveEmpty(queue);
+                    : RabbitMQActivitySource.BasicGetEmpty(queue);
 
                 activity?.SetStartTime(k.StartTime);
 

--- a/projects/Test/SequentialIntegration/TestActivitySource.cs
+++ b/projects/Test/SequentialIntegration/TestActivitySource.cs
@@ -402,7 +402,7 @@ namespace Test.SequentialIntegration
         private void AssertActivityData(bool useRoutingKeyAsOperationName, string queueName,
             List<Activity> activityList, bool isDeliver = false)
         {
-            string childName = isDeliver ? "process" : "receive";
+            string childName = isDeliver ? "deliver" : "fetch";
             Activity[] activities = activityList.ToArray();
             Assert.NotEmpty(activities);
 
@@ -418,11 +418,11 @@ namespace Test.SequentialIntegration
             }
 
             Activity sendActivity = activities.First(x =>
-                x.OperationName == (useRoutingKeyAsOperationName ? $"{queueName} send" : "send") &&
+                x.OperationName == (useRoutingKeyAsOperationName ? $"publish {queueName}" : "publish") &&
                 x.GetTagItem(RabbitMQActivitySource.MessagingDestinationRoutingKey) is string routingKeyTag &&
                 routingKeyTag == $"{queueName}");
             Activity receiveActivity = activities.Single(x =>
-                x.OperationName == (useRoutingKeyAsOperationName ? $"{queueName} {childName}" : $"{childName}") &&
+                x.OperationName == (useRoutingKeyAsOperationName ? $"{childName} {queueName}" : childName) &&
                 x.Links.First().Context.TraceId == sendActivity.TraceId);
             Assert.Equal(ActivityKind.Producer, sendActivity.Kind);
             Assert.Equal(ActivityKind.Consumer, receiveActivity.Kind);

--- a/projects/Test/SequentialIntegration/TestOpenTelemetry.cs
+++ b/projects/Test/SequentialIntegration/TestOpenTelemetry.cs
@@ -342,7 +342,8 @@ namespace Test.SequentialIntegration
         private void AssertActivityData(bool useRoutingKeyAsOperationName, string queueName,
             List<Activity> activityList, bool isDeliver = false, string baggageGuid = null)
         {
-            string childName = isDeliver ? "process" : "receive";
+            string childName = isDeliver ? "deliver" : "fetch";
+            string childType = isDeliver ? "process" : "receive";
             Activity[] activities = activityList.ToArray();
             Assert.NotEmpty(activities);
             foreach (var item in activities)
@@ -354,11 +355,11 @@ namespace Test.SequentialIntegration
             }
 
             Activity sendActivity = activities.First(x =>
-                x.OperationName == (useRoutingKeyAsOperationName ? $"{queueName} send" : "send") &&
+                x.OperationName == (useRoutingKeyAsOperationName ? $"publish {queueName}" : "publish") &&
                 x.GetTagItem(RabbitMQActivitySource.MessagingDestinationRoutingKey) is string routingKeyTag &&
                 routingKeyTag == $"{queueName}");
             Activity receiveActivity = activities.Single(x =>
-                x.OperationName == (useRoutingKeyAsOperationName ? $"{queueName} {childName}" : $"{childName}") &&
+                x.OperationName == (useRoutingKeyAsOperationName ? $"{childName} {queueName}" : childName) &&
                 x.Links.First().Context.TraceId == sendActivity.TraceId);
             Assert.Equal(ActivityKind.Producer, sendActivity.Kind);
             Assert.Equal(ActivityKind.Consumer, receiveActivity.Kind);
@@ -380,6 +381,10 @@ namespace Test.SequentialIntegration
             AssertIntTagGreaterThanZero(sendActivity, RabbitMQActivitySource.MessagingEnvelopeSize);
             AssertIntTagGreaterThanZero(sendActivity, RabbitMQActivitySource.MessagingBodySize);
             AssertIntTagGreaterThanZero(receiveActivity, RabbitMQActivitySource.MessagingBodySize);
+            AssertStringTagEquals(receiveActivity, RabbitMQActivitySource.MessagingOperationType, childType);
+            AssertStringTagEquals(receiveActivity, RabbitMQActivitySource.MessagingOperationName, childName);
+            AssertStringTagEquals(sendActivity, RabbitMQActivitySource.MessagingOperationType, "send");
+            AssertStringTagEquals(sendActivity, RabbitMQActivitySource.MessagingOperationName, "publish");
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

Update to latest OTel conventions

- Swap order of queue name and operation name in Activity name
- Add `messaging.operation.name` tag

Builds on #1716.
Fixes #1715.

In order to get 7.0 released, this can wait until 7.1.

## Types of Changes

What types of changes does your code introduce to this project?

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Regarding https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/1715#issuecomment-2450499881, I used `fetch` instead of `polling fetch` or `basic.get` because:
- It avoids using longer `basic_` prefix.
- It remains consistent with a single verb for all operation names.
- The word "polling" (to me) implies that the operation is repeated multiple times, but this activity is fired on a single instance of the `basic.get`. `fetch` (in my mind) conveys a pull operation to me and is meaningfully distinguished from `deliver`.