### PR TITLE
Added TryComplete instead of comple during channel shutdown

### DIFF
--- a/projects/RabbitMQ.Client/ConsumerDispatching/ConsumerDispatcherChannelBase.cs
+++ b/projects/RabbitMQ.Client/ConsumerDispatching/ConsumerDispatcherChannelBase.cs
@@ -228,7 +228,7 @@ namespace RabbitMQ.Client.ConsumerDispatching
 
         protected override Task InternalShutdownAsync()
         {
-            _writer.Complete();
+            _writer.TryComplete();
             return _worker;
         }
 


### PR DESCRIPTION
## Proposed Changes

Change from Threading.Channel.Complete() to TryComplete() to catch any race conditions. Race condition can occur if another thread already have called complete on this channel. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bug fix for #1884 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

