### PR TITLE
Fix spurious "buffer too small" in WriteLongstr(string) on 32-bit LAA…

### DIFF
--- a/projects/RabbitMQ.Client/Impl/WireFormatting.Write.cs
+++ b/projects/RabbitMQ.Client/Impl/WireFormatting.Write.cs
@@ -373,8 +373,19 @@ namespace RabbitMQ.Client.Impl
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int WriteLongstr(ref byte destination, string val)
         {
-            static int GetBytes(ref byte destination, string val, int byteCount)
+            static int GetBytes(ref byte destination, string val)
             {
+                // On 32-bit (large-address-aware) processes "bytes + int.MaxValue"
+                // wraps around whenever the destination buffer is located above
+                // 0x80000000, making the encoder throw a spurious "output byte
+                // buffer is too small" ArgumentException. Use the exact byte count
+                // there. On 64-bit the addition cannot overflow, so the original
+                // one-pass behavior is preserved; IntPtr.Size is a JIT-time
+                // constant, so the check itself is free.
+                int byteCount = IntPtr.Size == 4
+                    ? UTF8.GetByteCount(val)
+                    : int.MaxValue;
+
                 unsafe
                 {
                     fixed (char* chars = val)
@@ -385,13 +396,7 @@ namespace RabbitMQ.Client.Impl
                 }
             }
 
-            // Do not pass int.MaxValue as the destination byte count: the encoder
-            // computes "bytes + byteCount", which wraps around in 32-bit
-            // large-address-aware processes when the destination buffer is located
-            // above 0x80000000, throwing a spurious "output byte buffer is too
-            // small" ArgumentException. The exact byte count cannot wrap for a
-            // valid destination buffer, since the encoded bytes fit within it.
-            int bytesWritten = string.IsNullOrEmpty(val) ? 0 : GetBytes(ref destination.GetOffset(4), val, UTF8.GetByteCount(val));
+            int bytesWritten = string.IsNullOrEmpty(val) ? 0 : GetBytes(ref destination.GetOffset(4), val);
             NetworkOrderSerializer.WriteUInt32(ref destination, (uint)bytesWritten);
             return bytesWritten + 4;
         }

--- a/projects/RabbitMQ.Client/Impl/WireFormatting.Write.cs
+++ b/projects/RabbitMQ.Client/Impl/WireFormatting.Write.cs
@@ -373,19 +373,25 @@ namespace RabbitMQ.Client.Impl
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int WriteLongstr(ref byte destination, string val)
         {
-            static int GetBytes(ref byte destination, string val)
+            static int GetBytes(ref byte destination, string val, int byteCount)
             {
                 unsafe
                 {
                     fixed (char* chars = val)
                     fixed (byte* bytes = &destination)
                     {
-                        return UTF8.GetBytes(chars, val.Length, bytes, int.MaxValue);
+                        return UTF8.GetBytes(chars, val.Length, bytes, byteCount);
                     }
                 }
             }
 
-            int bytesWritten = string.IsNullOrEmpty(val) ? 0 : GetBytes(ref destination.GetOffset(4), val);
+            // Do not pass int.MaxValue as the destination byte count: the encoder
+            // computes "bytes + byteCount", which wraps around in 32-bit
+            // large-address-aware processes when the destination buffer is located
+            // above 0x80000000, throwing a spurious "output byte buffer is too
+            // small" ArgumentException. The exact byte count cannot wrap for a
+            // valid destination buffer, since the encoded bytes fit within it.
+            int bytesWritten = string.IsNullOrEmpty(val) ? 0 : GetBytes(ref destination.GetOffset(4), val, UTF8.GetByteCount(val));
             NetworkOrderSerializer.WriteUInt32(ref destination, (uint)bytesWritten);
             return bytesWritten + 4;
         }


### PR DESCRIPTION
… processes

## Problem

`WireFormatting.WriteLongstr(ref byte destination, string val)` calls `UTF8.GetBytes(chars, val.Length, bytes, int.MaxValue)`, passing `int.MaxValue` as the destination byte count.

Internally the encoder computes the end-of-buffer pointer as `bytes + byteCount`. In a **32-bit large-address-aware process** (e.g. an IIS application pool with *Enable 32-Bit Applications* on 64-bit Windows, where usable address space approaches 4 GB), whenever the destination buffer rented from the `ArrayPool` happens to be located **above `0x80000000`**, `bytes + int.MaxValue` overflows and wraps around. The encoder then believes it has zero bytes available and throws:

```
System.ArgumentException: The output byte buffer is too small to contain
the encoded data, encoding 'Unicode (UTF-8)' fallback
'System.Text.EncoderReplacementFallback'.
Parameter name: bytes
   at System.Text.Encoding.ThrowBytesOverflow()
   at System.Text.Encoding.ThrowBytesOverflow(EncoderNLS encoder, Boolean nothingEncoded)
   at System.Text.UTF8Encoding.GetBytes(Char* chars, Int32 charCount, Byte* bytes, Int32 byteCount, EncoderNLS baseEncoder)
   at System.Text.UTF8Encoding.GetBytes(Char* chars, Int32 charCount, Byte* bytes, Int32 byteCount)
   at RabbitMQ.Client.Impl.WireFormatting.<WriteLongstr>g__GetBytes|39_0(Byte& destination, String val)
   at RabbitMQ.Client.Impl.WireFormatting.WriteFieldValue(Byte& destination, Object value)
   at RabbitMQ.Client.Impl.WireFormatting.WriteTable(Byte& destination, IDictionary`2 val)
   at RabbitMQ.Client.BasicProperties.RabbitMQ.Client.IAmqpWriteable.WriteTo(Span`1 span)
   at RabbitMQ.Client.Impl.Framing.Header.WriteTo[T](Span`1 span, UInt16 channel, T& header, Int32 bodyLength)
   at RabbitMQ.Client.Impl.Framing.SerializeToFrames[TMethod,THeader](...)
   at RabbitMQ.Client.Impl.Channel.BasicPublishAsync(...)
```

The failure is intermittent and content-independent: the very same publish succeeds or fails depending only on where the pooled buffer lands in the address space. In our production system (ASP.NET on IIS, 32-bit worker process) it appears once the worker's virtual address space grows past 2 GB, and disappears after an IIS recycle (address space pressure resets). Once the process is above the threshold we measured a stable **~1% failure rate** on publishes, so this is reliably reproducible, not a fluke.

Observed with 7.1.2 and 7.2.1; the code on `main` is unchanged.

Related: #1952 shows the same exception type for `shortstr`, but that case is about the 255-byte protocol limit. This one is different: no limit is actually exceeded — it is pure 32-bit pointer-arithmetic overflow caused by the `int.MaxValue` argument.

Notably, `WriteShortstr(string)` **already bounds the byte count** it passes to `UTF8.GetBytes` (since #1953, via `GetMaxByteCount` / `GetByteCount`). This PR applies the equivalent safety to `WriteLongstr(string)`.

## Reproduction

Standalone program, deterministic (100% reproducible). Must be compiled x86 **with the LargeAddressAware flag** (IIS 32-bit worker processes are LAA by default):

```csharp
// Allocate one buffer at the top of the address space (> 2 GB) and one
// normally (< 2 GB), then run the exact call WriteLongstr makes:
IntPtr high = VirtualAlloc(IntPtr.Zero, (UIntPtr)65536,
    MEM_COMMIT | MEM_RESERVE | MEM_TOP_DOWN, PAGE_READWRITE);
IntPtr low  = VirtualAlloc(IntPtr.Zero, (UIntPtr)65536,
    MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);

string val = "some.assembly.qualified.name"; // any short ASCII string
fixed (char* chars = val)
{
    // low buffer (e.g. 0x00CD0000): writes fine
    Encoding.UTF8.GetBytes(chars, val.Length, (byte*)low, int.MaxValue);

    // high buffer (e.g. 0xFFAA0000): throws the exact exception above,
    // because (bytes + int.MaxValue) wraps around 2^32
    Encoding.UTF8.GetBytes(chars, val.Length, (byte*)high, int.MaxValue);
}
```

## Fix

Pass the exact required byte count (`UTF8.GetByteCount(val)`) instead of `int.MaxValue`. Since the encoded bytes fit inside the (valid) rented buffer by construction, `destination + exactByteCount` can never wrap.

The `GetMaxByteCount` fast path used by `WriteShortstr` was deliberately not used here: for `longstr` there is no 255-byte cap to validate against, and the *max* count (≈ 3×length) could still theoretically wrap for very long strings when the buffer sits near the very top of the address space. The exact count is provably safe for any valid destination buffer. The extra `GetByteCount` pass only affects the string overload used for field table values (typically short header strings).

## Testing note

This cannot be covered by a regular unit test: it requires a 32-bit large-address-aware host whose allocations land above 0x80000000, which cannot be forced from managed code in a normal CI run. The standalone repro above demonstrates the failure deterministically.


