### PR TITLE
Apply [StructLayout(LayoutKind.Explicit)] union to DecimalData

### DIFF
--- a/projects/RabbitMQ.Client/Impl/WireFormatting.Read.cs
+++ b/projects/RabbitMQ.Client/Impl/WireFormatting.Read.cs
@@ -50,8 +50,8 @@ namespace RabbitMQ.Client.Impl
             }
 
             uint unsignedMantissa = NetworkOrderDeserializer.ReadUInt32(span.Slice(1));
-            var data = new DecimalData(((uint)(scale << 16)) | unsignedMantissa & 0x80000000, 0, unsignedMantissa & 0x7FFFFFFF, 0);
-            return Unsafe.As<DecimalData, decimal>(ref data);
+            var data = new DecimalData { Flags = ((uint)(scale << 16)) | unsignedMantissa & 0x80000000, Lo = unsignedMantissa & 0x7FFFFFFF };
+            return data.Value;
         }
 
         public static IList? ReadArray(ReadOnlySpan<byte> span, out int bytesRead)

--- a/projects/RabbitMQ.Client/Impl/WireFormatting.Write.cs
+++ b/projects/RabbitMQ.Client/Impl/WireFormatting.Write.cs
@@ -95,8 +95,7 @@ namespace RabbitMQ.Client.Impl
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int WriteDecimal(ref byte destination, decimal value)
         {
-            // Cast the decimal to our struct to avoid the decimal.GetBits allocations.
-            DecimalData data = Unsafe.As<decimal, DecimalData>(ref value);
+            var data = new DecimalData { Value = value };
             // According to the documentation :-
             //  - word 0: low-order "mantissa"
             //  - word 1, word 2: medium- and high-order "mantissa"

--- a/projects/RabbitMQ.Client/Impl/WireFormatting.cs
+++ b/projects/RabbitMQ.Client/Impl/WireFormatting.cs
@@ -29,6 +29,7 @@
 //  Copyright (c) 2007-2026 Broadcom. All Rights Reserved.
 //---------------------------------------------------------------------------
 
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace RabbitMQ.Client.Impl
@@ -48,20 +49,23 @@ namespace RabbitMQ.Client.Impl
         // by to produce the Decimal value; bits 24-30 are unused and must be zero;
         // and finally bit 31 indicates the sign of the Decimal value, 0 meaning
         // positive and 1 meaning negative.
-        readonly struct DecimalData
+        // [StructLayout(LayoutKind.Explicit)] overlays Value with the four component
+        // fields, replacing Unsafe.As reinterpret casts in ReadDecimal/WriteDecimal
+        // with type-safe field access. The CLR validates the layout at JIT time.
+        // The same pattern was applied to LastTimedOutCommandIds in PR #1939.
+        [StructLayout(LayoutKind.Explicit)]
+        private struct DecimalData
         {
-            public readonly uint Flags;
-            public readonly uint Hi;
-            public readonly uint Lo;
-            public readonly uint Mid;
-
-            internal DecimalData(uint flags, uint hi, uint lo, uint mid)
-            {
-                Flags = flags;
-                Hi = hi;
-                Lo = lo;
-                Mid = mid;
-            }
+            [FieldOffset(0)]
+            public decimal Value;
+            [FieldOffset(0)]
+            public uint Flags;
+            [FieldOffset(4)]
+            public uint Hi;
+            [FieldOffset(8)]
+            public uint Lo;
+            [FieldOffset(12)]
+            public uint Mid;
         }
 
         private static readonly UTF8Encoding UTF8 = new UTF8Encoding();


### PR DESCRIPTION
## Proposed Changes

`DecimalData` used `Unsafe.As<decimal, DecimalData>` and `Unsafe.As<DecimalData, decimal>` to reinterpret-cast between `decimal` and its four component `uint` fields. The layout contract was implicit: the cast relied on `decimal`'s sequential field order with no enforcement at the type level.

This applies the same `[StructLayout(LayoutKind.Explicit)]` union pattern introduced for `LastTimedOutCommandIds` in #1939: a `decimal Value` field overlays the four `uint` component fields via `[FieldOffset]`. The CLR validates the layout at JIT time, and `ReadDecimal`/`WriteDecimal` use type-safe field access instead of `Unsafe.As`.

Note: this is a code quality improvement, not a bug fix. C# defaults to `LayoutKind.Sequential`, so the original `Unsafe.As` casts were relying on guaranteed layout. The explicit union makes that contract visible and CLR-verified.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [x] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

`danielmarbach` noted in the #1939 review that the `Unsafe.As` pattern used for `DecimalData` was the same one he had followed when writing that PR, and that it also lacked explicit layout. This PR closes that gap.
