### PR TITLE
Fix gh-1908: move Impl/ files from RabbitMQ.Client.Framing to RabbitMQ.Client.Impl namespace

### DIFF
--- a/projects/RabbitMQ.Client/Framing/Protocol.cs
+++ b/projects/RabbitMQ.Client/Framing/Protocol.cs
@@ -30,7 +30,7 @@
 //---------------------------------------------------------------------------
 
 using System;
-using RabbitMQ.Client.Framing;
+using RabbitMQ.Client.Impl;
 
 namespace RabbitMQ.Client.Framing
 {

--- a/projects/RabbitMQ.Client/Impl/AutorecoveringConnection.Recording.cs
+++ b/projects/RabbitMQ.Client/Impl/AutorecoveringConnection.Recording.cs
@@ -34,9 +34,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using RabbitMQ.Client.Impl;
+using RabbitMQ.Client.Framing;
 
-namespace RabbitMQ.Client.Framing
+namespace RabbitMQ.Client.Impl
 {
     internal sealed partial class AutorecoveringConnection
     {

--- a/projects/RabbitMQ.Client/Impl/AutorecoveringConnection.Recovery.cs
+++ b/projects/RabbitMQ.Client/Impl/AutorecoveringConnection.Recovery.cs
@@ -36,10 +36,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Exceptions;
-using RabbitMQ.Client.Impl;
+using RabbitMQ.Client.Framing;
 using RabbitMQ.Client.Logging;
 
-namespace RabbitMQ.Client.Framing
+namespace RabbitMQ.Client.Impl
 {
     internal sealed partial class AutorecoveringConnection
     {

--- a/projects/RabbitMQ.Client/Impl/AutorecoveringConnection.cs
+++ b/projects/RabbitMQ.Client/Impl/AutorecoveringConnection.cs
@@ -37,9 +37,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Exceptions;
-using RabbitMQ.Client.Impl;
+using RabbitMQ.Client.Framing;
 
-namespace RabbitMQ.Client.Framing
+namespace RabbitMQ.Client.Impl
 {
     internal sealed partial class AutorecoveringConnection : IConnection
     {

--- a/projects/RabbitMQ.Client/Impl/Connection.Commands.cs
+++ b/projects/RabbitMQ.Client/Impl/Connection.Commands.cs
@@ -36,9 +36,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Exceptions;
-using RabbitMQ.Client.Impl;
+using RabbitMQ.Client.Framing;
 
-namespace RabbitMQ.Client.Framing
+namespace RabbitMQ.Client.Impl
 {
     internal sealed partial class Connection
     {

--- a/projects/RabbitMQ.Client/Impl/Connection.Heartbeat.cs
+++ b/projects/RabbitMQ.Client/Impl/Connection.Heartbeat.cs
@@ -33,8 +33,9 @@ using System;
 using System.IO;
 using System.Threading;
 using RabbitMQ.Client.Events;
+using RabbitMQ.Client.Framing;
 
-namespace RabbitMQ.Client.Framing
+namespace RabbitMQ.Client.Impl
 {
     internal sealed partial class Connection
     {

--- a/projects/RabbitMQ.Client/Impl/Connection.Receive.cs
+++ b/projects/RabbitMQ.Client/Impl/Connection.Receive.cs
@@ -35,9 +35,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Exceptions;
-using RabbitMQ.Client.Impl;
+using RabbitMQ.Client.Framing;
 
-namespace RabbitMQ.Client.Framing
+namespace RabbitMQ.Client.Impl
 {
     internal sealed partial class Connection
     {

--- a/projects/RabbitMQ.Client/Impl/Connection.cs
+++ b/projects/RabbitMQ.Client/Impl/Connection.cs
@@ -39,10 +39,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Exceptions;
-using RabbitMQ.Client.Impl;
+using RabbitMQ.Client.Framing;
 using RabbitMQ.Client.Logging;
 
-namespace RabbitMQ.Client.Framing
+namespace RabbitMQ.Client.Impl
 {
     internal sealed partial class Connection : IConnection
     {

--- a/projects/RabbitMQ.Client/Impl/ProtocolBase.cs
+++ b/projects/RabbitMQ.Client/Impl/ProtocolBase.cs
@@ -31,9 +31,9 @@
 
 using System;
 using System.Collections.Generic;
-using RabbitMQ.Client.Impl;
+using RabbitMQ.Client.Framing;
 
-namespace RabbitMQ.Client.Framing
+namespace RabbitMQ.Client.Impl
 {
     internal abstract class ProtocolBase : IProtocol
     {

--- a/projects/Test/Common/IntegrationFixture.cs
+++ b/projects/Test/Common/IntegrationFixture.cs
@@ -42,7 +42,7 @@ using System.Threading.Tasks;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Exceptions;
-using RabbitMQ.Client.Framing;
+using RabbitMQ.Client.Impl;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/projects/Test/Common/TestConnectionRecoveryBase.cs
+++ b/projects/Test/Common/TestConnectionRecoveryBase.cs
@@ -34,7 +34,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using RabbitMQ.Client;
-using RabbitMQ.Client.Framing;
+using RabbitMQ.Client.Impl;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/projects/Test/Integration/ConnectionRecovery/EventHandlerRecovery/Connection/TestRecoveringConsumerEventHandlers.cs
+++ b/projects/Test/Integration/ConnectionRecovery/EventHandlerRecovery/Connection/TestRecoveringConsumerEventHandlers.cs
@@ -35,6 +35,7 @@ using System.Threading.Tasks;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Framing;
+using RabbitMQ.Client.Impl;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/projects/Test/Integration/ConnectionRecovery/EventHandlerRecovery/Connection/TestRecoverySucceededEventHandlers.cs
+++ b/projects/Test/Integration/ConnectionRecovery/EventHandlerRecovery/Connection/TestRecoverySucceededEventHandlers.cs
@@ -32,6 +32,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using RabbitMQ.Client.Framing;
+using RabbitMQ.Client.Impl;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/projects/Test/Integration/ConnectionRecovery/TestConsumerRecovery.cs
+++ b/projects/Test/Integration/ConnectionRecovery/TestConsumerRecovery.cs
@@ -33,6 +33,7 @@ using System.Threading.Tasks;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Framing;
+using RabbitMQ.Client.Impl;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/projects/Test/Integration/ConnectionRecovery/TestDeclaration.cs
+++ b/projects/Test/Integration/ConnectionRecovery/TestDeclaration.cs
@@ -34,6 +34,7 @@ using System.Threading.Tasks;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Framing;
+using RabbitMQ.Client.Impl;
 using Xunit;
 using Xunit.Abstractions;
 using QueueDeclareOk = RabbitMQ.Client.QueueDeclareOk;

--- a/projects/Test/Integration/ConnectionRecovery/TestQueueRecovery.cs
+++ b/projects/Test/Integration/ConnectionRecovery/TestQueueRecovery.cs
@@ -33,6 +33,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Framing;
+using RabbitMQ.Client.Impl;
 using Xunit;
 using Xunit.Abstractions;
 using QueueDeclareOk = RabbitMQ.Client.QueueDeclareOk;

--- a/projects/Test/Integration/ConnectionRecovery/TestRecoveryWithDeletedEntities.cs
+++ b/projects/Test/Integration/ConnectionRecovery/TestRecoveryWithDeletedEntities.cs
@@ -34,6 +34,7 @@ using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Exceptions;
 using RabbitMQ.Client.Framing;
+using RabbitMQ.Client.Impl;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/projects/Test/Integration/TestAsyncConsumer.cs
+++ b/projects/Test/Integration/TestAsyncConsumer.cs
@@ -599,7 +599,7 @@ namespace Test.Integration
         {
             await ValidateConsumerDispatchConcurrency();
 
-            AssertRecordedQueues((RabbitMQ.Client.Framing.AutorecoveringConnection)_conn, 0);
+            AssertRecordedQueues((RabbitMQ.Client.Impl.AutorecoveringConnection)_conn, 0);
             var tasks = new List<Task>();
             for (int i = 0; i < 256; i++)
             {
@@ -613,7 +613,7 @@ namespace Test.Integration
                 }));
             }
             await Task.WhenAll(tasks);
-            AssertRecordedQueues((RabbitMQ.Client.Framing.AutorecoveringConnection)_conn, 0);
+            AssertRecordedQueues((RabbitMQ.Client.Impl.AutorecoveringConnection)_conn, 0);
         }
 
         [Fact]

--- a/projects/Test/Integration/TestConnectionRecoveryWithoutSetup.cs
+++ b/projects/Test/Integration/TestConnectionRecoveryWithoutSetup.cs
@@ -36,6 +36,7 @@ using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Exceptions;
 using RabbitMQ.Client.Framing;
+using RabbitMQ.Client.Impl;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/projects/Test/Integration/TestConnectionTopologyRecovery.cs
+++ b/projects/Test/Integration/TestConnectionTopologyRecovery.cs
@@ -37,6 +37,7 @@ using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Exceptions;
 using RabbitMQ.Client.Framing;
+using RabbitMQ.Client.Impl;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/projects/Test/Integration/TestFloodPublishing.cs
+++ b/projects/Test/Integration/TestFloodPublishing.cs
@@ -65,7 +65,7 @@ namespace Test.Integration
             _connFactory.RequestedHeartbeat = TimeSpan.FromSeconds(60);
             _connFactory.AutomaticRecoveryEnabled = false;
             _conn = await _connFactory.CreateConnectionAsync();
-            Assert.IsNotType<RabbitMQ.Client.Framing.AutorecoveringConnection>(_conn);
+            Assert.IsNotType<RabbitMQ.Client.Impl.AutorecoveringConnection>(_conn);
             _channel = await _conn.CreateChannelAsync(_createChannelOptions);
 
             _conn.ConnectionShutdownAsync += (_, ea) =>
@@ -177,7 +177,7 @@ namespace Test.Integration
             _connFactory.AutomaticRecoveryEnabled = false;
 
             _conn = await _connFactory.CreateConnectionAsync();
-            Assert.IsNotType<RabbitMQ.Client.Framing.AutorecoveringConnection>(_conn);
+            Assert.IsNotType<RabbitMQ.Client.Impl.AutorecoveringConnection>(_conn);
             _channel = await _conn.CreateChannelAsync();
 
             string message = "Hello from test TestMultithreadFloodPublishing";

--- a/projects/Test/Integration/TestInitialConnection.cs
+++ b/projects/Test/Integration/TestInitialConnection.cs
@@ -34,6 +34,7 @@ using System.Threading.Tasks;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Exceptions;
 using RabbitMQ.Client.Framing;
+using RabbitMQ.Client.Impl;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/projects/Test/Integration/TestPublishSharedChannelAsync.cs
+++ b/projects/Test/Integration/TestPublishSharedChannelAsync.cs
@@ -77,7 +77,7 @@ namespace Test.Integration
             {
                 try
                 {
-                    Assert.IsNotType<RabbitMQ.Client.Framing.AutorecoveringConnection>(conn);
+                    Assert.IsNotType<RabbitMQ.Client.Impl.AutorecoveringConnection>(conn);
                     conn.ConnectionShutdownAsync += HandleConnectionShutdownAsync;
 
                     await using IChannel channel = await conn.CreateChannelAsync();

--- a/projects/Test/SequentialIntegration/TestConnectionRecovery.cs
+++ b/projects/Test/SequentialIntegration/TestConnectionRecovery.cs
@@ -35,6 +35,7 @@ using System.Threading.Tasks;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Framing;
+using RabbitMQ.Client.Impl;
 using Xunit;
 using Xunit.Abstractions;
 using QueueDeclareOk = RabbitMQ.Client.QueueDeclareOk;


### PR DESCRIPTION
Closes #1908.

## Summary

Eight `internal` files in `projects/RabbitMQ.Client/Impl/` declared `namespace RabbitMQ.Client.Framing` despite living in the `Impl/` directory:

- `Connection.cs`, `Connection.Commands.cs`, `Connection.Heartbeat.cs`, `Connection.Receive.cs`
- `AutorecoveringConnection.cs`, `AutorecoveringConnection.Recovery.cs`, `AutorecoveringConnection.Recording.cs`
- `ProtocolBase.cs`

All eight are changed to `namespace RabbitMQ.Client.Impl`.

## Mechanical changes

- In each moved file, swap `using RabbitMQ.Client.Impl;` for `using RabbitMQ.Client.Framing;` (the file was previously inside Framing and now needs to import it).
- `Connection.Heartbeat.cs` had neither using; `using RabbitMQ.Client.Framing;` is added.
- `Framing/Protocol.cs` inherits `ProtocolBase` (now in `RabbitMQ.Client.Impl`); `using RabbitMQ.Client.Impl;` is added.
- Test files that referenced `AutorecoveringConnection` via the old namespace are updated to import `RabbitMQ.Client.Impl` instead or in addition.

## Public API impact

None - all affected types are `internal`.
