### PR TITLE
Fix gh-1827: use TrySet* to prevent connection death on late RPC responses

### DIFF
--- a/projects/RabbitMQ.Client/Impl/AsyncRpcContinuations.cs
+++ b/projects/RabbitMQ.Client/Impl/AsyncRpcContinuations.cs
@@ -51,6 +51,7 @@ namespace RabbitMQ.Client.Impl
         private readonly ConfiguredTaskAwaitable<T> _tcsConfiguredTaskAwaitable;
         protected readonly TaskCompletionSource<T> _tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
 
+        private volatile bool _responseReceived;
         private bool _disposedValue;
 
         public AsyncRpcContinuation(TimeSpan continuationTimeout, CancellationToken rpcCancellationToken)
@@ -82,6 +83,8 @@ namespace RabbitMQ.Client.Impl
                 _continuationTimeoutCancellationTokenSource.Token, rpcCancellationToken);
         }
 
+        public bool ResponseReceived => _responseReceived;
+
         public CancellationToken CancellationToken
         {
             get
@@ -99,6 +102,7 @@ namespace RabbitMQ.Client.Impl
 
         public async Task HandleCommandAsync(IncomingCommand cmd)
         {
+            _responseReceived = true;
             try
             {
                 await DoHandleCommandAsync(cmd)
@@ -149,7 +153,7 @@ namespace RabbitMQ.Client.Impl
 
         protected void HandleUnexpectedCommand(IncomingCommand cmd)
         {
-            _tcs.SetException(new InvalidOperationException($"Received unexpected command of type {cmd.CommandId}!"));
+            _tcs.TrySetException(new InvalidOperationException($"Received unexpected command of type {cmd.CommandId}!"));
         }
 
         protected virtual void Dispose(bool disposing)
@@ -212,12 +216,12 @@ namespace RabbitMQ.Client.Impl
             if (cmd.CommandId == ProtocolCommandId.ConnectionSecure)
             {
                 var secure = new ConnectionSecure(cmd.MethodSpan);
-                _tcs.SetResult(new ConnectionSecureOrTune(secure._challenge, default));
+                _tcs.TrySetResult(new ConnectionSecureOrTune(secure._challenge, default));
             }
             else if (cmd.CommandId == ProtocolCommandId.ConnectionTune)
             {
                 var tune = new ConnectionTune(cmd.MethodSpan);
-                _tcs.SetResult(new ConnectionSecureOrTune(default, new ConnectionTuneDetails
+                _tcs.TrySetResult(new ConnectionSecureOrTune(default, new ConnectionTuneDetails
                 {
                     m_channelMax = tune._channelMax,
                     m_frameMax = tune._frameMax,
@@ -251,7 +255,7 @@ namespace RabbitMQ.Client.Impl
         {
             if (cmd.CommandId == _expectedCommandId)
             {
-                _tcs.SetResult(true);
+                _tcs.TrySetResult(true);
             }
             else
             {
@@ -284,14 +288,14 @@ namespace RabbitMQ.Client.Impl
                 {
                     await _consumerDispatcher.HandleBasicCancelOkAsync(_consumerTag, CancellationToken)
                         .ConfigureAwait(false);
-                    _tcs.SetResult(true);
+                    _tcs.TrySetResult(true);
                 }
                 else
                 {
                     string msg = string.Format("Consumer tag '{0}' does not match expected consumer tag for basic.cancel operation {1}",
                         result._consumerTag, _consumerTag);
                     var ex = new InvalidOperationException(msg);
-                    _tcs.SetException(ex);
+                    _tcs.TrySetException(ex);
                 }
             }
             else
@@ -326,7 +330,7 @@ namespace RabbitMQ.Client.Impl
                 await _consumerDispatcher.HandleBasicConsumeOkAsync(_consumer, method._consumerTag, CancellationToken)
                     .ConfigureAwait(false);
 
-                _tcs.SetResult(method._consumerTag);
+                _tcs.TrySetResult(method._consumerTag);
             }
             else
             {
@@ -367,11 +371,11 @@ namespace RabbitMQ.Client.Impl
                     header,
                     cmd.Body.ToArray());
 
-                _tcs.SetResult(result);
+                _tcs.TrySetResult(result);
             }
             else if (cmd.CommandId == ProtocolCommandId.BasicGetEmpty)
             {
-                _tcs.SetResult(null);
+                _tcs.TrySetResult(null);
             }
             else
             {
@@ -412,7 +416,7 @@ namespace RabbitMQ.Client.Impl
 
         public Task OnConnectionShutdownAsync(object? sender, ShutdownEventArgs reason)
         {
-            _tcs.SetResult(true);
+            _tcs.TrySetResult(true);
             return Task.CompletedTask;
         }
     }
@@ -473,7 +477,7 @@ namespace RabbitMQ.Client.Impl
             {
                 var method = new Client.Framing.QueueDeclareOk(cmd.MethodSpan);
                 var result = new QueueDeclareOk(method._queue, method._messageCount, method._consumerCount);
-                _tcs.SetResult(result);
+                _tcs.TrySetResult(result);
             }
             else
             {
@@ -515,7 +519,7 @@ namespace RabbitMQ.Client.Impl
             if (cmd.CommandId == ProtocolCommandId.QueueDeleteOk)
             {
                 var method = new QueueDeleteOk(cmd.MethodSpan);
-                _tcs.SetResult(method._messageCount);
+                _tcs.TrySetResult(method._messageCount);
             }
             else
             {
@@ -541,7 +545,7 @@ namespace RabbitMQ.Client.Impl
             if (cmd.CommandId == ProtocolCommandId.QueuePurgeOk)
             {
                 var method = new QueuePurgeOk(cmd.MethodSpan);
-                _tcs.SetResult(method._messageCount);
+                _tcs.TrySetResult(method._messageCount);
             }
             else
             {

--- a/projects/RabbitMQ.Client/Impl/Channel.cs
+++ b/projects/RabbitMQ.Client/Impl/Channel.cs
@@ -310,7 +310,7 @@ namespace RabbitMQ.Client.Impl
                 }
                 catch (OperationCanceledException)
                 {
-                    _continuationQueue.RpcCanceled(k.HandledProtocolCommandIds);
+                    _continuationQueue.RpcCanceled(k.ResponseReceived, k.HandledProtocolCommandIds);
                     throw;
                 }
             }
@@ -354,7 +354,7 @@ namespace RabbitMQ.Client.Impl
                 }
                 catch (OperationCanceledException)
                 {
-                    _continuationQueue.RpcCanceled(k.HandledProtocolCommandIds);
+                    _continuationQueue.RpcCanceled(k.ResponseReceived, k.HandledProtocolCommandIds);
                     throw;
                 }
             }
@@ -394,7 +394,7 @@ namespace RabbitMQ.Client.Impl
                 }
                 catch (OperationCanceledException)
                 {
-                    _continuationQueue.RpcCanceled(k.HandledProtocolCommandIds);
+                    _continuationQueue.RpcCanceled(k.ResponseReceived, k.HandledProtocolCommandIds);
                     throw;
                 }
             }
@@ -989,7 +989,7 @@ namespace RabbitMQ.Client.Impl
                     }
                     catch
                     {
-                        _continuationQueue.RpcCanceled(k.HandledProtocolCommandIds);
+                        _continuationQueue.RpcCanceled(k.ResponseReceived, k.HandledProtocolCommandIds);
                         throw;
                     }
                 }
@@ -1029,7 +1029,7 @@ namespace RabbitMQ.Client.Impl
                 }
                 catch
                 {
-                    _continuationQueue.RpcCanceled(k.HandledProtocolCommandIds);
+                    _continuationQueue.RpcCanceled(k.ResponseReceived, k.HandledProtocolCommandIds);
                     throw;
                 }
             }
@@ -1073,7 +1073,7 @@ namespace RabbitMQ.Client.Impl
                 }
                 catch (OperationCanceledException)
                 {
-                    _continuationQueue.RpcCanceled(k.HandledProtocolCommandIds);
+                    _continuationQueue.RpcCanceled(k.ResponseReceived, k.HandledProtocolCommandIds);
                     throw;
                 }
             }
@@ -1118,7 +1118,7 @@ namespace RabbitMQ.Client.Impl
                 }
                 catch (OperationCanceledException)
                 {
-                    _continuationQueue.RpcCanceled(k.HandledProtocolCommandIds);
+                    _continuationQueue.RpcCanceled(k.ResponseReceived, k.HandledProtocolCommandIds);
                     throw;
                 }
             }
@@ -1151,7 +1151,7 @@ namespace RabbitMQ.Client.Impl
                 }
                 catch (OperationCanceledException)
                 {
-                    _continuationQueue.RpcCanceled(k.HandledProtocolCommandIds);
+                    _continuationQueue.RpcCanceled(k.ResponseReceived, k.HandledProtocolCommandIds);
                     throw;
                 }
             }
@@ -1193,7 +1193,7 @@ namespace RabbitMQ.Client.Impl
                     }
                     catch (OperationCanceledException)
                     {
-                        _continuationQueue.RpcCanceled(k.HandledProtocolCommandIds);
+                        _continuationQueue.RpcCanceled(k.ResponseReceived, k.HandledProtocolCommandIds);
                         throw;
                     }
                 }
@@ -1244,7 +1244,7 @@ namespace RabbitMQ.Client.Impl
                     }
                     catch (OperationCanceledException)
                     {
-                        _continuationQueue.RpcCanceled(k.HandledProtocolCommandIds);
+                        _continuationQueue.RpcCanceled(k.ResponseReceived, k.HandledProtocolCommandIds);
                         throw;
                     }
                 }
@@ -1288,7 +1288,7 @@ namespace RabbitMQ.Client.Impl
                     }
                     catch (OperationCanceledException)
                     {
-                        _continuationQueue.RpcCanceled(k.HandledProtocolCommandIds);
+                        _continuationQueue.RpcCanceled(k.ResponseReceived, k.HandledProtocolCommandIds);
                         throw;
                     }
                 }
@@ -1333,7 +1333,7 @@ namespace RabbitMQ.Client.Impl
                     }
                     catch (OperationCanceledException)
                     {
-                        _continuationQueue.RpcCanceled(k.HandledProtocolCommandIds);
+                        _continuationQueue.RpcCanceled(k.ResponseReceived, k.HandledProtocolCommandIds);
                         throw;
                     }
                 }
@@ -1413,7 +1413,7 @@ namespace RabbitMQ.Client.Impl
                     }
                     catch (OperationCanceledException)
                     {
-                        _continuationQueue.RpcCanceled(k.HandledProtocolCommandIds);
+                        _continuationQueue.RpcCanceled(k.ResponseReceived, k.HandledProtocolCommandIds);
                         throw;
                     }
                 }
@@ -1456,7 +1456,7 @@ namespace RabbitMQ.Client.Impl
                     }
                     catch (OperationCanceledException)
                     {
-                        _continuationQueue.RpcCanceled(k.HandledProtocolCommandIds);
+                        _continuationQueue.RpcCanceled(k.ResponseReceived, k.HandledProtocolCommandIds);
                         throw;
                     }
                 }
@@ -1518,7 +1518,7 @@ namespace RabbitMQ.Client.Impl
                     }
                     catch (OperationCanceledException)
                     {
-                        _continuationQueue.RpcCanceled(k.HandledProtocolCommandIds);
+                        _continuationQueue.RpcCanceled(k.ResponseReceived, k.HandledProtocolCommandIds);
                         throw;
                     }
                 }
@@ -1552,7 +1552,7 @@ namespace RabbitMQ.Client.Impl
                 }
                 catch (OperationCanceledException)
                 {
-                    _continuationQueue.RpcCanceled(k.HandledProtocolCommandIds);
+                    _continuationQueue.RpcCanceled(k.ResponseReceived, k.HandledProtocolCommandIds);
                     throw;
                 }
             }
@@ -1586,7 +1586,7 @@ namespace RabbitMQ.Client.Impl
                 }
                 catch (OperationCanceledException)
                 {
-                    _continuationQueue.RpcCanceled(k.HandledProtocolCommandIds);
+                    _continuationQueue.RpcCanceled(k.ResponseReceived, k.HandledProtocolCommandIds);
                     throw;
                 }
             }
@@ -1618,7 +1618,7 @@ namespace RabbitMQ.Client.Impl
                 }
                 catch (OperationCanceledException)
                 {
-                    _continuationQueue.RpcCanceled(k.HandledProtocolCommandIds);
+                    _continuationQueue.RpcCanceled(k.ResponseReceived, k.HandledProtocolCommandIds);
                     throw;
                 }
             }
@@ -1650,7 +1650,7 @@ namespace RabbitMQ.Client.Impl
                 }
                 catch (OperationCanceledException)
                 {
-                    _continuationQueue.RpcCanceled(k.HandledProtocolCommandIds);
+                    _continuationQueue.RpcCanceled(k.ResponseReceived, k.HandledProtocolCommandIds);
                     throw;
                 }
             }
@@ -1682,7 +1682,7 @@ namespace RabbitMQ.Client.Impl
                 }
                 catch (OperationCanceledException)
                 {
-                    _continuationQueue.RpcCanceled(k.HandledProtocolCommandIds);
+                    _continuationQueue.RpcCanceled(k.ResponseReceived, k.HandledProtocolCommandIds);
                     throw;
                 }
             }

--- a/projects/RabbitMQ.Client/Impl/RpcContinuationQueue.cs
+++ b/projects/RabbitMQ.Client/Impl/RpcContinuationQueue.cs
@@ -143,9 +143,12 @@ namespace RabbitMQ.Client.Impl
             return false;
         }
 
-        public void RpcCanceled(ProtocolCommandId[] protocolCommandIds)
+        public void RpcCanceled(bool responseReceived, ProtocolCommandId[] protocolCommandIds)
         {
-            _rpcCancellationQueue.Enqueue(protocolCommandIds);
+            if (!responseReceived)
+            {
+                _rpcCancellationQueue.Enqueue(protocolCommandIds);
+            }
         }
 
         public bool ShouldIgnoreCommand(ProtocolCommandId commandId)


### PR DESCRIPTION
## Summary

Fixes #1827.

When an RPC continuation times out, a late-arriving server response could call `_tcs.SetResult()` on an already-cancelled `TaskCompletionSource`, throwing `InvalidOperationException`. That exception propagated up through `Channel.HandleCommandAsync` and into the connection's unhandled-exception handler, which closed the connection with AMQP code 541 (INTERNAL_ERROR).

The existing `ShouldIgnoreCommand`/`RpcCanceled` mechanism (introduced in #1802) was designed to absorb late responses, but it has a timing gap: if the late response arrives before the `catch` block calls `RpcCanceled`, `ShouldIgnoreCommand` returns `false` and the throwing `SetResult` reaches the already-cancelled TCS.

## Changes

**`AsyncRpcContinuations.cs`**

- Replace all `_tcs.SetResult`/`_tcs.SetException` calls in every `DoHandleCommandAsync` implementation and in `HandleUnexpectedCommand` with `TrySetResult`/`TrySetException`. This makes a late arrival a silent no-op rather than a crash.
- Add a `volatile bool _responseReceived` field (exposed as `ResponseReceived`) that is set to `true` at the entry of `HandleCommandAsync`, before `DoHandleCommandAsync` is called. This marks that the server did send a response, even if it arrived too late.

**`RpcContinuationQueue.cs`**

- Change `RpcCanceled(ProtocolCommandId[])` to `RpcCanceled(bool responseReceived, ProtocolCommandId[])`. When `responseReceived` is `true`, the method skips enqueuing the `ShouldIgnoreCommand` sentinel. Without this guard, a late response absorbed by `TrySetResult` (returning `false`) would still add a stale sentinel that could silently eat the next retry response of the same command type on that channel.

**`Channel.cs`**

- Update all 20 `RpcCanceled` call sites to pass `k.ResponseReceived` as the first argument.

## Test plan

- [ ] Existing unit and integration test suites pass
- [ ] Manual verification: trigger a continuation timeout (e.g. set `ContinuationTimeout` to a very short value under a slow broker) and confirm no AMQP 541 connection closure occurs and the channel remains open for subsequent operations
