### PR TITLE
Add dedicated exception for `basic.return` messages.

### DIFF
--- a/projects/RabbitMQ.Client/Exceptions/PublishException.cs
+++ b/projects/RabbitMQ.Client/Exceptions/PublishException.cs
@@ -73,40 +73,50 @@ namespace RabbitMQ.Client.Exceptions
     {
         private readonly string _exchange;
         private readonly string _routingKey;
+        private readonly ushort _replyCode;
+        private readonly string _replyText;
 
-        public PublishReturnException(ulong publishSequenceNumber, string exchange, string routingKey)
+        public PublishReturnException(ulong publishSequenceNumber,
+            string? exchange = null, string? routingKey = null,
+            ushort? replyCode = null, string? replyText = null)
             : base(publishSequenceNumber, true)
         {
-            _exchange = exchange;
-            _routingKey = routingKey;
+            _exchange = exchange ?? string.Empty;
+            _routingKey = routingKey ?? string.Empty;
+            _replyCode = replyCode ?? 0;
+            _replyText = replyText ?? string.Empty;
         }
 
         /// <summary>
-        /// Get the Exchange associated with this <c>basic.return</c>
+        /// Get the exchange associated with this <c>basic.return</c>
         /// </summary>
         public string Exchange => _exchange;
 
         /// <summary>
-        /// Get the RoutingKey associated with this <c>basic.return</c>
+        /// Get the routing key associated with this <c>basic.return</c>
         /// </summary>
         public string RoutingKey => _routingKey;
+
+        /// <summary>
+        /// Get the reply code associated with this <c>basic.return</c>
+        /// </summary>
+        public ushort ReplyCode => _replyCode;
+
+        /// <summary>
+        /// Get the reply text associated with this <c>basic.return</c>
+        /// </summary>
+        public string ReplyText => _replyText;
     }
 
     internal static class PublishExceptionFactory
     {
         internal static PublishException Create(bool isReturn,
-            ulong deliveryTag, string? exchange = null, string? routingKey = null)
+            ulong deliveryTag, string? exchange = null, string? routingKey = null,
+            ushort? replyCode = null, string? replyText = null)
         {
             if (isReturn)
             {
-                if (exchange is not null && routingKey is not null)
-                {
-                    return new PublishReturnException(deliveryTag, exchange, routingKey);
-                }
-                else
-                {
-                    return new PublishException(deliveryTag, isReturn);
-                }
+                return new PublishReturnException(deliveryTag, exchange, routingKey, replyCode, replyText);
             }
             else
             {

--- a/projects/RabbitMQ.Client/Exceptions/PublishException.cs
+++ b/projects/RabbitMQ.Client/Exceptions/PublishException.cs
@@ -63,4 +63,55 @@ namespace RabbitMQ.Client.Exceptions
         /// </summary>
         public ulong PublishSequenceNumber => _publishSequenceNumber;
     }
+
+    /// <summary>
+    /// Class for exceptions related to publisher confirmations
+    /// or the <c>mandatory</c> flag, when <c>basic.return</c> is
+    /// sent from the broker.
+    /// </summary>
+    public class PublishReturnException : PublishException
+    {
+        private readonly string _exchange;
+        private readonly string _routingKey;
+
+        public PublishReturnException(ulong publishSequenceNumber, string exchange, string routingKey)
+            : base(publishSequenceNumber, true)
+        {
+            _exchange = exchange;
+            _routingKey = routingKey;
+        }
+
+        /// <summary>
+        /// Get the Exchange associated with this <c>basic.return</c>
+        /// </summary>
+        public string Exchange => _exchange;
+
+        /// <summary>
+        /// Get the RoutingKey associated with this <c>basic.return</c>
+        /// </summary>
+        public string RoutingKey => _routingKey;
+    }
+
+    internal static class PublishExceptionFactory
+    {
+        internal static PublishException Create(bool isReturn,
+            ulong deliveryTag, string? exchange = null, string? routingKey = null)
+        {
+            if (isReturn)
+            {
+                if (exchange is not null && routingKey is not null)
+                {
+                    return new PublishReturnException(deliveryTag, exchange, routingKey);
+                }
+                else
+                {
+                    return new PublishException(deliveryTag, isReturn);
+                }
+            }
+            else
+            {
+                return new PublishException(deliveryTag, isReturn);
+            }
+        }
+    }
 }

--- a/projects/RabbitMQ.Client/Exceptions/PublishException.cs
+++ b/projects/RabbitMQ.Client/Exceptions/PublishException.cs
@@ -42,7 +42,11 @@ namespace RabbitMQ.Client.Exceptions
         private bool _isReturn = false;
         private ulong _publishSequenceNumber = ulong.MinValue;
 
-        public PublishException(ulong publishSequenceNumber, bool isReturn) : base()
+        public PublishException(ulong publishSequenceNumber, bool isReturn) : this(publishSequenceNumber, isReturn, "Message rejected by broker.")
+        {
+        }
+
+        public PublishException(ulong publishSequenceNumber, bool isReturn, string message) : base(message)
         {
             if (publishSequenceNumber == ulong.MinValue)
             {
@@ -76,10 +80,10 @@ namespace RabbitMQ.Client.Exceptions
         private readonly ushort _replyCode;
         private readonly string _replyText;
 
-        public PublishReturnException(ulong publishSequenceNumber,
+        public PublishReturnException(ulong publishSequenceNumber, string message,
             string? exchange = null, string? routingKey = null,
             ushort? replyCode = null, string? replyText = null)
-            : base(publishSequenceNumber, true)
+            : base(publishSequenceNumber, true, message)
         {
             _exchange = exchange ?? string.Empty;
             _routingKey = routingKey ?? string.Empty;
@@ -116,7 +120,8 @@ namespace RabbitMQ.Client.Exceptions
         {
             if (isReturn)
             {
-                return new PublishReturnException(deliveryTag, exchange, routingKey, replyCode, replyText);
+                string message = $"{replyCode} {replyText} Exchange: {exchange} Routing Key: {routingKey}";
+                return new PublishReturnException(deliveryTag, message, exchange, routingKey, replyCode, replyText);
             }
             else
             {

--- a/projects/RabbitMQ.Client/Impl/Channel.PublisherConfirms.cs
+++ b/projects/RabbitMQ.Client/Impl/Channel.PublisherConfirms.cs
@@ -223,7 +223,8 @@ namespace RabbitMQ.Client.Impl
                 {
                     if (_confirmsTaskCompletionSources.Remove(deliveryTag, out TaskCompletionSource<bool>? tcs))
                     {
-                        PublishException ex = PublishExceptionFactory.Create(isReturn, deliveryTag);
+                        PublishException ex = PublishExceptionFactory.Create(isReturn, deliveryTag,
+                            exchange, routingKey, replyCode, replyText);
                         tcs.SetException(ex);
                     }
                 }

--- a/projects/RabbitMQ.Client/Impl/Channel.PublisherConfirms.cs
+++ b/projects/RabbitMQ.Client/Impl/Channel.PublisherConfirms.cs
@@ -201,7 +201,8 @@ namespace RabbitMQ.Client.Impl
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void HandleNack(ulong deliveryTag, bool multiple, bool isReturn,
-            string? exchange = null, string? routingKey = null)
+            string? exchange = null, string? routingKey = null,
+            ushort? replyCode = null, string? replyText = null)
         {
             if (ShouldHandleAckOrNack(deliveryTag))
             {
@@ -211,7 +212,8 @@ namespace RabbitMQ.Client.Impl
                     {
                         if (pair.Key <= deliveryTag)
                         {
-                            PublishException ex = PublishExceptionFactory.Create(isReturn, pair.Key, exchange, routingKey);
+                            PublishException ex = PublishExceptionFactory.Create(isReturn, pair.Key,
+                                exchange, routingKey, replyCode, replyText);
                             pair.Value.SetException(ex);
                             _confirmsTaskCompletionSources.Remove(pair.Key, out _);
                         }
@@ -253,7 +255,8 @@ namespace RabbitMQ.Client.Impl
                 }
 
                 HandleNack(publishSequenceNumber, multiple: false, isReturn: true,
-                    exchange: basicReturnEvent.Exchange, routingKey: basicReturnEvent.RoutingKey);
+                    exchange: basicReturnEvent.Exchange, routingKey: basicReturnEvent.RoutingKey,
+                    replyCode: basicReturnEvent.ReplyCode, replyText: basicReturnEvent.ReplyText);
             }
         }
 

--- a/projects/RabbitMQ.Client/PublicAPI.Unshipped.txt
+++ b/projects/RabbitMQ.Client/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
+RabbitMQ.Client.Exceptions.PublishException.PublishException(ulong publishSequenceNumber, bool isReturn, string! message) -> void
 RabbitMQ.Client.Exceptions.PublishReturnException
 RabbitMQ.Client.Exceptions.PublishReturnException.Exchange.get -> string!
-RabbitMQ.Client.Exceptions.PublishReturnException.PublishReturnException(ulong publishSequenceNumber, string? exchange = null, string? routingKey = null, ushort? replyCode = null, string? replyText = null) -> void
+RabbitMQ.Client.Exceptions.PublishReturnException.PublishReturnException(ulong publishSequenceNumber, string! message, string? exchange = null, string? routingKey = null, ushort? replyCode = null, string? replyText = null) -> void
 RabbitMQ.Client.Exceptions.PublishReturnException.ReplyCode.get -> ushort
 RabbitMQ.Client.Exceptions.PublishReturnException.ReplyText.get -> string!
 RabbitMQ.Client.Exceptions.PublishReturnException.RoutingKey.get -> string!

--- a/projects/RabbitMQ.Client/PublicAPI.Unshipped.txt
+++ b/projects/RabbitMQ.Client/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 RabbitMQ.Client.Exceptions.PublishReturnException
 RabbitMQ.Client.Exceptions.PublishReturnException.Exchange.get -> string!
-RabbitMQ.Client.Exceptions.PublishReturnException.PublishReturnException(ulong publishSequenceNumber, string! exchange, string! routingKey) -> void
+RabbitMQ.Client.Exceptions.PublishReturnException.PublishReturnException(ulong publishSequenceNumber, string? exchange = null, string? routingKey = null, ushort? replyCode = null, string? replyText = null) -> void
+RabbitMQ.Client.Exceptions.PublishReturnException.ReplyCode.get -> ushort
+RabbitMQ.Client.Exceptions.PublishReturnException.ReplyText.get -> string!
 RabbitMQ.Client.Exceptions.PublishReturnException.RoutingKey.get -> string!

--- a/projects/RabbitMQ.Client/PublicAPI.Unshipped.txt
+++ b/projects/RabbitMQ.Client/PublicAPI.Unshipped.txt
@@ -1,0 +1,4 @@
+RabbitMQ.Client.Exceptions.PublishReturnException
+RabbitMQ.Client.Exceptions.PublishReturnException.Exchange.get -> string!
+RabbitMQ.Client.Exceptions.PublishReturnException.PublishReturnException(ulong publishSequenceNumber, string! exchange, string! routingKey) -> void
+RabbitMQ.Client.Exceptions.PublishReturnException.RoutingKey.get -> string!

--- a/projects/Test/Integration/TestBasicPublishAsync.cs
+++ b/projects/Test/Integration/TestBasicPublishAsync.cs
@@ -86,7 +86,7 @@ namespace Test.Integration
                 Assert.NotEqual(0, prex.ReplyCode);
                 Assert.NotNull(prex.ReplyText);
                 Assert.Equal("NO_ROUTE", prex.ReplyText);
-                
+
             }
         }
     }

--- a/projects/Test/Integration/TestBasicPublishAsync.cs
+++ b/projects/Test/Integration/TestBasicPublishAsync.cs
@@ -70,18 +70,23 @@ namespace Test.Integration
         [Fact]
         public async Task TestBasicReturnAsync()
         {
+            string routingKey = Guid.NewGuid().ToString();
             try
             {
-                await _channel.BasicPublishAsync(exchange: string.Empty, routingKey: Guid.NewGuid().ToString(),
+                await _channel.BasicPublishAsync(exchange: string.Empty, routingKey: routingKey,
                     mandatory: true, body: GetRandomBody());
             }
             catch (PublishReturnException prex)
             {
                 Assert.True(prex.IsReturn);
                 Assert.NotNull(prex.Exchange);
+                Assert.Equal(string.Empty, prex.Exchange);
                 Assert.NotNull(prex.RoutingKey);
+                Assert.Equal(routingKey, prex.RoutingKey);
                 Assert.NotEqual(0, prex.ReplyCode);
                 Assert.NotNull(prex.ReplyText);
+                Assert.Equal("NO_ROUTE", prex.ReplyText);
+                
             }
         }
     }

--- a/projects/Test/Integration/TestConcurrentAccessWithSharedChannel.cs
+++ b/projects/Test/Integration/TestConcurrentAccessWithSharedChannel.cs
@@ -145,8 +145,13 @@ namespace Test.Integration
                     }
                     catch (PublishException ex)
                     {
-                        if (ex.IsReturn)
+                        if (ex is PublishReturnException prex)
                         {
+                            Assert.True(prex.IsReturn);
+                            Assert.NotNull(prex.Exchange);
+                            Assert.NotNull(prex.RoutingKey);
+                            Assert.NotEqual(0, prex.ReplyCode);
+                            Assert.NotNull(prex.ReplyText);
                             Interlocked.Increment(ref totalReturnCount);
                         }
                         else


### PR DESCRIPTION
Fixes #1831

This PR adds the `PublishReturnException` class that includes the originating exchange and routing key for a `basic.return` message. It should be backwards-compatible in the API.