### PR TITLE
Ensure broker-originated channel closure completes

### DIFF
--- a/projects/Test/Integration/TestQueueDeclare.cs
+++ b/projects/Test/Integration/TestQueueDeclare.cs
@@ -58,6 +58,22 @@ namespace Test.Integration
         }
 
         [Fact]
+        public async Task TestPassiveQueueDeclareException_GH1749()
+        {
+            string q = GenerateQueueName();
+            try
+            {
+                await _channel.QueueDeclarePassiveAsync(q);
+            }
+            catch (Exception ex)
+            {
+                _output.WriteLine("{0} ex: {1}", _testDisplayName, ex);
+                await _channel.DisposeAsync();
+                _channel = null;
+            }
+        }
+
+        [Fact]
         public async Task TestConcurrentQueueDeclareAndBindAsync()
         {
             bool sawShutdown = false;


### PR DESCRIPTION
Fixes #1749

* Ensure `Dispose` and `DisposeAsync` are idempotent and thread-safe.
* Use TaskCompletionSource when `HandleChannelCloseAsync` runs to allow dispose methods to wait.
* Use `Interlocked` for thread safety.
* I like `_isDisposing` better. So sue me!
* Move the `Interlocked.Exchange` code to a getter, for readability.
* Minor nullable change.