### PR TITLE
Close write-loop channel on crash to unblock publishers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.claude/
 *.orig
 *.log
 _site/

--- a/projects/RabbitMQ.Client/Impl/SocketFrameHandler.cs
+++ b/projects/RabbitMQ.Client/Impl/SocketFrameHandler.cs
@@ -175,7 +175,13 @@ namespace RabbitMQ.Client.Impl
                     .ConfigureAwait(false);
                 try
                 {
-                    _channelWriter.Complete();
+                    // TryComplete rather than Complete: WriteLoopAsync may have
+                    // already completed the writer with an exception (see
+                    // issue #1930). Complete() would throw InvalidOperationException
+                    // in that race, the outer catch would swallow it, and
+                    // `await _writerTask` below would be skipped, leaving the
+                    // write-loop exception unobserved.
+                    _channelWriter.TryComplete();
                     if (_writerTask != null)
                     {
                         await _writerTask.ConfigureAwait(false);

--- a/projects/RabbitMQ.Client/Impl/SocketFrameHandler.cs
+++ b/projects/RabbitMQ.Client/Impl/SocketFrameHandler.cs
@@ -313,15 +313,16 @@ namespace RabbitMQ.Client.Impl
                 // TryComplete rather than Complete: CloseAsync may have raced
                 // us and already completed the channel.
                 _channelWriter.TryComplete(ex);
-
+                throw;
+            }
+            finally
+            {
                 // Drain any leftover frames so their pooled buffers return to
                 // the array pool rather than waiting for GC.
                 while (_channelReader.TryRead(out OutgoingFrame leftover))
                 {
                     leftover.Dispose();
                 }
-
-                throw;
             }
         }
     }

--- a/projects/RabbitMQ.Client/Impl/SocketFrameHandler.cs
+++ b/projects/RabbitMQ.Client/Impl/SocketFrameHandler.cs
@@ -240,16 +240,31 @@ namespace RabbitMQ.Client.Impl
             return WriteAsyncCore(frames, cancellationToken);
         }
 
-        private async ValueTask WriteAsyncCore(OutgoingFrame frames, CancellationToken cancellationToken)
+        private ValueTask WriteAsyncCore(OutgoingFrame frames, CancellationToken cancellationToken)
         {
-            try
+            ValueTask writeTask = _channelWriter.WriteAsync(frames, cancellationToken);
+            if (writeTask.IsCompletedSuccessfully)
             {
-                await _channelWriter.WriteAsync(frames, cancellationToken).ConfigureAwait(false);
+                return default;
             }
-            catch
+
+            // The channel accepted the frame asynchronously, or it rejected the
+            // write (e.g. because WriteLoopAsync completed the writer with an
+            // exception). In the rejection case `frames` never reached the
+            // reader, so this method owns the dispose. See issue #1930.
+            return AwaitAndDisposeOnFault(writeTask, frames);
+
+            static async ValueTask AwaitAndDisposeOnFault(ValueTask task, OutgoingFrame frames)
             {
-                frames.Dispose();
-                throw;
+                try
+                {
+                    await task.ConfigureAwait(false);
+                }
+                catch
+                {
+                    frames.Dispose();
+                    throw;
+                }
             }
         }
 
@@ -281,14 +296,26 @@ namespace RabbitMQ.Client.Impl
             catch (Exception ex)
             {
                 ESLog.Error("Background socket write loop has crashed", ex);
-                throw;
-            }
-            finally
-            {
+
+                // Fail both already-blocked and subsequent WriteAsync callers
+                // with ChannelClosedException(innerException: ex). Without
+                // this, producers block indefinitely on a full channel whose
+                // reader has died, and any holder of a publisher-confirm
+                // semaphore (Channel.BasicPublish.cs) blocks the shutdown
+                // handler in turn. See issue #1930.
+                //
+                // TryComplete rather than Complete: CloseAsync may have raced
+                // us and already completed the channel.
+                _channelWriter.TryComplete(ex);
+
+                // Drain any leftover frames so their pooled buffers return to
+                // the array pool rather than waiting for GC.
                 while (_channelReader.TryRead(out OutgoingFrame leftover))
                 {
                     leftover.Dispose();
                 }
+
+                throw;
             }
         }
     }

--- a/projects/RabbitMQ.Client/Impl/SocketFrameHandler.cs
+++ b/projects/RabbitMQ.Client/Impl/SocketFrameHandler.cs
@@ -252,9 +252,9 @@ namespace RabbitMQ.Client.Impl
             // write (e.g. because WriteLoopAsync completed the writer with an
             // exception). In the rejection case `frames` never reached the
             // reader, so this method owns the dispose. See issue #1930.
-            return AwaitAndDisposeOnFault(writeTask, frames);
+            return AwaitAndDisposeOnException(writeTask, frames);
 
-            static async ValueTask AwaitAndDisposeOnFault(ValueTask task, OutgoingFrame frames)
+            static async ValueTask AwaitAndDisposeOnException(ValueTask task, OutgoingFrame frames)
             {
                 try
                 {


### PR DESCRIPTION
Fixes #1930.

When the background write loop in `SocketFrameHandler` crashes on a socket failure, the bounded `Channel<RentedMemory>` was left open, leaving any subsequent producer blocked indefinitely on a full channel whose reader had died. With publisher confirms enabled this deadlocked the shutdown handler, because the holder of the publisher-confirm semaphore was a blocked publisher.

On write-loop failure, `TryComplete` the channel with the exception. Pending and future `WriteAsync` callers see a
`ChannelClosedException` whose `InnerException` is the socket fault, and release the publisher-confirm semaphore promptly, letting shutdown and recovery proceed. Any frames still buffered in the channel when the loop exits are drained and disposed so their pooled buffers return to `ArrayPool`.

Also dispose the caller's `RentedMemory` when
`_channelWriter.WriteAsync` faults (post-completion). Previously the struct was lost along with its pooled array. The hot path stays allocation-free.