### PR TITLE
Validate `shortstr` byte length in `WriteShortstr`

### DIFF
--- a/projects/RabbitMQ.Client/Impl/WireFormatting.Write.cs
+++ b/projects/RabbitMQ.Client/Impl/WireFormatting.Write.cs
@@ -342,19 +342,24 @@ namespace RabbitMQ.Client.Impl
             int bytesWritten = 0;
             if (!string.IsNullOrEmpty(val))
             {
+                int byteCount = UTF8.GetByteCount(val);
+                if (byteCount > byte.MaxValue)
+                {
+                    return ThrowArgumentTooLong(byteCount);
+                }
+
                 unsafe
                 {
-
                     ref byte valDestination = ref destination.GetOffset(1);
                     fixed (char* chars = val)
                     fixed (byte* bytes = &valDestination)
                     {
-                        bytesWritten = UTF8.GetBytes(chars, val!.Length, bytes, byte.MaxValue);
+                        bytesWritten = UTF8.GetBytes(chars, val!.Length, bytes, byteCount);
                     }
                 }
             }
 
-            destination = unchecked((byte)bytesWritten);
+            destination = (byte)bytesWritten;
             return bytesWritten + 1;
         }
 

--- a/projects/RabbitMQ.Client/Impl/WireFormatting.Write.cs
+++ b/projects/RabbitMQ.Client/Impl/WireFormatting.Write.cs
@@ -342,10 +342,17 @@ namespace RabbitMQ.Client.Impl
             int bytesWritten = 0;
             if (!string.IsNullOrEmpty(val))
             {
-                int byteCount = UTF8.GetByteCount(val);
+                // GetMaxByteCount is cheap bit arithmetic that yields an upper bound
+                // on the encoded size. Only fall back to the O(n) exact count when
+                // that upper bound exceeds the shortstr maximum.
+                int byteCount = UTF8.GetMaxByteCount(val!.Length);
                 if (byteCount > byte.MaxValue)
                 {
-                    return ThrowArgumentTooLong(byteCount);
+                    byteCount = UTF8.GetByteCount(val);
+                    if (byteCount > byte.MaxValue)
+                    {
+                        return ThrowArgumentTooLong(byteCount);
+                    }
                 }
 
                 unsafe

--- a/projects/Test/Unit/TestFieldTableFormatting.cs
+++ b/projects/Test/Unit/TestFieldTableFormatting.cs
@@ -129,7 +129,7 @@ namespace Test.Unit
             int bytesNeeded = WireFormatting.GetTableByteCount(t);
             byte[] bytes = new byte[bytesNeeded];
 
-            Assert.Throws<ArgumentException>(() => WireFormatting.WriteTable(ref bytes.GetStart(), t));
+            Assert.Throws<ArgumentOutOfRangeException>(() => WireFormatting.WriteTable(ref bytes.GetStart(), t));
         }
 
         [Fact]

--- a/projects/Test/Unit/TestWriteShortstr.cs
+++ b/projects/Test/Unit/TestWriteShortstr.cs
@@ -1,0 +1,84 @@
+// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2026 Broadcom. All Rights Reserved.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       https://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v2.0:
+//
+//---------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//  Copyright (c) 2007-2026 Broadcom. All Rights Reserved.
+//---------------------------------------------------------------------------
+
+using System;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Impl;
+using Xunit;
+
+namespace Test.Unit
+{
+    public class TestWriteShortstr
+    {
+        [Fact]
+        public void TestWriteShortstrAtMaxLengthSucceeds()
+        {
+            string val = new string('a', byte.MaxValue);
+            byte[] bytes = new byte[byte.MaxValue + 1];
+
+            int written = WireFormatting.WriteShortstr(ref bytes.GetStart(), val);
+
+            Assert.Equal(byte.MaxValue + 1, written);
+            int read = WireFormatting.ReadShortstr(bytes, out string actual);
+            Assert.Equal(byte.MaxValue + 1, read);
+            Assert.Equal(val, actual);
+        }
+
+        [Fact]
+        public void TestWriteShortstrTooLongThrowsClearException()
+        {
+            string val = new string('a', byte.MaxValue + 1);
+            byte[] bytes = new byte[byte.MaxValue + 2];
+
+            ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => WireFormatting.WriteShortstr(ref bytes.GetStart(), val));
+
+            Assert.Contains("maximum allowed length of 255 bytes", ex.Message);
+            Assert.Contains("256", ex.Message);
+        }
+
+        [Fact]
+        public void TestWriteShortstrCountsBytesNotChars()
+        {
+            // Each of these characters encodes to two UTF-8 bytes, so 200 characters
+            // is 400 bytes, which exceeds the shortstr maximum even though the string
+            // is well under 255 characters long.
+            string val = new string('é', 200);
+            byte[] bytes = new byte[512];
+
+            ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => WireFormatting.WriteShortstr(ref bytes.GetStart(), val));
+
+            Assert.Contains("maximum allowed length of 255 bytes", ex.Message);
+            Assert.Contains("400", ex.Message);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1952.

## Problem

When a string's UTF-8 encoding exceeds 255 bytes, the `string` overload of `WireFormatting.WriteShortstr` passed a hardcoded `byte.MaxValue` as the destination byte count to `UTF8.GetBytes`, producing a cryptic framework exception:

```
System.ArgumentException: The output byte buffer is too small to contain the encoded data, encoding codepage '65001' and fallback 'System.Text.EncoderReplacementFallback'. (Parameter 'bytes')
```

This gave no indication of which value was too long. A `shortstr` is length-prefixed by a single octet, so 255 bytes is its hard maximum. The `ReadOnlySpan<byte>` overload already validated this and threw a clear message; the `string` overload is the funnel for every other shortstr site (exchange, queue, routing key, `BasicProperties`, table keys, consumer tags), so all of them shared the defect.

## Fix

Compute the encoded byte count up front and throw the existing clear `ThrowArgumentTooLong` error when it exceeds 255:

```
Value exceeds the maximum allowed length of 255 bytes, was 256 long.
```

Pass the real `byteCount` to `GetBytes`, which is safe because the buffer is pre-sized to the true byte count via `GetRequiredBufferSize`. The `unchecked` cast on the length prefix is no longer needed now that the guard bounds `bytesWritten` to 255.

## Tests

Added unit tests covering the 255-byte boundary, a 256-byte string, and a multi-byte string whose char count is small but byte count exceeds 255. Updated `TestTableEncoding_LongKey` to expect the more specific `ArgumentOutOfRangeException`.