### PR TITLE
Create cancellation token from `timeout`

### DIFF
--- a/projects/RabbitMQ.Client/IConnectionExtensions.cs
+++ b/projects/RabbitMQ.Client/IConnectionExtensions.cs
@@ -59,11 +59,10 @@ namespace RabbitMQ.Client
         /// To wait infinitely for the close operations to complete use <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>.
         /// </para>
         /// </remarks>
-        public static async Task CloseAsync(this IConnection connection, TimeSpan timeout)
+        public static Task CloseAsync(this IConnection connection, TimeSpan timeout)
         {
-            using var cts = new CancellationTokenSource(timeout);
-            await connection.CloseAsync(Constants.ReplySuccess, "Goodbye", timeout, false, cts.Token)
-                .ConfigureAwait(false);
+            return connection.CloseAsync(Constants.ReplySuccess, "Goodbye", timeout, false,
+                CancellationToken.None);
         }
 
         /// <summary>
@@ -83,11 +82,10 @@ namespace RabbitMQ.Client
         /// Operation timeout.
         /// </para>
         /// </remarks>
-        public static async Task CloseAsync(this IConnection connection, ushort reasonCode, string reasonText, TimeSpan timeout)
+        public static Task CloseAsync(this IConnection connection, ushort reasonCode, string reasonText, TimeSpan timeout)
         {
-            using var cts = new CancellationTokenSource(timeout);
-            await connection.CloseAsync(reasonCode, reasonText, timeout, false, cts.Token)
-                .ConfigureAwait(false);
+            return connection.CloseAsync(reasonCode, reasonText, timeout, false,
+                CancellationToken.None);
         }
 
         /// <summary>
@@ -99,12 +97,10 @@ namespace RabbitMQ.Client
         /// <see cref="IOException"/> during closing connection.
         ///This method waits infinitely for the in-progress close operation to complete.
         /// </remarks>
-        public static async Task AbortAsync(this IConnection connection)
+        public static Task AbortAsync(this IConnection connection)
         {
-            using var cts = new CancellationTokenSource(InternalConstants.DefaultConnectionAbortTimeout);
-            await connection.CloseAsync(Constants.ReplySuccess,
-                "Connection close forced", InternalConstants.DefaultConnectionAbortTimeout, true, cts.Token)
-                .ConfigureAwait(false);
+            return connection.CloseAsync(Constants.ReplySuccess, "Connection close forced", InternalConstants.DefaultConnectionAbortTimeout, true,
+                CancellationToken.None);
         }
 
         /// <summary>
@@ -120,12 +116,10 @@ namespace RabbitMQ.Client
         /// A message indicating the reason for closing the connection
         /// </para>
         /// </remarks>
-        public static async Task AbortAsync(this IConnection connection, ushort reasonCode, string reasonText)
+        public static Task AbortAsync(this IConnection connection, ushort reasonCode, string reasonText)
         {
-            using var cts = new CancellationTokenSource(InternalConstants.DefaultConnectionAbortTimeout);
-            await connection.CloseAsync(reasonCode,
-                reasonText, InternalConstants.DefaultConnectionAbortTimeout, true, cts.Token)
-                .ConfigureAwait(false);
+            return connection.CloseAsync(reasonCode, reasonText, InternalConstants.DefaultConnectionAbortTimeout, true,
+                CancellationToken.None);
         }
 
         /// <summary>
@@ -141,12 +135,10 @@ namespace RabbitMQ.Client
         /// To wait infinitely for the close operations to complete use <see cref="Timeout.Infinite"/>.
         /// </para>
         /// </remarks>
-        public static async Task AbortAsync(this IConnection connection, TimeSpan timeout)
+        public static Task AbortAsync(this IConnection connection, TimeSpan timeout)
         {
-            using var cts = new CancellationTokenSource(InternalConstants.DefaultConnectionAbortTimeout);
-            await connection.CloseAsync(Constants.ReplySuccess,
-                "Connection close forced", timeout, true, cts.Token)
-                .ConfigureAwait(false);
+            return connection.CloseAsync(Constants.ReplySuccess, "Connection close forced", timeout, true,
+                CancellationToken.None);
         }
 
         /// <summary>
@@ -163,12 +155,10 @@ namespace RabbitMQ.Client
         /// A message indicating the reason for closing the connection.
         /// </para>
         /// </remarks>
-        public static async Task AbortAsync(this IConnection connection, ushort reasonCode, string reasonText, TimeSpan timeout)
+        public static Task AbortAsync(this IConnection connection, ushort reasonCode, string reasonText, TimeSpan timeout)
         {
-            using var cts = new CancellationTokenSource(InternalConstants.DefaultConnectionAbortTimeout);
-            await connection.CloseAsync(reasonCode,
-                reasonText, timeout, true, cts.Token)
-                .ConfigureAwait(false);
+            return connection.CloseAsync(reasonCode, reasonText, timeout, true,
+                CancellationToken.None);
         }
     }
 }

--- a/projects/RabbitMQ.Client/IConnectionExtensions.cs
+++ b/projects/RabbitMQ.Client/IConnectionExtensions.cs
@@ -59,10 +59,11 @@ namespace RabbitMQ.Client
         /// To wait infinitely for the close operations to complete use <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>.
         /// </para>
         /// </remarks>
-        public static Task CloseAsync(this IConnection connection, TimeSpan timeout)
+        public static async Task CloseAsync(this IConnection connection, TimeSpan timeout)
         {
-            return connection.CloseAsync(Constants.ReplySuccess, "Goodbye", timeout, false,
-                CancellationToken.None);
+            using var cts = new CancellationTokenSource(timeout);
+            await connection.CloseAsync(Constants.ReplySuccess, "Goodbye", timeout, false, cts.Token)
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -82,10 +83,11 @@ namespace RabbitMQ.Client
         /// Operation timeout.
         /// </para>
         /// </remarks>
-        public static Task CloseAsync(this IConnection connection, ushort reasonCode, string reasonText, TimeSpan timeout)
+        public static async Task CloseAsync(this IConnection connection, ushort reasonCode, string reasonText, TimeSpan timeout)
         {
-            return connection.CloseAsync(reasonCode, reasonText, timeout, false,
-                CancellationToken.None);
+            using var cts = new CancellationTokenSource(timeout);
+            await connection.CloseAsync(reasonCode, reasonText, timeout, false, cts.Token)
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -97,10 +99,12 @@ namespace RabbitMQ.Client
         /// <see cref="IOException"/> during closing connection.
         ///This method waits infinitely for the in-progress close operation to complete.
         /// </remarks>
-        public static Task AbortAsync(this IConnection connection)
+        public static async Task AbortAsync(this IConnection connection)
         {
-            return connection.CloseAsync(Constants.ReplySuccess, "Connection close forced", InternalConstants.DefaultConnectionAbortTimeout, true,
-                CancellationToken.None);
+            using var cts = new CancellationTokenSource(InternalConstants.DefaultConnectionAbortTimeout);
+            await connection.CloseAsync(Constants.ReplySuccess,
+                "Connection close forced", InternalConstants.DefaultConnectionAbortTimeout, true, cts.Token)
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -116,10 +120,12 @@ namespace RabbitMQ.Client
         /// A message indicating the reason for closing the connection
         /// </para>
         /// </remarks>
-        public static Task AbortAsync(this IConnection connection, ushort reasonCode, string reasonText)
+        public static async Task AbortAsync(this IConnection connection, ushort reasonCode, string reasonText)
         {
-            return connection.CloseAsync(reasonCode, reasonText, InternalConstants.DefaultConnectionAbortTimeout, true,
-                CancellationToken.None);
+            using var cts = new CancellationTokenSource(InternalConstants.DefaultConnectionAbortTimeout);
+            await connection.CloseAsync(reasonCode,
+                reasonText, InternalConstants.DefaultConnectionAbortTimeout, true, cts.Token)
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -135,10 +141,12 @@ namespace RabbitMQ.Client
         /// To wait infinitely for the close operations to complete use <see cref="Timeout.Infinite"/>.
         /// </para>
         /// </remarks>
-        public static Task AbortAsync(this IConnection connection, TimeSpan timeout)
+        public static async Task AbortAsync(this IConnection connection, TimeSpan timeout)
         {
-            return connection.CloseAsync(Constants.ReplySuccess, "Connection close forced", timeout, true,
-                CancellationToken.None);
+            using var cts = new CancellationTokenSource(InternalConstants.DefaultConnectionAbortTimeout);
+            await connection.CloseAsync(Constants.ReplySuccess,
+                "Connection close forced", timeout, true, cts.Token)
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -155,10 +163,12 @@ namespace RabbitMQ.Client
         /// A message indicating the reason for closing the connection.
         /// </para>
         /// </remarks>
-        public static Task AbortAsync(this IConnection connection, ushort reasonCode, string reasonText, TimeSpan timeout)
+        public static async Task AbortAsync(this IConnection connection, ushort reasonCode, string reasonText, TimeSpan timeout)
         {
-            return connection.CloseAsync(reasonCode, reasonText, timeout, true,
-                CancellationToken.None);
+            using var cts = new CancellationTokenSource(InternalConstants.DefaultConnectionAbortTimeout);
+            await connection.CloseAsync(reasonCode,
+                reasonText, timeout, true, cts.Token)
+                .ConfigureAwait(false);
         }
     }
 }

--- a/projects/RabbitMQ.Client/Impl/Connection.cs
+++ b/projects/RabbitMQ.Client/Impl/Connection.cs
@@ -330,8 +330,6 @@ namespace RabbitMQ.Client.Framing
             }
             else
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
                 await OnShutdownAsync(reason)
                     .ConfigureAwait(false);
                 await _session0.SetSessionClosingAsync(false, cancellationToken)
@@ -518,7 +516,6 @@ namespace RabbitMQ.Client.Framing
                 }
 
                 _session0.Dispose();
-                _mainLoopCts.Dispose();
 
                 await _channel0.DisposeAsync()
                     .ConfigureAwait(false);
@@ -529,6 +526,7 @@ namespace RabbitMQ.Client.Framing
             }
             finally
             {
+                _mainLoopCts.Dispose();
                 _disposed = true;
             }
         }

--- a/projects/Test/Integration/GH/TestGitHubIssues.cs
+++ b/projects/Test/Integration/GH/TestGitHubIssues.cs
@@ -131,5 +131,21 @@ namespace Test.Integration.GH
 
             Assert.True(_conn.Heartbeat != default);
         }
+
+        [Fact]
+        public async Task DisposeWhileCatchingTimeoutDeadlocksRepro_GH1759()
+        {
+            _connFactory = new ConnectionFactory();
+            _conn = await _connFactory.CreateConnectionAsync();
+            try
+            {
+                await _conn.CloseAsync(TimeSpan.Zero);
+            }
+            catch (Exception)
+            {
+            }
+
+            await _conn.DisposeAsync();
+        }
     }
 }


### PR DESCRIPTION
Fixes #1759

When passing a timeout of 0, `DisposeAsync` would block forever after closing a connection.

This change ensures that the timeout is used in a cancellation token.