### PR TITLE
Closes#1849:  include a message id tag in rabbitmqactivitysource for published messages

### DIFF
--- a/projects/RabbitMQ.Client/Impl/Channel.BasicPublish.cs
+++ b/projects/RabbitMQ.Client/Impl/Channel.BasicPublish.cs
@@ -61,7 +61,7 @@ namespace RabbitMQ.Client.Impl
                 var cmd = new BasicPublish(exchange, routingKey, mandatory, default);
 
                 using Activity? sendActivity = RabbitMQActivitySource.PublisherHasListeners
-                    ? RabbitMQActivitySource.BasicPublish(routingKey, exchange, body.Length)
+                    ? RabbitMQActivitySource.BasicPublish(routingKey, exchange, body.Length, basicProperties)
                     : default;
 
                 ulong publishSequenceNumber = 0;
@@ -116,7 +116,7 @@ namespace RabbitMQ.Client.Impl
                 var cmd = new BasicPublishMemory(exchange.Bytes, routingKey.Bytes, mandatory, default);
 
                 using Activity? sendActivity = RabbitMQActivitySource.PublisherHasListeners
-                    ? RabbitMQActivitySource.BasicPublish(routingKey.Value, exchange.Value, body.Length)
+                    ? RabbitMQActivitySource.BasicPublish(routingKey.Value, exchange.Value, body.Length, basicProperties)
                     : default;
 
                 ulong publishSequenceNumber = 0;

--- a/projects/RabbitMQ.Client/Impl/RabbitMQActivitySource.cs
+++ b/projects/RabbitMQ.Client/Impl/RabbitMQActivitySource.cs
@@ -66,7 +66,7 @@ namespace RabbitMQ.Client
             new KeyValuePair<string, object?>(ProtocolVersion, "0.9.1")
         };
 
-        internal static Activity? BasicPublish(string routingKey, string exchange, int bodySize,
+        internal static Activity? BasicPublish(string routingKey, string exchange, int bodySize, IReadOnlyBasicProperties basicProperties,
             ActivityContext linkedContext = default)
         {
             if (!s_publisherSource.HasListeners())
@@ -83,7 +83,7 @@ namespace RabbitMQ.Client
                     ActivityKind.Producer, linkedContext);
             if (activity != null && activity.IsAllDataRequested)
             {
-                PopulateMessagingTags(MessagingOperationTypeSend, MessagingOperationNameBasicPublish, routingKey, exchange, 0, bodySize, activity);
+                PopulateMessagingTags(MessagingOperationTypeSend, MessagingOperationNameBasicPublish, routingKey, exchange, 0, basicProperties, bodySize, activity);
             }
 
             return activity;

--- a/projects/Test/SequentialIntegration/TestHeartbeats.cs
+++ b/projects/Test/SequentialIntegration/TestHeartbeats.cs
@@ -59,7 +59,7 @@ namespace Test.SequentialIntegration
 
         [SkippableFact(Timeout = 35000)]
         [Trait("Category", "LongRunning")]
-        public async Task TestThatHeartbeatWriterUsesConfigurableInterval()
+        public async Task TestThatHeartbeatWriterUsesConfigurableIntervalAsync()
         {
             Skip.IfNot(LongRunningTestsEnabled(), "RABBITMQ_LONG_RUNNING_TESTS is not set, skipping test");
 
@@ -72,7 +72,7 @@ namespace Test.SequentialIntegration
 
         [SkippableFact]
         [Trait("Category", "LongRunning")]
-        public async Task TestThatHeartbeatWriterWithTLSEnabled()
+        public async Task TestThatHeartbeatWriterWithTLSEnabledAsync()
         {
             Skip.IfNot(LongRunningTestsEnabled(), "RABBITMQ_LONG_RUNNING_TESTS is not set, skipping test");
 
@@ -94,7 +94,7 @@ namespace Test.SequentialIntegration
 
         [SkippableFact(Timeout = 90000)]
         [Trait("Category", "LongRunning")]
-        public async Task TestHundredsOfConnectionsWithRandomHeartbeatInterval()
+        public async Task TestHundredsOfConnectionsWithRandomHeartbeatIntervalAsync()
         {
             Skip.IfNot(LongRunningTestsEnabled(), "RABBITMQ_LONG_RUNNING_TESTS is not set, skipping test");
 


### PR DESCRIPTION
## Proposed Changes

Addresses https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/1849.

Updated the `RabbitMQActivitySource.BasicPublish` method to allow for `IReadOnlyBasicProperties` to be passed in as an additional parameter. This allows the `IReadOnlyBasicProperties` to then be passed along to the `PopulateMessagingTags` method, which adds the `MessageId` as a tag.


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] New feature (non-breaking change which adds functionality - #1849)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq) - I can't get to this link. Is it valid?
- [x] I have added tests that prove my fix is effective or that my feature works

