### PR TITLE
Update `ExchangeType` to include more core and tier 1 plugin-provided types

### DIFF
--- a/projects/RabbitMQ.Client/ExchangeType.cs
+++ b/projects/RabbitMQ.Client/ExchangeType.cs
@@ -64,7 +64,39 @@ namespace RabbitMQ.Client
         /// </summary>
         public const string Topic = "topic";
 
-        private static readonly string[] s_all = { Fanout, Direct, Topic, Headers };
+        /// <summary>
+        /// Exchange type used for consistent hash exchanges.
+        /// </summary>
+        /// <remarks>
+        /// Requires the <c>rabbitmq_consistent_hash_exchange</c> plugin to be enabled.
+        /// </remarks>
+        public const string ConsistentHash = "x-consistent-hash";
+
+        /// <summary>
+        /// Exchange type used for local random exchanges.
+        /// </summary>
+        /// <remarks>
+        /// Available in RabbitMQ 4.2.0 and later.
+        /// </remarks>
+        public const string LocalRandom = "x-local-random";
+
+        /// <summary>
+        /// Exchange type used for modulus hash exchanges.
+        /// </summary>
+        /// <remarks>
+        /// Available in RabbitMQ 4.3.0 and later.
+        /// </remarks>
+        public const string ModulusHash = "x-modulus-hash";
+
+        /// <summary>
+        /// Exchange type used for random exchanges.
+        /// </summary>
+        /// <remarks>
+        /// Requires the <c>rabbitmq_random_exchange</c> plugin to be enabled.
+        /// </remarks>
+        public const string Random = "x-random";
+
+        private static readonly string[] s_all = { Fanout, Direct, Topic, Headers, ConsistentHash, LocalRandom, ModulusHash, Random };
 
         /// <summary>
         /// Retrieve a collection containing all standard exchange types.

--- a/projects/RabbitMQ.Client/PublicAPI/PublicAPI.Unshipped.net8.0.txt
+++ b/projects/RabbitMQ.Client/PublicAPI/PublicAPI.Unshipped.net8.0.txt
@@ -1,0 +1,4 @@
+const RabbitMQ.Client.ExchangeType.ConsistentHash = "x-consistent-hash" -> string
+const RabbitMQ.Client.ExchangeType.LocalRandom = "x-local-random" -> string
+const RabbitMQ.Client.ExchangeType.ModulusHash = "x-modulus-hash" -> string
+const RabbitMQ.Client.ExchangeType.Random = "x-random" -> string

--- a/projects/RabbitMQ.Client/PublicAPI/PublicAPI.Unshipped.netstandard2.0.txt
+++ b/projects/RabbitMQ.Client/PublicAPI/PublicAPI.Unshipped.netstandard2.0.txt
@@ -1,0 +1,4 @@
+const RabbitMQ.Client.ExchangeType.ConsistentHash = "x-consistent-hash" -> string
+const RabbitMQ.Client.ExchangeType.LocalRandom = "x-local-random" -> string
+const RabbitMQ.Client.ExchangeType.ModulusHash = "x-modulus-hash" -> string
+const RabbitMQ.Client.ExchangeType.Random = "x-random" -> string


### PR DESCRIPTION
`x-modulus-hash` is an built-in exchange type as of RabbitMQ `4.3.0`.