### PR TITLE
Allow for messages up to the modern RabbitMQ hard upper limit (of 512 MiB)

### DIFF
--- a/projects/RabbitMQ.Client/AmqpTcpEndpoint.cs
+++ b/projects/RabbitMQ.Client/AmqpTcpEndpoint.cs
@@ -78,7 +78,7 @@ namespace RabbitMQ.Client
             _port = portOrMinusOne;
             Ssl = ssl;
             _maxInboundMessageBodySize = Math.Min(maxInboundMessageBodySize,
-                InternalConstants.DefaultRabbitMqMaxInboundMessageBodySize);
+                InternalConstants.MaximumRabbitMqMaxInboundMessageBodySize);
         }
 
         /// <summary>

--- a/projects/RabbitMQ.Client/InternalConstants.cs
+++ b/projects/RabbitMQ.Client/InternalConstants.cs
@@ -41,9 +41,9 @@ namespace RabbitMQ.Client
         /// <summary>
         /// Largest message size, in bytes, allowed in RabbitMQ.        
         /// Note: <code>rabbit.max_message_size</code> setting (https://www.rabbitmq.com/configure.html)
-        /// configures the largest message size which should be lower than this maximum of 128MiB.
+        /// configures the largest message size which should not be higher than this maximum of 512MiB.
         /// </summary>
-        internal const uint DefaultRabbitMqMaxInboundMessageBodySize = 1_048_576 * 128;
+        internal const uint MaximumRabbitMqMaxInboundMessageBodySize = 1_048_576 * 512;
 
         /// <summary>
         /// Largest client provide name, in characters, allowed in RabbitMQ.

--- a/projects/Test/Integration/TestConnectionFactory.cs
+++ b/projects/Test/Integration/TestConnectionFactory.cs
@@ -320,8 +320,8 @@ namespace Test.Integration
         public void TestCreateAmqpTCPEndPointOverridesMaxMessageSizeWhenGreaterThanMaximumAllowed()
         {
             var ep = new AmqpTcpEndpoint("localhost", -1, new SslOption(),
-                2 * InternalConstants.DefaultRabbitMqMaxInboundMessageBodySize);
-            Assert.Equal(InternalConstants.DefaultRabbitMqMaxInboundMessageBodySize, ep.MaxInboundMessageBodySize);
+                2 * InternalConstants.MaximumRabbitMqMaxInboundMessageBodySize);
+            Assert.Equal(InternalConstants.MaximumRabbitMqMaxInboundMessageBodySize, ep.MaxInboundMessageBodySize);
         }
 
         [Fact]


### PR DESCRIPTION
## Proposed Changes

This fixes the bug of not being able to receive messages larger than 128 MiB.

There was a constant `InternalConstants.DefaultRabbitMqMaxInboundMessageBodySize` which was set to 128 MiB.

However, the only usage of this constant is actually as an **upper limit** not a **default**: `Math.Min(maxInboundMessageBodySize, InternalConstants.DefaultRabbitMqMaxInboundMessageBodySize)`

I renamed the constant to **Maximum**RabbitMqMaxInboundMessageBodySize to reflect its actual meaning and changed its value to 512 MiB, which is the correct maximum value for max_message_size according to the [documentation](https://www.rabbitmq.com/docs/next/configure).

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
