### PR TITLE
Allow parent/child relationship in Opentelemetry spans

### DIFF
--- a/projects/RabbitMQ.Client.OpenTelemetry/PublicAPI.Unshipped.txt
+++ b/projects/RabbitMQ.Client.OpenTelemetry/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+~static OpenTelemetry.Trace.OpenTelemetryExtensions.AddRabbitMQInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<RabbitMQ.Client.RabbitMQTracingOptions> configure) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/projects/RabbitMQ.Client.OpenTelemetry/TraceProviderBuilderExtensions.cs
+++ b/projects/RabbitMQ.Client.OpenTelemetry/TraceProviderBuilderExtensions.cs
@@ -8,14 +8,24 @@ using RabbitMQ.Client;
 
 namespace OpenTelemetry.Trace
 {
+
     public static class OpenTelemetryExtensions
     {
-        public static TracerProviderBuilder AddRabbitMQInstrumentation(this TracerProviderBuilder builder)
+        public static TracerProviderBuilder AddRabbitMQInstrumentation(this TracerProviderBuilder builder, Action<RabbitMQTracingOptions> configure)
         {
+            var options = new RabbitMQTracingOptions();
+            configure?.Invoke(options);
+            RabbitMQActivitySource.TracingOptions = options;
+
             RabbitMQActivitySource.ContextExtractor = OpenTelemetryContextExtractor;
             RabbitMQActivitySource.ContextInjector = OpenTelemetryContextInjector;
             builder.AddSource("RabbitMQ.Client.*");
             return builder;
+        }
+
+        public static TracerProviderBuilder AddRabbitMQInstrumentation(this TracerProviderBuilder builder)
+        {
+            return AddRabbitMQInstrumentation(builder, null);
         }
 
         private static ActivityContext OpenTelemetryContextExtractor(IReadOnlyBasicProperties props)

--- a/projects/RabbitMQ.Client/Impl/RabbitMQTracingOptions.cs
+++ b/projects/RabbitMQ.Client/Impl/RabbitMQTracingOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace RabbitMQ.Client
+{
+    public class RabbitMQTracingOptions
+    {
+        public bool UseRoutingKeyAsOperationName { get; set; } = true;
+        public bool UsePublisherAsParent { get; set; } = true;
+    }
+}

--- a/projects/RabbitMQ.Client/PublicAPI.Unshipped.txt
+++ b/projects/RabbitMQ.Client/PublicAPI.Unshipped.txt
@@ -5,3 +5,11 @@ RabbitMQ.Client.Exceptions.PublishReturnException.PublishReturnException(ulong p
 RabbitMQ.Client.Exceptions.PublishReturnException.ReplyCode.get -> ushort
 RabbitMQ.Client.Exceptions.PublishReturnException.ReplyText.get -> string!
 RabbitMQ.Client.Exceptions.PublishReturnException.RoutingKey.get -> string!
+RabbitMQ.Client.RabbitMQTracingOptions
+RabbitMQ.Client.RabbitMQTracingOptions.RabbitMQTracingOptions() -> void
+RabbitMQ.Client.RabbitMQTracingOptions.UsePublisherAsParent.get -> bool
+RabbitMQ.Client.RabbitMQTracingOptions.UsePublisherAsParent.set -> void
+RabbitMQ.Client.RabbitMQTracingOptions.UseRoutingKeyAsOperationName.get -> bool
+RabbitMQ.Client.RabbitMQTracingOptions.UseRoutingKeyAsOperationName.set -> void
+static RabbitMQ.Client.RabbitMQActivitySource.TracingOptions.get -> RabbitMQ.Client.RabbitMQTracingOptions!
+static RabbitMQ.Client.RabbitMQActivitySource.TracingOptions.set -> void

--- a/projects/Test/SequentialIntegration/TestActivitySource.cs
+++ b/projects/Test/SequentialIntegration/TestActivitySource.cs
@@ -76,11 +76,14 @@ namespace Test.SequentialIntegration
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task TestPublisherAndConsumerActivityTags(bool useRoutingKeyAsOperationName)
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public async Task TestPublisherAndConsumerActivityTags(bool useRoutingKeyAsOperationName, bool usePublisherAsParent)
         {
             RabbitMQActivitySource.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
+            RabbitMQActivitySource.TracingOptions.UsePublisherAsParent = usePublisherAsParent;
             var _activities = new List<Activity>();
             using ActivityListener activityListener = StartActivityListener(_activities);
             await Task.Delay(500);
@@ -106,15 +109,18 @@ namespace Test.SequentialIntegration
 
             await _channel.BasicCancelAsync(consumerTag);
             await Task.Delay(500);
-            AssertActivityData(useRoutingKeyAsOperationName, queueName, _activities, true);
+            AssertActivityData(useRoutingKeyAsOperationName, usePublisherAsParent, queueName, _activities, true);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task TestPublisherWithCachedStringsAndConsumerActivityTags(bool useRoutingKeyAsOperationName)
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public async Task TestPublisherWithCachedStringsAndConsumerActivityTags(bool useRoutingKeyAsOperationName, bool usePublisherAsParent)
         {
             RabbitMQActivitySource.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
+            RabbitMQActivitySource.TracingOptions.UsePublisherAsParent = usePublisherAsParent;
             var _activities = new List<Activity>();
             using ActivityListener activityListener = StartActivityListener(_activities);
             await Task.Delay(500);
@@ -142,15 +148,18 @@ namespace Test.SequentialIntegration
 
             await _channel.BasicCancelAsync(consumerTag);
             await Task.Delay(500);
-            AssertActivityData(useRoutingKeyAsOperationName, queueName, _activities, true);
+            AssertActivityData(useRoutingKeyAsOperationName, usePublisherAsParent, queueName, _activities, true);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task TestPublisherWithPublicationAddressAndConsumerActivityTags(bool useRoutingKeyAsOperationName)
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public async Task TestPublisherWithPublicationAddressAndConsumerActivityTags(bool useRoutingKeyAsOperationName, bool usePublisherAsParent)
         {
             RabbitMQActivitySource.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
+            RabbitMQActivitySource.TracingOptions.UsePublisherAsParent = usePublisherAsParent;
             var _activities = new List<Activity>();
             using ActivityListener activityListener = StartActivityListener(_activities);
             await Task.Delay(500);
@@ -177,15 +186,18 @@ namespace Test.SequentialIntegration
 
             await _channel.BasicCancelAsync(consumerTag);
             await Task.Delay(500);
-            AssertActivityData(useRoutingKeyAsOperationName, queueName, _activities, true);
+            AssertActivityData(useRoutingKeyAsOperationName, usePublisherAsParent, queueName, _activities, true);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task TestPublisherAndConsumerActivityTagsAsync(bool useRoutingKeyAsOperationName)
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public async Task TestPublisherAndConsumerActivityTagsAsync(bool useRoutingKeyAsOperationName, bool usePublisherAsParent)
         {
             RabbitMQActivitySource.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
+            RabbitMQActivitySource.TracingOptions.UsePublisherAsParent = usePublisherAsParent;
             var activities = new List<Activity>();
             using ActivityListener activityListener = StartActivityListener(activities);
             await Task.Delay(500);
@@ -212,15 +224,18 @@ namespace Test.SequentialIntegration
 
             await _channel.BasicCancelAsync(consumerTag);
             await Task.Delay(500);
-            AssertActivityData(useRoutingKeyAsOperationName, queueName, activities, true);
+            AssertActivityData(useRoutingKeyAsOperationName, usePublisherAsParent, queueName, activities, true);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task TestPublisherWithCachedStringsAndConsumerActivityTagsAsync(bool useRoutingKeyAsOperationName)
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public async Task TestPublisherWithCachedStringsAndConsumerActivityTagsAsync(bool useRoutingKeyAsOperationName, bool usePublisherAsParent)
         {
             RabbitMQActivitySource.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
+            RabbitMQActivitySource.TracingOptions.UsePublisherAsParent = usePublisherAsParent;
             var activities = new List<Activity>();
             using ActivityListener activityListener = StartActivityListener(activities);
             await Task.Delay(500);
@@ -249,15 +264,18 @@ namespace Test.SequentialIntegration
 
             await _channel.BasicCancelAsync(consumerTag);
             await Task.Delay(500);
-            AssertActivityData(useRoutingKeyAsOperationName, queueName, activities, true);
+            AssertActivityData(useRoutingKeyAsOperationName, usePublisherAsParent, queueName, activities, true);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task TestPublisherWithPublicationAddressAndConsumerActivityTagsAsync(bool useRoutingKeyAsOperationName)
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public async Task TestPublisherWithPublicationAddressAndConsumerActivityTagsAsync(bool useRoutingKeyAsOperationName, bool usePublisherAsParent)
         {
             RabbitMQActivitySource.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
+            RabbitMQActivitySource.TracingOptions.UsePublisherAsParent = usePublisherAsParent;
             var activities = new List<Activity>();
             using ActivityListener activityListener = StartActivityListener(activities);
             await Task.Delay(500);
@@ -285,15 +303,18 @@ namespace Test.SequentialIntegration
 
             await _channel.BasicCancelAsync(consumerTag);
             await Task.Delay(500);
-            AssertActivityData(useRoutingKeyAsOperationName, queueName, activities, true);
+            AssertActivityData(useRoutingKeyAsOperationName, usePublisherAsParent, queueName, activities, true);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task TestPublisherAndBasicGetActivityTags(bool useRoutingKeyAsOperationName)
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public async Task TestPublisherAndBasicGetActivityTags(bool useRoutingKeyAsOperationName, bool usePublisherAsParent)
         {
             RabbitMQActivitySource.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
+            RabbitMQActivitySource.TracingOptions.UsePublisherAsParent = usePublisherAsParent;
             var activities = new List<Activity>();
             using ActivityListener activityListener = StartActivityListener(activities);
             await Task.Delay(500);
@@ -311,7 +332,7 @@ namespace Test.SequentialIntegration
                 ok = await _channel.QueueDeclarePassiveAsync(queue);
                 Assert.Equal(0u, ok.MessageCount);
                 await Task.Delay(500);
-                AssertActivityData(useRoutingKeyAsOperationName, queue, activities, false);
+                AssertActivityData(useRoutingKeyAsOperationName, usePublisherAsParent, queue, activities, false);
             }
             finally
             {
@@ -320,11 +341,14 @@ namespace Test.SequentialIntegration
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task TestPublisherWithCachedStringsAndBasicGetActivityTags(bool useRoutingKeyAsOperationName)
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public async Task TestPublisherWithCachedStringsAndBasicGetActivityTags(bool useRoutingKeyAsOperationName, bool usePublisherAsParent)
         {
             RabbitMQActivitySource.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
+            RabbitMQActivitySource.TracingOptions.UsePublisherAsParent = usePublisherAsParent;
             var activities = new List<Activity>();
             using ActivityListener activityListener = StartActivityListener(activities);
             await Task.Delay(500);
@@ -344,7 +368,7 @@ namespace Test.SequentialIntegration
                 ok = await _channel.QueueDeclarePassiveAsync(queue);
                 Assert.Equal(0u, ok.MessageCount);
                 await Task.Delay(500);
-                AssertActivityData(useRoutingKeyAsOperationName, queue, activities, false);
+                AssertActivityData(useRoutingKeyAsOperationName, usePublisherAsParent, queue, activities, false);
             }
             finally
             {
@@ -353,11 +377,14 @@ namespace Test.SequentialIntegration
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task TestPublisherWithPublicationAddressAndBasicGetActivityTags(bool useRoutingKeyAsOperationName)
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public async Task TestPublisherWithPublicationAddressAndBasicGetActivityTags(bool useRoutingKeyAsOperationName, bool usePublisherAsParent)
         {
             RabbitMQActivitySource.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
+            RabbitMQActivitySource.TracingOptions.UsePublisherAsParent = usePublisherAsParent;
             var activities = new List<Activity>();
             using ActivityListener activityListener = StartActivityListener(activities);
             await Task.Delay(500);
@@ -377,7 +404,7 @@ namespace Test.SequentialIntegration
                 ok = await _channel.QueueDeclarePassiveAsync(queue);
                 Assert.Equal(0u, ok.MessageCount);
                 await Task.Delay(500);
-                AssertActivityData(useRoutingKeyAsOperationName, queue, activities, false);
+                AssertActivityData(useRoutingKeyAsOperationName, usePublisherAsParent, queue, activities, false);
             }
             finally
             {
@@ -399,7 +426,7 @@ namespace Test.SequentialIntegration
             return activityListener;
         }
 
-        private void AssertActivityData(bool useRoutingKeyAsOperationName, string queueName,
+        private void AssertActivityData(bool useRoutingKeyAsOperationName, bool usePublisherAsParent, string queueName,
             List<Activity> activityList, bool isDeliver = false)
         {
             string childName = isDeliver ? "deliver" : "fetch";
@@ -422,11 +449,20 @@ namespace Test.SequentialIntegration
                 x.GetTagItem(RabbitMQActivitySource.MessagingDestinationRoutingKey) is string routingKeyTag &&
                 routingKeyTag == $"{queueName}");
             Activity receiveActivity = activities.Single(x =>
-                x.OperationName == (useRoutingKeyAsOperationName ? $"{childName} {queueName}" : childName) &&
-                x.Links.First().Context.TraceId == sendActivity.TraceId);
+                x.OperationName == (useRoutingKeyAsOperationName ? $"{childName} {queueName}" : childName));
             Assert.Equal(ActivityKind.Producer, sendActivity.Kind);
             Assert.Equal(ActivityKind.Consumer, receiveActivity.Kind);
-            Assert.Null(receiveActivity.ParentId);
+            Assert.Equal(sendActivity.TraceId, receiveActivity.Links.Single().Context.TraceId);
+            if (usePublisherAsParent)
+            {
+                Assert.Equal(sendActivity.Id, receiveActivity.ParentId);
+                Assert.Equal(sendActivity.TraceId, receiveActivity.TraceId);
+            }
+            else
+            {
+                Assert.Null(receiveActivity.ParentId);
+                Assert.NotEqual(sendActivity.TraceId, receiveActivity.TraceId);
+            }
             AssertStringTagNotNullOrEmpty(sendActivity, "network.peer.address");
             AssertStringTagNotNullOrEmpty(sendActivity, "network.local.address");
             AssertStringTagNotNullOrEmpty(sendActivity, "server.address");

--- a/projects/Test/SequentialIntegration/TestOpenTelemetry.cs
+++ b/projects/Test/SequentialIntegration/TestOpenTelemetry.cs
@@ -82,21 +82,38 @@ namespace Test.SequentialIntegration
             Assert.True(activity.GetTagItem(name) is int result && result > 0);
         }
 
+        [Fact]
+        public void TestDefaultTracingOptions()
+        {
+            using var tracer = Sdk.CreateTracerProviderBuilder()
+                .AddRabbitMQInstrumentation()
+                .Build();
+
+            Assert.True(RabbitMQActivitySource.UseRoutingKeyAsOperationName);
+            Assert.True(RabbitMQActivitySource.TracingOptions.UseRoutingKeyAsOperationName);
+            Assert.True(RabbitMQActivitySource.TracingOptions.UsePublisherAsParent);
+        }
+
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task TestPublisherAndConsumerActivityTags(bool useRoutingKeyAsOperationName)
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public async Task TestPublisherAndConsumerActivityTags(bool useRoutingKeyAsOperationName, bool usePublisherAsParent)
         {
             var exportedItems = new List<Activity>();
             using var tracer = Sdk.CreateTracerProviderBuilder()
-                .AddRabbitMQInstrumentation()
+                .AddRabbitMQInstrumentation(options =>
+                {
+                    options.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
+                    options.UsePublisherAsParent = usePublisherAsParent;
+                })
                 .AddInMemoryExporter(exportedItems)
                 .Build();
             string baggageGuid = Guid.NewGuid().ToString();
             Baggage.SetBaggage("TestItem", baggageGuid);
             Assert.Equal(baggageGuid, Baggage.GetBaggage("TestItem"));
 
-            RabbitMQActivitySource.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
             await Task.Delay(500);
             string queueName = $"{Guid.NewGuid()}";
             QueueDeclareOk q = await _channel.QueueDeclareAsync(queueName);
@@ -132,24 +149,29 @@ namespace Test.SequentialIntegration
 
             await _channel.BasicCancelAsync(consumerTag);
             await Task.Delay(500);
-            AssertActivityData(useRoutingKeyAsOperationName, queueName, exportedItems, true);
+            AssertActivityData(useRoutingKeyAsOperationName, usePublisherAsParent, queueName, exportedItems, true);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task TestPublisherAndConsumerActivityTagsAsync(bool useRoutingKeyAsOperationName)
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public async Task TestPublisherAndConsumerActivityTagsAsync(bool useRoutingKeyAsOperationName, bool usePublisherAsParent)
         {
             var exportedItems = new List<Activity>();
             using var tracer = Sdk.CreateTracerProviderBuilder()
-                .AddRabbitMQInstrumentation()
+                .AddRabbitMQInstrumentation(options =>
+                {
+                    options.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
+                    options.UsePublisherAsParent = usePublisherAsParent;
+                })
                 .AddInMemoryExporter(exportedItems)
                 .Build();
             string baggageGuid = Guid.NewGuid().ToString();
             Baggage.SetBaggage("TestItem", baggageGuid);
             Assert.Equal(baggageGuid, Baggage.GetBaggage("TestItem"));
 
-            RabbitMQActivitySource.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
             await Task.Delay(500);
 
             string queueName = $"{Guid.NewGuid()}";
@@ -186,24 +208,29 @@ namespace Test.SequentialIntegration
 
             await _channel.BasicCancelAsync(consumerTag);
             await Task.Delay(500);
-            AssertActivityData(useRoutingKeyAsOperationName, queueName, exportedItems, true);
+            AssertActivityData(useRoutingKeyAsOperationName, usePublisherAsParent, queueName, exportedItems, true);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task TestPublisherWithPublicationAddressAndConsumerActivityTagsAsync(bool useRoutingKeyAsOperationName)
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public async Task TestPublisherWithPublicationAddressAndConsumerActivityTagsAsync(bool useRoutingKeyAsOperationName, bool usePublisherAsParent)
         {
             var exportedItems = new List<Activity>();
             using var tracer = Sdk.CreateTracerProviderBuilder()
-                .AddRabbitMQInstrumentation()
+                .AddRabbitMQInstrumentation(options =>
+                {
+                    options.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
+                    options.UsePublisherAsParent = usePublisherAsParent;
+                })
                 .AddInMemoryExporter(exportedItems)
                 .Build();
             string baggageGuid = Guid.NewGuid().ToString();
             Baggage.SetBaggage("TestItem", baggageGuid);
             Assert.Equal(baggageGuid, Baggage.GetBaggage("TestItem"));
 
-            RabbitMQActivitySource.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
             await Task.Delay(500);
 
             string queueName = $"{Guid.NewGuid()}";
@@ -241,24 +268,29 @@ namespace Test.SequentialIntegration
 
             await _channel.BasicCancelAsync(consumerTag);
             await Task.Delay(500);
-            AssertActivityData(useRoutingKeyAsOperationName, queueName, exportedItems, true);
+            AssertActivityData(useRoutingKeyAsOperationName, usePublisherAsParent, queueName, exportedItems, true);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task TestPublisherWithCachedStringsAndConsumerActivityTagsAsync(bool useRoutingKeyAsOperationName)
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public async Task TestPublisherWithCachedStringsAndConsumerActivityTagsAsync(bool useRoutingKeyAsOperationName, bool usePublisherAsParent)
         {
             var exportedItems = new List<Activity>();
             using var tracer = Sdk.CreateTracerProviderBuilder()
-                .AddRabbitMQInstrumentation()
+                .AddRabbitMQInstrumentation(options =>
+                {
+                    options.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
+                    options.UsePublisherAsParent = usePublisherAsParent;
+                })
                 .AddInMemoryExporter(exportedItems)
                 .Build();
             string baggageGuid = Guid.NewGuid().ToString();
             Baggage.SetBaggage("TestItem", baggageGuid);
             Assert.Equal(baggageGuid, Baggage.GetBaggage("TestItem"));
 
-            RabbitMQActivitySource.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
             await Task.Delay(500);
 
             string queueName = $"{Guid.NewGuid()}";
@@ -297,23 +329,28 @@ namespace Test.SequentialIntegration
 
             await _channel.BasicCancelAsync(consumerTag);
             await Task.Delay(500);
-            AssertActivityData(useRoutingKeyAsOperationName, queueName, exportedItems, true);
+            AssertActivityData(useRoutingKeyAsOperationName, usePublisherAsParent, queueName, exportedItems, true);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task TestPublisherAndBasicGetActivityTags(bool useRoutingKeyAsOperationName)
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public async Task TestPublisherAndBasicGetActivityTags(bool useRoutingKeyAsOperationName, bool usePublisherAsParent)
         {
             var exportedItems = new List<Activity>();
             using var tracer = Sdk.CreateTracerProviderBuilder()
-                .AddRabbitMQInstrumentation()
+                .AddRabbitMQInstrumentation(options =>
+                {
+                    options.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
+                    options.UsePublisherAsParent = usePublisherAsParent;
+                })
                 .AddInMemoryExporter(exportedItems)
                 .Build();
             string baggageGuid = Guid.NewGuid().ToString();
             Baggage.SetBaggage("TestItem", baggageGuid);
             Assert.Equal(baggageGuid, Baggage.GetBaggage("TestItem"));
-            RabbitMQActivitySource.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
             await Task.Delay(500);
             string queue = $"queue-{Guid.NewGuid()}";
             const string msg = "for basic.get";
@@ -331,7 +368,7 @@ namespace Test.SequentialIntegration
                 ok = await _channel.QueueDeclarePassiveAsync(queue);
                 Assert.Equal(0u, ok.MessageCount);
                 await Task.Delay(500);
-                AssertActivityData(useRoutingKeyAsOperationName, queue, exportedItems, false);
+                AssertActivityData(useRoutingKeyAsOperationName, usePublisherAsParent, queue, exportedItems, false);
             }
             finally
             {
@@ -339,7 +376,7 @@ namespace Test.SequentialIntegration
             }
         }
 
-        private void AssertActivityData(bool useRoutingKeyAsOperationName, string queueName,
+        private void AssertActivityData(bool useRoutingKeyAsOperationName, bool usePublisherAsParent, string queueName,
             List<Activity> activityList, bool isDeliver = false, string baggageGuid = null)
         {
             string childName = isDeliver ? "deliver" : "fetch";
@@ -359,11 +396,20 @@ namespace Test.SequentialIntegration
                 x.GetTagItem(RabbitMQActivitySource.MessagingDestinationRoutingKey) is string routingKeyTag &&
                 routingKeyTag == $"{queueName}");
             Activity receiveActivity = activities.Single(x =>
-                x.OperationName == (useRoutingKeyAsOperationName ? $"{childName} {queueName}" : childName) &&
-                x.Links.First().Context.TraceId == sendActivity.TraceId);
+                x.OperationName == (useRoutingKeyAsOperationName ? $"{childName} {queueName}" : childName));
             Assert.Equal(ActivityKind.Producer, sendActivity.Kind);
             Assert.Equal(ActivityKind.Consumer, receiveActivity.Kind);
-            Assert.Null(receiveActivity.ParentId);
+            Assert.Equal(sendActivity.TraceId, receiveActivity.Links.Single().Context.TraceId);
+            if (usePublisherAsParent)
+            {
+                Assert.Equal(sendActivity.Id, receiveActivity.ParentId);
+                Assert.Equal(sendActivity.TraceId, receiveActivity.TraceId);
+            }
+            else
+            {
+                Assert.Null(receiveActivity.ParentId);
+                Assert.NotEqual(sendActivity.TraceId, receiveActivity.TraceId);
+            }
             AssertStringTagNotNullOrEmpty(sendActivity, "network.peer.address");
             AssertStringTagNotNullOrEmpty(sendActivity, "network.local.address");
             AssertStringTagNotNullOrEmpty(sendActivity, "server.address");
@@ -385,6 +431,7 @@ namespace Test.SequentialIntegration
             AssertStringTagEquals(receiveActivity, RabbitMQActivitySource.MessagingOperationName, childName);
             AssertStringTagEquals(sendActivity, RabbitMQActivitySource.MessagingOperationType, "send");
             AssertStringTagEquals(sendActivity, RabbitMQActivitySource.MessagingOperationName, "publish");
+
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

Adds an option to set remote span as parent rather than link when propagating Opentelemetry context between the publisher and receiver.
See issue #1666

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments


