### PR TITLE
Skip flaky test

### DIFF
--- a/projects/Test/Integration/TestBasicPublish.cs
+++ b/projects/Test/Integration/TestBasicPublish.cs
@@ -170,9 +170,11 @@ namespace Test.Integration
             await _channel.BasicCancelAsync(tag);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task TestMaxInboundMessageBodySize()
         {
+            Skip.If(true, "TODO - FUTURE - reinstate test. It is flaky now.");
+
             var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             using var cts = new CancellationTokenSource(WaitSpan);
             using CancellationTokenRegistration ctr = cts.Token.Register(() => tcs.SetCanceled());


### PR DESCRIPTION
`AlreadyClosedException` is not consistently thrown.

Related to #1572 #1356 #1217 #1218