### PR TITLE
Fix URI round-trip for credentials containing special characters

### DIFF
--- a/projects/RabbitMQ.Client/ConnectionFactory.cs
+++ b/projects/RabbitMQ.Client/ConnectionFactory.cs
@@ -656,12 +656,12 @@ namespace RabbitMQ.Client
 
             if (false == string.IsNullOrEmpty(UserName))
             {
-                builder.UserName = UserName;
+                builder.UserName = Uri.EscapeDataString(UserName);
             }
 
             if (false == string.IsNullOrEmpty(Password))
             {
-                builder.Password = Password;
+                builder.Password = Uri.EscapeDataString(Password);
             }
 
             if (false == string.IsNullOrEmpty(VirtualHost))
@@ -709,15 +709,15 @@ namespace RabbitMQ.Client
             string userInfo = uri.UserInfo;
             if (!string.IsNullOrEmpty(userInfo))
             {
-                string[] userPass = userInfo.Split(':');
-                if (userPass.Length > 2)
+                int colonIndex = userInfo.IndexOf(':');
+                if (colonIndex == -1)
                 {
-                    throw new ArgumentException($"Bad user info in AMQP URI: {userInfo}");
+                    UserName = UriDecode(userInfo);
                 }
-                UserName = UriDecode(userPass[0]);
-                if (userPass.Length == 2)
+                else
                 {
-                    Password = UriDecode(userPass[1]);
+                    UserName = UriDecode(userInfo.Substring(0, colonIndex));
+                    Password = UriDecode(userInfo.Substring(colonIndex + 1));
                 }
             }
 

--- a/projects/RabbitMQ.Client/ConnectionFactory.cs
+++ b/projects/RabbitMQ.Client/ConnectionFactory.cs
@@ -710,7 +710,7 @@ namespace RabbitMQ.Client
             if (!string.IsNullOrEmpty(userInfo))
             {
                 int colonIndex = userInfo.IndexOf(':');
-                if (colonIndex == -1)
+                if (colonIndex < 0)
                 {
                     UserName = UriDecode(userInfo);
                 }

--- a/projects/Test/Unit/TestAmqpUri.cs
+++ b/projects/Test/Unit/TestAmqpUri.cs
@@ -272,5 +272,123 @@ namespace Test.Unit
 
             return factory.Uri;
         }
+
+        [Theory]
+        [InlineData("admin#123")]
+        [InlineData("admin:123")]
+        [InlineData("admin:pass:word")]
+        [InlineData("p@ssword")]
+        [InlineData("p word")]
+        [InlineData("p/word")]
+        [InlineData("p?word")]
+        [InlineData("p%word")]
+        [InlineData("#")]
+        [InlineData("##")]
+        [InlineData(":::")]
+        public void TestSetUri_PasswordWithSpecialCharacters(string password)
+        {
+            string user = "admin";
+            string host = "myhost";
+            int port = 5672;
+            string vhost = "/";
+
+            var uriString = $"amqp://{Uri.EscapeDataString(user)}:{Uri.EscapeDataString(password)}@{host}:{port}/%2F";
+            var uri = new Uri(uriString);
+
+            var factory = new ConnectionFactory { Uri = uri };
+
+            Assert.Equal(user, factory.UserName);
+            Assert.Equal(password, factory.Password);
+            Assert.Equal(host, factory.HostName);
+            Assert.Equal(port, factory.Port);
+            Assert.Equal(vhost, factory.VirtualHost);
+        }
+
+        [Theory]
+        [InlineData("admin#123")]
+        [InlineData("admin:123")]
+        [InlineData("admin:pass:word")]
+        [InlineData("p@ssword")]
+        [InlineData("p word")]
+        [InlineData("p/word")]
+        [InlineData("p?word")]
+        [InlineData("p%word")]
+        [InlineData("#")]
+        [InlineData("##")]
+        [InlineData(":::")]
+        public void TestGetUri_PasswordWithSpecialCharacters(string password)
+        {
+            var factory = new ConnectionFactory
+            {
+                UserName = "admin",
+                Password = password,
+                HostName = "myhost",
+                Port = 5672,
+                VirtualHost = "/"
+            };
+
+            Uri uri = factory.Uri;
+
+            var factory2 = new ConnectionFactory { Uri = uri };
+
+            Assert.Equal(factory.UserName, factory2.UserName);
+            Assert.Equal(factory.Password, factory2.Password);
+            Assert.Equal(factory.HostName, factory2.HostName);
+            Assert.Equal(factory.Port, factory2.Port);
+            Assert.Equal(factory.VirtualHost, factory2.VirtualHost);
+        }
+
+        [Theory]
+        [InlineData("adm#in")]
+        [InlineData("adm:in")]
+        [InlineData("adm@in")]
+        [InlineData("adm in")]
+        [InlineData("adm/in")]
+        public void TestSetUri_UserNameWithSpecialCharacters(string userName)
+        {
+            string password = "pass";
+            string host = "myhost";
+            int port = 5672;
+            string vhost = "/";
+
+            var uriString = $"amqp://{Uri.EscapeDataString(userName)}:{Uri.EscapeDataString(password)}@{host}:{port}/%2F";
+            var uri = new Uri(uriString);
+
+            var factory = new ConnectionFactory { Uri = uri };
+
+            Assert.Equal(userName, factory.UserName);
+            Assert.Equal(password, factory.Password);
+            Assert.Equal(host, factory.HostName);
+            Assert.Equal(port, factory.Port);
+            Assert.Equal(vhost, factory.VirtualHost);
+        }
+
+        [Theory]
+        [InlineData("adm#in")]
+        [InlineData("adm:in")]
+        [InlineData("adm@in")]
+        [InlineData("adm in")]
+        [InlineData("adm/in")]
+        public void TestGetUri_UserNameWithSpecialCharacters(string userName)
+        {
+            var factory = new ConnectionFactory
+            {
+                UserName = userName,
+                Password = "pass",
+                HostName = "myhost",
+                Port = 5672,
+                VirtualHost = "/"
+            };
+
+            Uri uri = factory.Uri;
+
+            var factory2 = new ConnectionFactory { Uri = uri };
+
+            Assert.Equal(factory.UserName, factory2.UserName);
+            Assert.Equal(factory.Password, factory2.Password);
+            Assert.Equal(factory.HostName, factory2.HostName);
+            Assert.Equal(factory.Port, factory2.Port);
+            Assert.Equal(factory.VirtualHost, factory2.VirtualHost);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Fix `SetUri` to split `UserInfo` on the first colon only (via `IndexOf`), allowing colons in the password per RFC 3986
- Fix `GetUri` to percent-encode `UserName` and `Password` via `Uri.EscapeDataString` before assigning to `UriBuilder`, which does not encode colons in the userinfo component
- Add unit tests covering `#`, `:`, `@`, space, `/`, `?`, and `%` in both username and password, exercising both the `SetUri` (pre-encoded URI input) and `GetUri` -> `SetUri` (property round-trip) paths

## Notes

The original discussion (#1943) reports "Invalid port specified" when a password contains `#`. That error comes from .NET's `System.Uri` constructor when given an unescaped string - it is not a bug in this library. However, during investigation I found a real bug: `SetUri` uses `Split(':')` and rejects results with more than two parts, which breaks when credentials contain literal colons. `UriBuilder` does not percent-encode colons in userinfo, so the `GetUri()` -> `SetUri()` round-trip was lossy.

## Test plan

- [x] All 34 `TestAmqpUri` tests pass (including 4 previously failing colon cases)
- [x] Full unit test suite (124 tests) passes with no regressions
