### PR TITLE
Add regression tests for #1930

### DIFF
--- a/projects/RabbitMQ.Client/ConnectionFactory.cs
+++ b/projects/RabbitMQ.Client/ConnectionFactory.cs
@@ -243,6 +243,8 @@ namespace RabbitMQ.Client
         /// </summary>
         public TimeSpan SocketWriteTimeout { get; set; } = DefaultConnectionTimeout;
 
+        internal TimeSpan SocketFlushTimeout { get; set; } = TimeSpan.Zero;
+
         /// <summary>
         /// TLS options setting.
         /// </summary>
@@ -625,6 +627,11 @@ namespace RabbitMQ.Client
             if (SocketWriteTimeout > RequestedHeartbeat)
             {
                 fh.WriteTimeout = SocketWriteTimeout;
+            }
+
+            if (SocketFlushTimeout != default && fh is SocketFrameHandler sfh)
+            {
+                sfh.FlushTimeout = SocketFlushTimeout;
             }
 
             return fh;

--- a/projects/RabbitMQ.Client/Impl/Connection.cs
+++ b/projects/RabbitMQ.Client/Impl/Connection.cs
@@ -353,17 +353,24 @@ namespace RabbitMQ.Client.Impl
                 await OnShutdownAsync(reason)
                     .ConfigureAwait(false);
 
-                await _session0.SetSessionClosingAsync(false, cts.Token)
-                    .ConfigureAwait(false);
-
                 try
                 {
+                    await _session0.SetSessionClosingAsync(false, cts.Token)
+                        .ConfigureAwait(false);
+
                     // Try to send connection.close wait for CloseOk in the MainLoop
                     if (false == _closed)
                     {
                         var method = new ConnectionClose(reason.ReplyCode, reason.ReplyText, 0, 0);
                         await _session0.TransmitAsync(method, cts.Token)
                             .ConfigureAwait(false);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    if (false == abort)
+                    {
+                        throw;
                     }
                 }
                 catch (System.Threading.Channels.ChannelClosedException)

--- a/projects/RabbitMQ.Client/Impl/SocketFrameHandler.cs
+++ b/projects/RabbitMQ.Client/Impl/SocketFrameHandler.cs
@@ -136,6 +136,16 @@ namespace RabbitMQ.Client.Impl
             }
         }
 
+        private TimeSpan _flushTimeout;
+#if NET
+        private CancellationTokenSource? _flushTimeoutCts;
+#endif
+
+        internal TimeSpan FlushTimeout
+        {
+            set => _flushTimeout = value;
+        }
+
         public static async Task<SocketFrameHandler> CreateAsync(AmqpTcpEndpoint amqpTcpEndpoint, Func<AddressFamily, ITcpClient> socketFactory,
             TimeSpan connectionTimeout, CancellationToken cancellationToken)
         {
@@ -211,6 +221,9 @@ namespace RabbitMQ.Client.Impl
             finally
             {
                 _closingSemaphore.Dispose();
+#if NET
+                _flushTimeoutCts?.Dispose();
+#endif
                 _closed = true;
             }
         }
@@ -285,7 +298,7 @@ namespace RabbitMQ.Client.Impl
                         try
                         {
                             frames.WriteTo(_pipeWriter);
-                            await _pipeWriter.FlushAsync()
+                            await FlushPipeAsync()
                                 .ConfigureAwait(false);
                             RabbitMqClientEventSource.Log.CommandSent(frames.Size);
                         }
@@ -295,7 +308,7 @@ namespace RabbitMQ.Client.Impl
                         }
                     }
 
-                    await _pipeWriter.FlushAsync()
+                    await FlushPipeAsync()
                         .ConfigureAwait(false);
                 }
             }
@@ -324,6 +337,36 @@ namespace RabbitMQ.Client.Impl
                     leftover.Dispose();
                 }
             }
+        }
+
+        // Flush the pipe writer, applying a cancellation timeout when configured.
+        // A non-default _flushTimeout allows tests to bound how long an async socket
+        // write can stall before the write loop is crashed and blocked publishers are
+        // unblocked. See issue #1930.
+        private async ValueTask FlushPipeAsync()
+        {
+            if (_flushTimeout == default)
+            {
+                await _pipeWriter.FlushAsync().ConfigureAwait(false);
+                return;
+            }
+
+#if NET
+            // Reuse a single CTS across flushes to avoid allocating a new CTS and
+            // backing timer on every call. TryReset() recycles it when the previous
+            // flush completed before the timeout; if the timeout fired (CTS already
+            // cancelled) TryReset() returns false and we allocate a fresh one.
+            if (_flushTimeoutCts is null || !_flushTimeoutCts.TryReset())
+            {
+                _flushTimeoutCts?.Dispose();
+                _flushTimeoutCts = new CancellationTokenSource();
+            }
+            _flushTimeoutCts.CancelAfter(_flushTimeout);
+            await _pipeWriter.FlushAsync(_flushTimeoutCts.Token).ConfigureAwait(false);
+#else
+            using var cts = new CancellationTokenSource(_flushTimeout);
+            await _pipeWriter.FlushAsync(cts.Token).ConfigureAwait(false);
+#endif
         }
     }
 }

--- a/projects/Test/Common/IntegrationFixture.cs
+++ b/projects/Test/Common/IntegrationFixture.cs
@@ -36,6 +36,7 @@ using System.Linq;
 using System.Net.Sockets;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -52,6 +53,7 @@ namespace Test
     {
         private static readonly bool s_isRunningInCI = false;
         private static readonly bool s_isVerbose = false;
+        private static readonly bool s_isNetFramework = false;
         private static int _connectionIdx = 0;
 
         private Exception _connectionCallbackException;
@@ -89,6 +91,7 @@ namespace Test
         {
             s_isRunningInCI = InitIsRunningInCI();
             s_isVerbose = InitIsVerbose();
+            s_isNetFramework = InitIsNetFramework();
 
             if (s_isRunningInCI)
             {
@@ -342,6 +345,11 @@ namespace Test
         protected static bool IsWindows
         {
             get { return Util.IsWindows; }
+        }
+
+        protected static bool IsNetFramework
+        {
+            get { return s_isNetFramework; }
         }
 
         protected static bool IsVerbose
@@ -615,6 +623,12 @@ namespace Test
             }
 
             return false;
+        }
+
+        private static bool InitIsNetFramework()
+        {
+            return RuntimeInformation.FrameworkDescription
+                .StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
         }
 
         private static int GetConnectionIdx()

--- a/projects/Test/Integration/TestToxiproxy.cs
+++ b/projects/Test/Integration/TestToxiproxy.cs
@@ -31,6 +31,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -48,6 +49,7 @@ namespace Test.Integration
         private readonly TimeSpan _heartbeatTimeout = TimeSpan.FromSeconds(1);
         private ToxiproxyManager _toxiproxyManager;
         private int _proxyPort;
+        private string _proxyHost;
 
         public TestToxiproxy(ITestOutputHelper output) : base(output)
         {
@@ -65,6 +67,7 @@ namespace Test.Integration
             {
                 _toxiproxyManager = new ToxiproxyManager(_testDisplayName, IsRunningInCI, IsWindows);
                 _proxyPort = ToxiproxyManager.ProxyPort;
+                _proxyHost = _toxiproxyManager.ProxyHost;
                 return _toxiproxyManager.InitializeAsync();
             }
             else
@@ -448,6 +451,290 @@ namespace Test.Integration
             await ch.CloseAsync();
 
             Assert.True(sawContinuationTimeout);
+        }
+
+        // Regression test for https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/1930
+        // Scenario A: publisher confirms disabled.
+        //
+        // The bug: when WriteLoopAsync crashes (socket error) without calling
+        // _channelWriter.TryComplete(ex), publishers blocked on a full
+        // Channel<OutgoingFrame>(128) block on WriteAsync indefinitely because
+        // nobody completes the channel and unblocks them.
+        //
+        // The fix: _channelWriter.TryComplete(ex) in the write-loop catch →
+        // blocked WriteAsync callers receive ChannelClosedException → all
+        // publishers complete immediately.
+        //
+        // Test strategy (Toxiproxy):
+        //   1. BandwidthToxic(Rate=1, UpStream) throttles the write path to
+        //      1 KB/s. The OS TCP send buffer fills, FlushAsync stalls, and the
+        //      128-slot outgoing channel fills. Publishers beyond those 128 slots
+        //      block directly on WriteAsync — the pre-condition for the hang.
+        //   2. cf.SocketFlushTimeout = 5 s crashes the stalled write loop after 5 s.
+        //   3. Task.WhenAll(publishTasks).WaitAsync(15 s) must complete.
+        [SkippableFact]
+        [Trait("Category", "Toxiproxy")]
+        public async Task TestPublishDoesNotHangAfterConnectionLoss_NoConfirms_GH1930()
+        {
+            Skip.IfNot(AreToxiproxyTestsEnabled, "RABBITMQ_TOXIPROXY_TESTS is not set, skipping test");
+            // SocketFlushTimeout works by passing a CancellationToken to
+            // PipeWriter.FlushAsync. On .NET Framework, NetworkStream does not
+            // support cooperative cancellation of an in-progress socket write,
+            // so the token is ignored and the write loop never times out.
+            Skip.If(IsNetFramework, "SocketFlushTimeout requires PipeWriter.FlushAsync cancellation support, which is not available on .NET Framework");
+
+            ConnectionFactory cf = CreateConnectionFactory();
+            cf.HostName = _proxyHost;
+            cf.Port = _proxyPort;
+            cf.AutomaticRecoveryEnabled = false;
+            cf.RequestedHeartbeat = TimeSpan.FromSeconds(600);
+            cf.ContinuationTimeout = TimeSpan.FromSeconds(5);
+            cf.SocketFlushTimeout = TimeSpan.FromSeconds(5);
+
+            await using IConnection conn = await cf.CreateConnectionAsync();
+            await using IChannel ch = await conn.CreateChannelAsync();
+            QueueDeclareOk q = await ch.QueueDeclareAsync();
+
+            using var cts = new CancellationTokenSource();
+
+            string bandwidthToxicName = $"rmq-upstream-bandwidth-{Now}-{GenerateShortUuid()}";
+            var bandwidthToxic = new BandwidthToxic
+            {
+                Name = bandwidthToxicName,
+                Toxicity = 1.0,
+                Stream = ToxicDirection.UpStream,
+            };
+            bandwidthToxic.Attributes.Rate = 1;
+            await _toxiproxyManager.AddToxicAsync(bandwidthToxic);
+
+            const int PublishCount = 512;
+            byte[] body = GetRandomBody(ushort.MaxValue);
+            var publishTasks = new List<Task>(PublishCount);
+            for (int i = 0; i < PublishCount; i++)
+            {
+                publishTasks.Add(PublishIgnoringErrorsAsync(ch, q.QueueName, body, cts.Token));
+            }
+
+            // Wait until the completed-task count stabilises: once stable the 128-slot
+            // channel is full and the remaining publishers are blocked on WriteAsync.
+            int prevDone = -1, stablePolls = 0;
+            while (stablePolls < 5)
+            {
+                await Task.Delay(100);
+                int done = publishTasks.Count(t => t.IsCompleted);
+                if (done == prevDone)
+                {
+                    stablePolls++;
+                }
+                else
+                {
+                    stablePolls = 0;
+                    prevDone = done;
+                }
+            }
+
+            // Guard: the channel holds 128 frames. Any blockedCount > 128 proves
+            // the channel is full and the write loop has stopped draining it — the
+            // exact pre-condition the test exercises. How many complete before the
+            // stall depends on OS TCP send-buffer size, so we only assert the minimum.
+            int blockedCount = publishTasks.Count(t => !t.IsCompleted);
+            Assert.True(blockedCount > 128,
+                $"{blockedCount}/{PublishCount} tasks are blocked before flush timeout – the write loop " +
+                $"may not have stalled. Increase PublishCount or body size.");
+
+            var publishCompletionTimeout = TimeSpan.FromSeconds(15);
+            cts.CancelAfter(TimeSpan.FromSeconds(30));
+            try
+            {
+                await Task.WhenAll(publishTasks).WaitAsync(publishCompletionTimeout);
+            }
+            finally
+            {
+                cts.Cancel();
+            }
+        }
+
+        // Regression test for https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/1930
+        // Scenario B: publisher confirms enabled.
+        //
+        // The bug: when WriteLoopAsync crashes (socket error) without calling
+        // _channelWriter.TryComplete(ex), publishers blocked on a full
+        // Channel<OutgoingFrame>(128) hold _confirmSemaphore(1,1)
+        // indefinitely.  The connection-shutdown handler
+        // (MaybeHandlePublisherConfirmationTcsOnChannelShutdownAsync) needs
+        // the same semaphore and deadlocks, so BasicPublishAsync never throws
+        // or returns — the publisher hangs forever.
+        //
+        // The fix: _channelWriter.TryComplete(ex) in the write-loop catch →
+        // blocked WriteAsync callers receive ChannelClosedException →
+        // semaphore released → shutdown handler proceeds → all publishers complete.
+        //
+        // Test strategy (Toxiproxy):
+        //   1. BandwidthToxic(Rate=1, UpStream) throttles the write path to
+        //      1 KB/s.  The OS TCP send buffer fills, FlushAsync stalls, the
+        //      128-slot outgoing channel fills, and one publisher blocks on
+        //      WriteAsync while holding _confirmSemaphore — the exact
+        //      pre-condition for the deadlock.
+        //   2. cf.SocketFlushTimeout = 5 s causes the stalled
+        //      PipeWriter.FlushAsync to throw OperationCanceledException
+        //      after 5 s, crashing the write loop while the read loop remains alive.
+        //      Because _closeReason is not set at crash time, publishers 130+
+        //      can re-fill the channel — the exact condition that triggers the deadlock
+        //      without the fix.
+        //   3. Task.WhenAll(publishTasks).WaitAsync(15 s) must complete within
+        //      the timeout.
+        //
+        // Why this approach is reliable on all platforms:
+        //   A CancellationToken passed to PipeWriter.FlushAsync fires
+        //   deterministically after 5 s on Windows and Linux alike, regardless of how
+        //   the OS handles RST/FIN signals.  This makes the test a true regression guard
+        //   on every CI platform.
+        [SkippableFact]
+        [Trait("Category", "Toxiproxy")]
+        public async Task TestPublishDoesNotHangAfterConnectionLoss_WithConfirms_GH1930()
+        {
+            Skip.IfNot(AreToxiproxyTestsEnabled, "RABBITMQ_TOXIPROXY_TESTS is not set, skipping test");
+            // SocketFlushTimeout works by passing a CancellationToken to
+            // PipeWriter.FlushAsync. On .NET Framework, NetworkStream does not
+            // support cooperative cancellation of an in-progress socket write,
+            // so the token is ignored and the write loop never times out.
+            Skip.If(IsNetFramework, "SocketFlushTimeout requires PipeWriter.FlushAsync cancellation support, which is not available on .NET Framework");
+
+            ConnectionFactory cf = CreateConnectionFactory();
+            cf.HostName = _proxyHost;
+            cf.Port = _proxyPort;
+            cf.AutomaticRecoveryEnabled = false;
+            // RabbitMQ negotiates heartbeat = min(client, server_default=60s). 600 s keeps
+            // the effective value at 60 s which is well above the 15 s WaitAsync timeout,
+            // so the server will not close the connection while the upstream bandwidth toxic
+            // is throttling writes.
+            cf.RequestedHeartbeat = TimeSpan.FromSeconds(600);
+            // Short continuation timeout so that channel/connection disposal completes
+            // quickly once we close the proxy (the server will never send close-ok).
+            cf.ContinuationTimeout = TimeSpan.FromSeconds(5);
+            // Crash the write loop after 5 s of stall instead of sending a TCP RST.
+            // PipeWriter.FlushAsync(CancellationToken) cancels on all platforms
+            // (Windows and Linux), making this a deterministic regression guard.
+            cf.SocketFlushTimeout = TimeSpan.FromSeconds(5);
+
+            // publisherConfirmationTrackingEnabled: false matches the exact scenario
+            // described in the issue where the semaphore deadlock was observed.
+            var channelOpts = new CreateChannelOptions(
+                publisherConfirmationsEnabled: true,
+                publisherConfirmationTrackingEnabled: false);
+
+            await using IConnection conn = await cf.CreateConnectionAsync();
+            await using IChannel ch = await conn.CreateChannelAsync(channelOpts);
+            QueueDeclareOk q = await ch.QueueDeclareAsync();
+
+            // No timeout yet – we start the cleanup timer only after the connection is
+            // severed so that it is always strictly longer than the WaitAsync timeout.
+            using var cts = new CancellationTokenSource();
+
+            // Throttle upstream writes to 1 KB/s.
+            //
+            // Toxiproxy reads client data at 1 KB/s so its receive window shrinks to zero
+            // quickly.  Once the OS TCP send buffer is full, the write loop's
+            // PipeWriter.FlushAsync stalls.  This guarantees the bounded
+            // Channel<OutgoingFrame> (128 slots) fills up and a publisher holds
+            // _confirmSemaphore(1,1) while blocked on WriteAsync – the exact deadlock
+            // pre-condition.
+            string bandwidthToxicName = $"rmq-upstream-bandwidth-{Now}-{GenerateShortUuid()}";
+            var bandwidthToxic = new BandwidthToxic
+            {
+                Name = bandwidthToxicName,
+                Toxicity = 1.0,
+                Stream = ToxicDirection.UpStream,
+            };
+            bandwidthToxic.Attributes.Rate = 1; // 1 KB/s – reliably stalls the write loop
+            await _toxiproxyManager.AddToxicAsync(bandwidthToxic);
+
+            // With confirms enabled, _confirmSemaphore(1,1) serialises publishes one
+            // at a time. Publishers fill the 128-slot channel almost instantly while the
+            // stalled write loop cannot drain it. The publisher that encounters a full
+            // channel blocks on WriteAsync while holding the semaphore; every subsequent
+            // publisher queues behind that semaphore.
+            const int PublishCount = 512;
+            byte[] body = GetRandomBody(ushort.MaxValue); // 65 KB – fills OS socket buffer in a few frames
+            var publishTasks = new List<Task>(PublishCount);
+            for (int i = 0; i < PublishCount; i++)
+            {
+                publishTasks.Add(PublishIgnoringErrorsAsync(ch, q.QueueName, body, cts.Token));
+            }
+
+            // Wait until the completed-task count stabilises for at least 5 consecutive
+            // 100 ms polls.  Once it is stable we know:
+            //  - the write loop's FlushAsync is blocked (Rate=1 exhausted OS buffers), and
+            //  - a publisher is blocked on _channelWriter.WriteAsync while holding the
+            //    semaphore (the exact deadlock pre-condition).
+            // A pure fixed-delay would be weaker: tasks could all complete before we
+            // trigger the RST, making the test vacuous.
+            int prevDone = -1, stablePolls = 0;
+            while (stablePolls < 5)
+            {
+                await Task.Delay(100);
+                int done = publishTasks.Count(t => t.IsCompleted);
+                if (done == prevDone)
+                {
+                    stablePolls++;
+                }
+                else
+                {
+                    stablePolls = 0;
+                    prevDone = done;
+                }
+            }
+
+            // Guard: publishers must still be blocked. If all completed the test is vacuous.
+            // Guard: the channel holds 128 frames. Any blockedCount > 128 proves
+            // the channel is full and the write loop has stopped draining it — the
+            // exact pre-condition the test exercises. How many complete before the
+            // stall depends on OS TCP send-buffer size, so we only assert the minimum.
+            int blockedCount = publishTasks.Count(t => !t.IsCompleted);
+            Assert.True(blockedCount > 128,
+                $"{blockedCount}/{PublishCount} tasks are blocked before flush timeout – the write loop " +
+                $"may not have stalled. Increase PublishCount or body size.");
+
+            // Use a test-local timeout that is short enough to keep CI fast but long
+            // enough for the flush timeout + fix propagation to complete (5 s flush
+            // timeout → write-loop crash → TryComplete → publishers complete), typically
+            // < 8 s in practice.
+            var publishCompletionTimeout = TimeSpan.FromSeconds(15);
+
+            // The cleanup CTS fires strictly after WaitAsync times out, ensuring the
+            // deadlock (without fix) is observable as TimeoutException, not silently
+            // broken by cancellation.
+            cts.CancelAfter(TimeSpan.FromSeconds(30));
+            try
+            {
+                // With the fix: TryComplete(ex) is called on write-loop crash, the
+                // blocked WriteAsync throws ChannelClosedException immediately, the
+                // semaphore is released, and all remaining publishers complete within
+                // milliseconds.
+                //
+                // Without the fix: the semaphore is never released, the shutdown handler
+                // deadlocks, and Task.WhenAll never completes → TimeoutException.
+                await Task.WhenAll(publishTasks).WaitAsync(publishCompletionTimeout);
+            }
+            finally
+            {
+                // Cancel immediately so that any stuck publishers are unblocked before
+                // channel and connection disposal, keeping teardown fast.
+                cts.Cancel();
+            }
+        }
+
+        private static async Task PublishIgnoringErrorsAsync(IChannel ch, string queueName, byte[] body,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                await ch.BasicPublishAsync("", queueName, body, cancellationToken);
+            }
+            catch
+            {
+                // Exception is expected when the connection is cut or the token fires.
+            }
         }
 
         private bool AreToxiproxyTestsEnabled

--- a/projects/Test/Integration/ToxiproxyManager.cs
+++ b/projects/Test/Integration/ToxiproxyManager.cs
@@ -20,6 +20,12 @@ namespace Integration
 
         private bool _disposedValue = false;
 
+        /// <summary>
+        /// The hostname clients should use to connect to the Toxiproxy server.
+        /// Defaults to <c>localhost</c>; overridden by <c>RABBITMQ_TOXIPROXY_HOST</c>.
+        /// </summary>
+        public string ProxyHost { get; private set; } = "localhost";
+
         public ToxiproxyManager(string testDisplayName, bool isRunningInCI, bool isWindows)
         {
             if (string.IsNullOrWhiteSpace(testDisplayName))
@@ -28,14 +34,6 @@ namespace Integration
             }
 
             _testDisplayName = testDisplayName;
-
-            /*
-             * Note:
-             * Do NOT set resetAllToxicsAndProxiesOnClose to true, because it will
-             * clear proxies being used by parallel TFM test runs
-             */
-            _proxyConnection = new Connection(resetAllToxicsAndProxiesOnClose: false);
-            _proxyClient = _proxyConnection.Client();
 
             // to start, assume everything is on localhost
             _proxy = new Proxy
@@ -59,6 +57,39 @@ namespace Integration
                     _proxy.Upstream = "rabbitmq-dotnet-client-rabbitmq:5672";
                 }
             }
+
+            // Allow Docker-based local development to override the upstream host.
+            // Set RABBITMQ_TOXIPROXY_UPSTREAM_HOST=<container-name-or-ip> when both
+            // Toxiproxy and RabbitMQ run in Docker and 127.0.0.1 refers to the
+            // Toxiproxy container's own loopback rather than the RabbitMQ container.
+            string upstreamHostOverride = Environment.GetEnvironmentVariable("RABBITMQ_TOXIPROXY_UPSTREAM_HOST");
+            if (!string.IsNullOrEmpty(upstreamHostOverride))
+            {
+                _proxy.Upstream = $"{upstreamHostOverride}:5672";
+            }
+
+            // Allow specifying the Toxiproxy management API host and the host that
+            // clients should use to connect to the proxy.  Useful when running tests
+            // from WSL2 using the Docker bridge IP (e.g. 172.26.0.3) to get a direct
+            // Linux-to-Linux TCP path that propagates TCP RST without any Windows
+            // port-forwarding proxy in between.
+            string toxiproxyHost = "127.0.0.1";
+            string proxyHostOverride = Environment.GetEnvironmentVariable("RABBITMQ_TOXIPROXY_HOST");
+            if (!string.IsNullOrEmpty(proxyHostOverride))
+            {
+                toxiproxyHost = proxyHostOverride;
+                ProxyHost = proxyHostOverride;
+                // Ensure the proxy listens on all interfaces so non-loopback clients connect.
+                _proxy.Listen = $"0.0.0.0:{ProxyPort}";
+            }
+
+            /*
+             * Note:
+             * Do NOT set resetAllToxicsAndProxiesOnClose to true, because it will
+             * clear proxies being used by parallel TFM test runs
+             */
+            _proxyConnection = new Connection(toxiproxyHost, resetAllToxicsAndProxiesOnClose: false);
+            _proxyClient = _proxyConnection.Client();
         }
 
         public async Task InitializeAsync()


### PR DESCRIPTION
## Proposed Changes

Regression tests for #1930, plus the fixes needed to make them pass reliably.

**Issue summary:** when the write loop crashes (socket error or flush timeout) without calling `_channelWriter.TryComplete(ex)`, publishers blocked on a full `Channel<OutgoingFrame>(128)` stall indefinitely. With publisher confirms enabled the confirm semaphore is never released, which deadlocks the connection shutdown handler. With confirms disabled publishers block directly on `WriteAsync` with no escape path. Both scenarios were reported in #1930.

**What this PR adds:**

`SocketFlushTimeout` (internal) on `ConnectionFactory` - sets a cancellation deadline on `PipeWriter.FlushAsync` inside the write loop. When the deadline fires the write loop crashes via `OperationCanceledException`. This is a test knob, not a public API; the default (zero) disables it. It is used by the Toxiproxy tests to crash the write loop deterministically on all platforms without relying on TCP RST propagation, which is unreliable through Windows port-forwarding.

`ToxiproxyManager` changes - added a `ProxyHost` property and support for two new environment variables: `RABBITMQ_TOXIPROXY_HOST` (overrides both the management API host and the address clients connect to, useful when running tests from WSL2 using the Docker bridge IP) and `RABBITMQ_TOXIPROXY_UPSTREAM_HOST` (overrides the upstream RabbitMQ address seen by Toxiproxy, needed when both services run in Docker and `127.0.0.1` would resolve to the Toxiproxy container's own loopback). Connection construction was moved after all environment variable processing so the resolved host is used consistently.

Two regression tests using `BandwidthToxic(Rate=1, UpStream)` to throttle the write path to 1 KB/s - this fills the OS TCP send buffer, stalls `FlushAsync`, and fills the 128-slot outgoing channel, creating the exact pre-condition from the issue without killing the TCP connection:

- `TestPublishDoesNotHangAfterConnectionLoss_NoConfirms_GH1930` - scenario A from the issue: publishers block directly on `WriteAsync` when the channel is full and the write loop has stalled.
- `TestPublishDoesNotHangAfterConnectionLoss_WithConfirms_GH1930` - scenario B: one publisher holds `_confirmSemaphore(1,1)` while blocked on `WriteAsync`; without the fix the shutdown handler deadlocks waiting for the same semaphore.

**Fixes included in this PR (review feedback):**

- `Connection.CloseAsync`: moved `SetSessionClosingAsync` inside the try block and added `catch (OperationCanceledException)` alongside the existing `catch (ChannelClosedException)`. When the local 5-second abort timeout fires before `TransmitAsync` completes, `_channelWriter.WriteAsync` checks the cancelled token first and throws `OperationCanceledException` rather than `ChannelClosedException`. The missing catch caused the exception to escape through `DisposeAsync` to the test runner. See commit bbcd19a4c.
- `SocketFlushTimeout` made internal and removed from `IFrameHandler`. See commit cfc8d3f98.
- `FlushPipeAsync`: on NET, reuse a single `CancellationTokenSource` via `TryReset()` + `CancelAfter()` instead of allocating a new one per flush. See commit f0287a219.
- `blockedCount` guard lowered from `>= PublishCount/2` to `> 128`. The channel holds exactly 128 frames so any count above 128 proves the channel is full and the write loop has stopped draining, independent of OS TCP send-buffer size. See commit 55ca36b8f.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #1930)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories
