### PR TITLE
Add 'contents: read' to workflow permissions to increase the OpenSSF scorecard of the repo

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -3,6 +3,9 @@ name: build/test rabbitmq-dotnet-client
 on:
   - workflow_call
 
+permissions:
+  contents: read
+
 jobs:
   build-win32:
     runs-on: windows-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,9 @@ on:
   schedule:
     - cron: '16 4 * * 4'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,6 +10,9 @@ on:
       - main
       - 'rabbitmq-dotnet-client-*'
 
+permissions:
+  contents: read
+
 jobs:
   call-build-test:
     uses: ./.github/workflows/build-test.yaml

--- a/.github/workflows/oauth2.yaml
+++ b/.github/workflows/oauth2.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build-test:
     strategy:

--- a/.github/workflows/publish-nuget.yaml
+++ b/.github/workflows/publish-nuget.yaml
@@ -6,6 +6,9 @@ on:
       NUGET_API_KEY:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   publish-nuget:
     runs-on: windows-latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,6 +6,9 @@ on:
       # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
       - published
 
+permissions:
+  contents: read
+
 jobs:
   call-build-test:
     uses: ./.github/workflows/build-test.yaml


### PR DESCRIPTION
## Proposed Changes

These changes are being introduced to increase the repository's score that is calculated by the [OpenSSF Scorecard](https://openssf.org/projects/scorecard/) ([GitHub repo](https://github.com/ossf/scorecard)) tool.

This Pull Request updates the top-level permissions configuration within repo's GitHub workflows. It sets the default contents permission to read for the workflow token. The changes were done according to the [recommendations](https://github.com/ossf/scorecard/blob/40bbc9c958aa66327fb026b2136f1951298ca0f8/docs/checks.md#token-permissions) from Scorecard regarding the token permissions and the [discussion](https://github.com/rabbitmq/rabbitmq-dotnet-client/discussions/1877) of this repository.

## Types of Changes

Marked it as Other, but it is not the best choice. I would appreciate a recommendation regarding the right type.

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [x] Other

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
