### PR TITLE
chore: bump regular System.Text.RegularExpressions due to a known CVE in earlier versions

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -20,9 +20,9 @@ jobs:
           path: |
             ~/.nuget/packages
             ~/AppData/Local/NuGet/v3-cache
-          key: ${{ runner.os }}-v1-nuget-${{ hashFiles('**/*.csproj') }}
+          key: ${{ runner.os }}-v2-nuget-${{ hashFiles('**/*.csproj','projects/Directory.Packages.props') }}
           restore-keys: |
-            ${{ runner.os }}-v1-nuget-
+            ${{ runner.os }}-v2-nuget-
       - name: Build (Debug)
         run: dotnet build ${{ github.workspace }}\Build.csproj
       - name: Verify
@@ -142,9 +142,9 @@ jobs:
           path: |
             ~/.nuget/packages
             ~/.local/share/NuGet/v3-cache
-          key: ${{ runner.os }}-v1-nuget-${{ hashFiles('**/*.csproj') }}
+          key: ${{ runner.os }}-v2-nuget-${{ hashFiles('**/*.csproj','projects/Directory.Packages.props') }}
           restore-keys: |
-            ${{ runner.os }}-v1-nuget-
+            ${{ runner.os }}-v2-nuget-
       - name: Build (Debug)
         run: dotnet build ${{ github.workspace }}/Build.csproj
       - name: Verify

--- a/projects/Directory.Packages.props
+++ b/projects/Directory.Packages.props
@@ -16,6 +16,8 @@
     -->
     <PackageVersion Include="System.IO.Pipelines" Version="8.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+    <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="System.Threading.RateLimiting" Version="8.0.0" />
     <PackageVersion Include="WireMock.Net" Version="1.5.62" />
     <PackageVersion Include="xunit" Version="2.9.0" />
@@ -33,12 +35,8 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Threading.Channels" Version="8.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="System.Net.Http.Json" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework)=='net472'">
-    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <GlobalPackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />

--- a/projects/Test/Common/Common.csproj
+++ b/projects/Test/Common/Common.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
   
   <ItemGroup>
+    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="EasyNetQ.Management.Client" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.abstractions" />

--- a/projects/Test/Integration/Integration.csproj
+++ b/projects/Test/Integration/Integration.csproj
@@ -39,6 +39,7 @@
   -->
 
   <ItemGroup>
+    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />

--- a/projects/Test/Integration/TestExchangeDeclare.cs
+++ b/projects/Test/Integration/TestExchangeDeclare.cs
@@ -112,6 +112,7 @@ namespace Test.Integration
             var exchangeNames = new ConcurrentBag<string>();
             var tasks = new List<Task>();
             NotSupportedException nse = null;
+            Exception unexpectedException = null;
             for (int i = 0; i < 256; i++)
             {
                 var t = Task.Run(async () =>
@@ -129,13 +130,24 @@ namespace Test.Integration
                             {
                                 nse = e;
                             }
+                            catch (Exception ex)
+                            {
+                                unexpectedException = ex;
+                            }
                         });
                 tasks.Add(t);
             }
 
             await Task.WhenAll(tasks);
 
-            Assert.Null(nse);
+            if (nse is not null)
+            {
+                Assert.Fail($"got unexpected NotSupportedException: {nse}");
+            }
+            if (unexpectedException is not null)
+            {
+                Assert.Fail($"got unexpected Exception: {unexpectedException}");
+            }
             tasks.Clear();
 
             foreach (string exchangeName in exchangeNames)
@@ -154,13 +166,24 @@ namespace Test.Integration
                             {
                                 nse = e;
                             }
+                            catch (Exception ex)
+                            {
+                                unexpectedException = ex;
+                            }
                         });
                 tasks.Add(t);
             }
 
             await Task.WhenAll(tasks);
 
-            Assert.Null(nse);
+            if (nse is not null)
+            {
+                Assert.Fail($"got unexpected NotSupportedException: {nse}");
+            }
+            if (unexpectedException is not null)
+            {
+                Assert.Fail($"got unexpected Exception: {unexpectedException}");
+            }
         }
     }
 }

--- a/projects/Test/OAuth2/OAuth2.csproj
+++ b/projects/Test/OAuth2/OAuth2.csproj
@@ -28,6 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="System.Text.RegularExpressions" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
     <PackageReference Include="System.Net.Http" />

--- a/projects/Test/SequentialIntegration/SequentialIntegration.csproj
+++ b/projects/Test/SequentialIntegration/SequentialIntegration.csproj
@@ -38,6 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
     <PackageReference Include="xunit" />

--- a/projects/Test/SequentialIntegration/SequentialIntegration.csproj
+++ b/projects/Test/SequentialIntegration/SequentialIntegration.csproj
@@ -17,6 +17,7 @@
     <SignAssembly>true</SignAssembly>
     <IsTestProject>true</IsTestProject>
     <LangVersion>12.0</LangVersion>
+    <TestTfmsInParallel>false</TestTfmsInParallel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/projects/Test/Unit/Unit.csproj
+++ b/projects/Test/Unit/Unit.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />


### PR DESCRIPTION
## Proposed Changes

Add explicit dependencies due to cve on System.Text.RegularExpressions 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
