### PR TITLE
Change HandledProtocolCommandIds to use ReadOnlySpan for improved performance

### DIFF
--- a/projects/RabbitMQ.Client/Impl/AsyncRpcContinuations.cs
+++ b/projects/RabbitMQ.Client/Impl/AsyncRpcContinuations.cs
@@ -98,7 +98,7 @@ namespace RabbitMQ.Client.Impl
             return _tcsConfiguredTaskAwaitable.GetAwaiter();
         }
 
-        public abstract ProtocolCommandId[] HandledProtocolCommandIds { get; }
+        public abstract ReadOnlySpan<ProtocolCommandId> HandledProtocolCommandIds { get; }
 
         public async Task HandleCommandAsync(IncomingCommand cmd)
         {
@@ -208,7 +208,7 @@ namespace RabbitMQ.Client.Impl
         {
         }
 
-        public override ProtocolCommandId[] HandledProtocolCommandIds
+        public override ReadOnlySpan<ProtocolCommandId> HandledProtocolCommandIds
             => [ProtocolCommandId.ConnectionSecure, ProtocolCommandId.ConnectionTune];
 
         protected override Task DoHandleCommandAsync(IncomingCommand cmd)
@@ -248,8 +248,8 @@ namespace RabbitMQ.Client.Impl
             _expectedCommandId = expectedCommandId;
         }
 
-        public override ProtocolCommandId[] HandledProtocolCommandIds
-            => [_expectedCommandId];
+        public override ReadOnlySpan<ProtocolCommandId> HandledProtocolCommandIds
+            => new[] { _expectedCommandId };
 
         protected override Task DoHandleCommandAsync(IncomingCommand cmd)
         {
@@ -318,7 +318,7 @@ namespace RabbitMQ.Client.Impl
             _consumerDispatcher = consumerDispatcher;
         }
 
-        public override ProtocolCommandId[] HandledProtocolCommandIds
+        public override ReadOnlySpan<ProtocolCommandId> HandledProtocolCommandIds
             => [ProtocolCommandId.BasicConsumeOk];
 
         protected override async Task DoHandleCommandAsync(IncomingCommand cmd)
@@ -350,7 +350,7 @@ namespace RabbitMQ.Client.Impl
             _adjustDeliveryTag = adjustDeliveryTag;
         }
 
-        public override ProtocolCommandId[] HandledProtocolCommandIds
+        public override ReadOnlySpan<ProtocolCommandId> HandledProtocolCommandIds
             => [ProtocolCommandId.BasicGetOk, ProtocolCommandId.BasicGetEmpty];
 
         internal DateTime StartTime { get; } = DateTime.UtcNow;
@@ -468,7 +468,7 @@ namespace RabbitMQ.Client.Impl
         {
         }
 
-        public override ProtocolCommandId[] HandledProtocolCommandIds
+        public override ReadOnlySpan<ProtocolCommandId> HandledProtocolCommandIds
             => [ProtocolCommandId.QueueDeclareOk];
 
         protected override Task DoHandleCommandAsync(IncomingCommand cmd)
@@ -511,7 +511,7 @@ namespace RabbitMQ.Client.Impl
         {
         }
 
-        public override ProtocolCommandId[] HandledProtocolCommandIds
+        public override ReadOnlySpan<ProtocolCommandId> HandledProtocolCommandIds
             => [ProtocolCommandId.QueueDeleteOk];
 
         protected override Task DoHandleCommandAsync(IncomingCommand cmd)
@@ -537,7 +537,7 @@ namespace RabbitMQ.Client.Impl
         {
         }
 
-        public override ProtocolCommandId[] HandledProtocolCommandIds
+        public override ReadOnlySpan<ProtocolCommandId> HandledProtocolCommandIds
             => [ProtocolCommandId.QueuePurgeOk];
 
         protected override Task DoHandleCommandAsync(IncomingCommand cmd)

--- a/projects/RabbitMQ.Client/Impl/RpcContinuationQueue.cs
+++ b/projects/RabbitMQ.Client/Impl/RpcContinuationQueue.cs
@@ -32,6 +32,7 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using RabbitMQ.Client.Events;
@@ -68,15 +69,19 @@ namespace RabbitMQ.Client.Impl
 
         private const int CommandIdBufferLength = 2;
 
-        private struct LastTimedOutCommandIds
+        // Two ProtocolCommandId values (each uint) laid out as a struct
+        // reinterpreted as a single long for lock-free atomic
+        // read-modify-write via Interlocked.Exchange.
+        // Since ProtocolCommandId: uint has no zero-valued member,
+        // default(LastTimedOutCommandIds) == 0 means "no timed-out command".
+        private readonly struct LastTimedOutCommandIds(ProtocolCommandId first, ProtocolCommandId second = 0)
         {
-            public ProtocolCommandId First;
-            public ProtocolCommandId Second;
+            public readonly ProtocolCommandId First = first;
+            public readonly ProtocolCommandId Second = second;
         }
 
         private static readonly EmptyRpcContinuation s_tmp = new EmptyRpcContinuation();
-        private LastTimedOutCommandIds _lastTimedOutCommandIds;
-        private int _lastTimedOutCommandIdsCount;
+        private long _lastTimedOutCommandIds;
         private IRpcContinuation _outstandingRpc = s_tmp;
 
         ///<summary>Enqueue a continuation, marking a pending RPC.</summary>
@@ -160,19 +165,11 @@ namespace RabbitMQ.Client.Impl
 
             // AMQP 0-9-1 RPCs handle at most 2 response command IDs
             // (e.g. BasicGetOk/BasicGetEmpty, ConnectionSecure/ConnectionTune)
-            Debug.Assert(protocolCommandIds.Length <= CommandIdBufferLength);
+            Debug.Assert(protocolCommandIds.Length is > 0 and <= CommandIdBufferLength);
 
-            int count = protocolCommandIds.Length;
-            _lastTimedOutCommandIdsCount = count;
-            _lastTimedOutCommandIds = default;
-            if (count > 0)
-            {
-                _lastTimedOutCommandIds.First = protocolCommandIds[0];
-                if (count > 1)
-                {
-                    _lastTimedOutCommandIds.Second = protocolCommandIds[1];
-                }
-            }
+            var ids = new LastTimedOutCommandIds(first: protocolCommandIds[0], second: protocolCommandIds.Length > 1 ? protocolCommandIds[1] : 0);
+
+            Interlocked.Exchange(ref _lastTimedOutCommandIds, Unsafe.As<LastTimedOutCommandIds, long>(ref ids));
         }
 
         public bool ShouldIgnoreCommand(ProtocolCommandId commandId)
@@ -180,12 +177,15 @@ namespace RabbitMQ.Client.Impl
             // rabbitmq/rabbitmq-dotnet-client#1802
             // This keeps track of ProtocolCommandId values from previous RPC
             // commands that have timed out.
-            LastTimedOutCommandIds last = _lastTimedOutCommandIds;
-            int count = _lastTimedOutCommandIdsCount;
-            _lastTimedOutCommandIds = default;
-            _lastTimedOutCommandIdsCount = 0;
+            long raw = Interlocked.Exchange(ref _lastTimedOutCommandIds, 0L);
 
-            return commandId == last.First || (count > 1 && commandId == last.Second);
+            if (raw == 0L)
+            {
+                return false;
+            }
+
+            var ids = Unsafe.As<long, LastTimedOutCommandIds>(ref raw);
+            return commandId == ids.First || (ids.Second != 0 && commandId == ids.Second);
         }
     }
 }

--- a/projects/RabbitMQ.Client/Impl/RpcContinuationQueue.cs
+++ b/projects/RabbitMQ.Client/Impl/RpcContinuationQueue.cs
@@ -30,9 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using RabbitMQ.Client.Events;
@@ -67,8 +65,17 @@ namespace RabbitMQ.Client.Impl
             }
         }
 
+        private const int CommandIdBufferLength = 2;
+
+        private struct LastTimedOutCommandIds
+        {
+            public ProtocolCommandId First;
+            public ProtocolCommandId Second;
+        }
+
         private static readonly EmptyRpcContinuation s_tmp = new EmptyRpcContinuation();
-        private readonly Queue<ProtocolCommandId[]> _rpcCancellationQueue = new();
+        private LastTimedOutCommandIds _lastTimedOutCommandIds;
+        private int _lastTimedOutCommandIdsCount;
         private IRpcContinuation _outstandingRpc = s_tmp;
 
         ///<summary>Enqueue a continuation, marking a pending RPC.</summary>
@@ -143,11 +150,28 @@ namespace RabbitMQ.Client.Impl
             return false;
         }
 
-        public void RpcCanceled(bool responseReceived, ProtocolCommandId[] protocolCommandIds)
+        public void RpcCanceled(bool responseReceived, ReadOnlySpan<ProtocolCommandId> protocolCommandIds)
         {
-            if (!responseReceived)
+            if (responseReceived)
             {
-                _rpcCancellationQueue.Enqueue(protocolCommandIds);
+                return;
+            }
+
+            if (protocolCommandIds.Length > CommandIdBufferLength)
+            {
+                throw new ArgumentOutOfRangeException(nameof(protocolCommandIds));
+            }
+
+            int count = protocolCommandIds.Length;
+            _lastTimedOutCommandIdsCount = count;
+            _lastTimedOutCommandIds = default;
+            if (count > 0)
+            {
+                _lastTimedOutCommandIds.First = protocolCommandIds[0];
+                if (count > 1)
+                {
+                    _lastTimedOutCommandIds.Second = protocolCommandIds[1];
+                }
             }
         }
 
@@ -156,18 +180,27 @@ namespace RabbitMQ.Client.Impl
             // rabbitmq/rabbitmq-dotnet-client#1802
             // This keeps track of ProtocolCommandId values from previous RPC
             // commands that have timed out.
-            bool rv = false;
+            LastTimedOutCommandIds last = _lastTimedOutCommandIds;
+            int count = _lastTimedOutCommandIdsCount;
+            _lastTimedOutCommandIds = default;
+            _lastTimedOutCommandIdsCount = 0;
 
-            if (_rpcCancellationQueue.Count > 0)
+            if (count == 0)
             {
-                ProtocolCommandId[] lastErroredCommandIds = _rpcCancellationQueue.Dequeue();
-                if (lastErroredCommandIds.Contains(commandId))
-                {
-                    rv = true;
-                }
+                return false;
             }
 
-            return rv;
+            if (commandId == last.First)
+            {
+                return true;
+            }
+
+            if (count > 1 && commandId == last.Second)
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/projects/RabbitMQ.Client/Impl/RpcContinuationQueue.cs
+++ b/projects/RabbitMQ.Client/Impl/RpcContinuationQueue.cs
@@ -32,7 +32,7 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using RabbitMQ.Client.Events;
@@ -69,15 +69,19 @@ namespace RabbitMQ.Client.Impl
 
         private const int CommandIdBufferLength = 2;
 
-        // Two ProtocolCommandId values (each uint) laid out as a struct
-        // reinterpreted as a single long for lock-free atomic
-        // read-modify-write via Interlocked.Exchange.
-        // Since ProtocolCommandId: uint has no zero-valued member,
-        // default(LastTimedOutCommandIds) == 0 means "no timed-out command".
-        private readonly struct LastTimedOutCommandIds(ProtocolCommandId first, ProtocolCommandId second = 0)
+        // Two ProtocolCommandId values (each uint) unioned with a single long
+        // so that Interlocked.Exchange can read/write both atomically.
+        // Since ProtocolCommandId : uint has no zero-valued member,
+        // default(LastTimedOutCommandIds).RawValue == 0L means "no timed-out command".
+        [StructLayout(LayoutKind.Explicit)]
+        private struct LastTimedOutCommandIds
         {
-            public readonly ProtocolCommandId First = first;
-            public readonly ProtocolCommandId Second = second;
+            [FieldOffset(0)]
+            public ProtocolCommandId First;
+            [FieldOffset(sizeof(ProtocolCommandId))]
+            public ProtocolCommandId Second;
+            [FieldOffset(0)]
+            public long RawValue;
         }
 
         private static readonly EmptyRpcContinuation s_tmp = new EmptyRpcContinuation();
@@ -167,9 +171,13 @@ namespace RabbitMQ.Client.Impl
             // (e.g. BasicGetOk/BasicGetEmpty, ConnectionSecure/ConnectionTune)
             Debug.Assert(protocolCommandIds.Length is > 0 and <= CommandIdBufferLength);
 
-            var ids = new LastTimedOutCommandIds(first: protocolCommandIds[0], second: protocolCommandIds.Length > 1 ? protocolCommandIds[1] : 0);
+            var ids = new LastTimedOutCommandIds
+            {
+                First = protocolCommandIds[0],
+                Second = protocolCommandIds.Length > 1 ? protocolCommandIds[1] : default
+            };
 
-            Interlocked.Exchange(ref _lastTimedOutCommandIds, Unsafe.As<LastTimedOutCommandIds, long>(ref ids));
+            Interlocked.Exchange(ref _lastTimedOutCommandIds, ids.RawValue);
         }
 
         public bool ShouldIgnoreCommand(ProtocolCommandId commandId)
@@ -184,8 +192,8 @@ namespace RabbitMQ.Client.Impl
                 return false;
             }
 
-            var ids = Unsafe.As<long, LastTimedOutCommandIds>(ref raw);
-            return commandId == ids.First || (ids.Second != 0 && commandId == ids.Second);
+            var ids = new LastTimedOutCommandIds { RawValue = raw };
+            return commandId == ids.First || (ids.Second != default && commandId == ids.Second);
         }
     }
 }

--- a/projects/RabbitMQ.Client/Impl/RpcContinuationQueue.cs
+++ b/projects/RabbitMQ.Client/Impl/RpcContinuationQueue.cs
@@ -30,6 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -157,10 +158,9 @@ namespace RabbitMQ.Client.Impl
                 return;
             }
 
-            if (protocolCommandIds.Length > CommandIdBufferLength)
-            {
-                throw new ArgumentOutOfRangeException(nameof(protocolCommandIds));
-            }
+            // AMQP 0-9-1 RPCs handle at most 2 response command IDs
+            // (e.g. BasicGetOk/BasicGetEmpty, ConnectionSecure/ConnectionTune)
+            Debug.Assert(protocolCommandIds.Length <= CommandIdBufferLength);
 
             int count = protocolCommandIds.Length;
             _lastTimedOutCommandIdsCount = count;
@@ -185,22 +185,7 @@ namespace RabbitMQ.Client.Impl
             _lastTimedOutCommandIds = default;
             _lastTimedOutCommandIdsCount = 0;
 
-            if (count == 0)
-            {
-                return false;
-            }
-
-            if (commandId == last.First)
-            {
-                return true;
-            }
-
-            if (count > 1 && commandId == last.Second)
-            {
-                return true;
-            }
-
-            return false;
+            return commandId == last.First || (count > 1 && commandId == last.Second);
         }
     }
 }

--- a/projects/RabbitMQ.Client/Impl/RpcContinuationQueue.cs
+++ b/projects/RabbitMQ.Client/Impl/RpcContinuationQueue.cs
@@ -185,6 +185,11 @@ namespace RabbitMQ.Client.Impl
             // rabbitmq/rabbitmq-dotnet-client#1802
             // This keeps track of ProtocolCommandId values from previous RPC
             // commands that have timed out.
+            //
+            // Consume the timed-out state unconditionally, even when commandId does
+            // not match. This is safe because AMQP 0-9-1 enforces strict request-response
+            // ordering on a channel, so a late response is always the very next
+            // incoming command.
             long raw = Interlocked.Exchange(ref _lastTimedOutCommandIds, 0L);
 
             if (raw == 0L)

--- a/projects/Test/Unit/TestRpcContinuationQueue.cs
+++ b/projects/Test/Unit/TestRpcContinuationQueue.cs
@@ -81,5 +81,82 @@ namespace Test.Unit
                 queue.Enqueue(inputContinuation1);
             });
         }
+
+        [Fact]
+        public void TestShouldIgnoreCommand_NoTimedOutCommands_ReturnsFalse()
+        {
+            RpcContinuationQueue queue = new RpcContinuationQueue();
+            Assert.False(queue.ShouldIgnoreCommand(ProtocolCommandId.BasicAck));
+        }
+
+        [Fact]
+        public void TestShouldIgnoreCommand_SingleTimedOutCommand_MatchesFirst()
+        {
+            RpcContinuationQueue queue = new RpcContinuationQueue();
+            queue.RpcCanceled(false, [ProtocolCommandId.QueueDeclareOk]);
+            Assert.True(queue.ShouldIgnoreCommand(ProtocolCommandId.QueueDeclareOk));
+        }
+
+        [Fact]
+        public void TestShouldIgnoreCommand_SingleTimedOutCommand_NoMatch()
+        {
+            RpcContinuationQueue queue = new RpcContinuationQueue();
+            queue.RpcCanceled(false, [ProtocolCommandId.QueueDeclareOk]);
+            Assert.False(queue.ShouldIgnoreCommand(ProtocolCommandId.BasicAck));
+        }
+
+        [Fact]
+        public void TestShouldIgnoreCommand_TwoTimedOutCommands_MatchesFirst()
+        {
+            RpcContinuationQueue queue = new RpcContinuationQueue();
+            queue.RpcCanceled(false, [ProtocolCommandId.BasicGetOk, ProtocolCommandId.BasicGetEmpty]);
+            Assert.True(queue.ShouldIgnoreCommand(ProtocolCommandId.BasicGetOk));
+        }
+
+        [Fact]
+        public void TestShouldIgnoreCommand_TwoTimedOutCommands_MatchesSecond()
+        {
+            RpcContinuationQueue queue = new RpcContinuationQueue();
+            queue.RpcCanceled(false, [ProtocolCommandId.BasicGetOk, ProtocolCommandId.BasicGetEmpty]);
+            Assert.True(queue.ShouldIgnoreCommand(ProtocolCommandId.BasicGetEmpty));
+        }
+
+        [Fact]
+        public void TestShouldIgnoreCommand_TwoTimedOutCommands_NoMatch()
+        {
+            RpcContinuationQueue queue = new RpcContinuationQueue();
+            queue.RpcCanceled(false, [ProtocolCommandId.BasicGetOk, ProtocolCommandId.BasicGetEmpty]);
+            Assert.False(queue.ShouldIgnoreCommand(ProtocolCommandId.BasicAck));
+        }
+
+        [Fact]
+        public void TestShouldIgnoreCommand_ConsumesTimedOutState()
+        {
+            RpcContinuationQueue queue = new RpcContinuationQueue();
+            queue.RpcCanceled(false, [ProtocolCommandId.QueueDeclareOk]);
+            Assert.True(queue.ShouldIgnoreCommand(ProtocolCommandId.QueueDeclareOk));
+            // Second call should return false — the timed-out state was consumed
+            Assert.False(queue.ShouldIgnoreCommand(ProtocolCommandId.QueueDeclareOk));
+        }
+
+        [Fact]
+        public void TestShouldIgnoreCommand_EmptyAfterConsume()
+        {
+            RpcContinuationQueue queue = new RpcContinuationQueue();
+            queue.RpcCanceled(false, [ProtocolCommandId.QueueDeclareOk]);
+            // Consume with a non-matching command ID
+            Assert.False(queue.ShouldIgnoreCommand(ProtocolCommandId.BasicAck));
+            // Now the timed-out state is consumed, any check returns false
+            Assert.False(queue.ShouldIgnoreCommand(ProtocolCommandId.QueueDeclareOk));
+        }
+
+        [Fact]
+        public void TestRpcCanceled_ResponseReceivedTrue_DoesNotRecord()
+        {
+            RpcContinuationQueue queue = new RpcContinuationQueue();
+            queue.RpcCanceled(true, [ProtocolCommandId.QueueDeclareOk]);
+            // Since responseReceived=true, no command IDs should be recorded
+            Assert.False(queue.ShouldIgnoreCommand(ProtocolCommandId.QueueDeclareOk));
+        }
     }
 }


### PR DESCRIPTION
## Proposed Changes

Replace `Queue<ProtocolCommandId[]>` with a lock-free `readonly struct` reinterpreted as `long` via `Unsafe.As` for atomic `Interlocked.Exchange`, eliminating heap allocations and fixing a thread-safety bug. Also change `HandledProtocolCommandIds` from `ProtocolCommandId[]` to `ReadOnlySpan<ProtocolCommandId>` to support zero-copy propagation.

### Thread-safety fix

The previous `Queue<ProtocolCommandId[]>` implementation had no thread-safety guarantees — `Queue<T>` is not thread-safe, and the check-then-act pattern (`Count > 0` then `Dequeue()`) was a TOCTOU race. The initial struct replacement also had an ordering vulnerability: `_lastTimedOutCommandIdsCount` was written before the command ID fields, so `ShouldIgnoreCommand` could observe a non-zero count with still-zeroed IDs.

The new implementation uses a single `long` field with `Interlocked.Exchange` for both the write (in `RpcCanceled`) and the read-and-reset (in `ShouldIgnoreCommand`). This provides:
- **Atomicity on all platforms** (including 32-bit) — readers see either the old state (0 = empty) or the complete new state, never a torn partial write
- **Full memory barrier** — proper visibility across threads without needing `volatile` or `lock`

### RpcContinuationQueue

- Replace `Queue<ProtocolCommandId[]>` with a `readonly struct LastTimedOutCommandIds(first, second = 0)` reinterpreted as `long` via `Unsafe.As` for lock-free atomic read-modify-write via `Interlocked.Exchange`
- Since `ProtocolCommandId : uint` has no zero-valued member, `default` (0) serves as the "empty" sentinel, eliminating the need for a separate count field
- `RpcCanceled` now accepts `ReadOnlySpan<ProtocolCommandId>` and constructs the struct, then writes it atomically — zero heap allocation
- `ShouldIgnoreCommand` uses `Interlocked.Exchange` to atomically read-and-reset, then compares directly against the struct fields — no LINQ, no Collection
- Early return on `raw == 0L` avoids any comparison work on the hot path (no timeout pending)
- `Debug.Assert` enforces `protocolCommandIds.Length is > 0 and <= 2`
- Removes `System.Collections.Generic`, `System.Linq` dependencies; adds `System.Runtime.CompilerServices` for `Unsafe.As`

### AsyncRpcContinuations

- Change `HandledProtocolCommandIds` from `ProtocolCommandId[]` to `ReadOnlySpan<ProtocolCommandId>`

### Tests

- Added 8 unit tests for `ShouldIgnoreCommand` and `RpcCanceled`: empty state, single/two command matching, non-matching, state consumption, and `responseReceived=true` guard

### Benchmark results

<img width="1350" height="880" alt="image" src="https://github.com/user-attachments/assets/c6f75b0c-8ec1-49ac-812b-2b1180c6d9bb" />

Although one could argue the comparison is "unfair" since this implementation is now properly handling the race. But still very good gains

