### PR TITLE
Guard against null when removing ShutdownHandler

### DIFF
--- a/projects/RabbitMQ.Client/client/impl/ModelBase.cs
+++ b/projects/RabbitMQ.Client/client/impl/ModelBase.cs
@@ -681,7 +681,10 @@ namespace RabbitMQ.Client.Impl
                 k.m_consumer = DefaultConsumer;
             }
 
-            ConsumerDispatcher.HandleBasicCancelOk(k.m_consumer, consumerTag);
+            if (!(k.m_consumer is null))
+            {
+                ConsumerDispatcher.HandleBasicCancelOk(k.m_consumer, consumerTag);
+            }
 
             k.HandleCommand(IncomingCommand.Empty); // release the continuation.
         }
@@ -1073,7 +1076,10 @@ namespace RabbitMQ.Client.Impl
                 _consumers.Remove(consumerTag);
             }
 
-            ModelShutdown -= k.m_consumer.HandleModelShutdown;
+            if (!(k.m_consumer is null))
+            {
+                ModelShutdown -= k.m_consumer.HandleModelShutdown;
+            }
         }
 
         public void BasicCancelNoWait(string consumerTag)

--- a/projects/Unit/TestBasicCancelAnyConsumer.cs
+++ b/projects/Unit/TestBasicCancelAnyConsumer.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading;
+using NUnit.Framework;
+using RabbitMQ.Client.Events;
+
+namespace RabbitMQ.Client.Unit
+{
+    [TestFixture]
+    public class TestBasicCancelAnyConsumer : IntegrationFixture
+    {
+        [Test]
+        public void TestBasicCancelWithQueueDelete()
+        {
+            // Arrange
+            Exception modelException = null;
+            Model.CallbackException += HandleCallbackException;
+            Model.QueueDeclare(TestContext.CurrentContext.Test.Name, false, false, false);
+            string consumerTag = Model.BasicConsume(TestContext.CurrentContext.Test.Name, false, new VoidConsumer());
+
+            // Act
+            WithTemporaryModel(m => m.QueueDelete(TestContext.CurrentContext.Test.Name));
+            TestDelegate act = () => Model.BasicCancel(consumerTag);
+
+            // Assert
+            Assert.DoesNotThrow(act);
+            SpinWait.SpinUntil(() => !(modelException is null), TimingFixture.TestTimeout);
+            Assert.IsNull(modelException, "The model has thrown an exception when cancelling a consumer after the queue has been deleted. This exception comes from the scheduling of CancelOk Action.");
+
+            // Cleanup
+            Model.CallbackException -= HandleCallbackException;
+
+            void HandleCallbackException(object sender, CallbackExceptionEventArgs e) => modelException = e.Exception;
+        }
+
+        private sealed class VoidConsumer : DefaultBasicConsumer{}
+    }
+}


### PR DESCRIPTION
## Proposed Changes

Solving Bug #1858 
A race condition occurs when a RabbitMQ client and server simultaneously try to cancel the same consumer. This can happen, for example, if the queue being consumed is deleted on the server at the same moment the client cancels the consumer.

This creates a conflict in ModelBase.cs between the `HandleBasicCancel` and `HandleBasicCancelOk` methods. Both methods attempt to remove the consumer, but they operate differently:
- `HandleBasicCancel` is initiated by the server and directly removes the consumer.
- `HandleBasicCancelOk` is a confirmation from the server for a client-initiated cancellation. It tries to schedule a final action using the consumer object.

If `HandleBasicCancel` executes first, it removes the consumer. When `HandleBasicCancelOk` subsequently runs, it attempts to operate on a consumer that no longer exists, leading to an error when `BasicCancel` tries to remove the Shutdown EventHandler.

The fix for this race condition is relatively straightforward. The solution is to process the cancellation requests on a FCFS basis while adding null checks to ensure that all subsequent methods to execute does not cause an error by trying to access a consumer that has already been removed. (To my Knowlage it is only `HandleBasicCancel` and `HandleBasicCancelOk`)

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #1858)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [?] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)  - I can't get to this link. Is it valid?
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [-] I have added necessary documentation (if appropriate)
- [-] Any dependent changes have been merged and published in related repositories

## Further Comments

-