### PR TITLE
Improve AsyncManualResetEvent implementation to address races

### DIFF
--- a/projects/RabbitMQ.Client/Impl/Channel.BasicPublish.cs
+++ b/projects/RabbitMQ.Client/Impl/Channel.BasicPublish.cs
@@ -229,11 +229,11 @@ namespace RabbitMQ.Client.Impl
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private ValueTask MaybeEnforceFlowControlAsync(CancellationToken cancellationToken)
+        private Task MaybeEnforceFlowControlAsync(CancellationToken cancellationToken)
         {
             if (_flowControlBlock.IsSet)
             {
-                return default;
+                return Task.CompletedTask;
             }
 
             return _flowControlBlock.WaitAsync(cancellationToken);


### PR DESCRIPTION
## Proposed Changes

I used the implementation further in some very high concurrent scenarios and ran into token problems with the manual reset implementation under the cover. I have concluded the original version I tweaked had some races that we collectively missed. 

The race condition occurs in WaitAsync() where the IsSet check and valueTaskSource.Version capture happen at different moments without synchronization, allowing Set() or Reset() to execute between these operations and change the state. If Reset() is called after the IsSet check passes but before the ValueTask is created, the version becomes stale and the awaited task will never complete because it references the old version while the ManualResetValueTaskSourceCore has been reset. Additionally, the gap between checking IsSet and updating state in both Set() and Reset() creates windows where multiple threads can pass the initial checks simultaneously, leading to operations being performed on inconsistent state.

This implementation passed my concurrency tests, but it doesn't hurt if the original involved reviewers give this another review @lukebakken @paulomorgado @bollhals 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
