### PR TITLE
Fix `global.json` SDK version for setup-dotnet v6

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "8.0.100",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   }


### PR DESCRIPTION
## Summary

CI on `main` is currently red on every run: both `build-ubuntu` and `build-win32` fail at the setup-dotnet step, and all test jobs are skipped as a result. Example: https://github.com/rabbitmq/rabbitmq-dotnet-client/actions/runs/30289402242

## Cause

Dependabot #1957 bumped `actions/setup-dotnet` from 5.3.0 to 6.0.0. setup-dotnet v6 changed how it validates `global.json`: when `rollForward` is set, `sdk.version` must be a full SDK version. Our `global.json` pinned `8.0.0`, which is not a valid SDK feature-band version, so v6 fails:

```
Version '8.0.0' is not valid for the 'sdk.version' value in global.json.
When 'rollForward' is specified, a full SDK version is required.
```

## Fix

Pin `sdk.version` to `8.0.100`, a valid feature-band version. With `rollForward: latestFeature` retained, it still resolves to the latest installed 8.0.x SDK, so the effective behavior is unchanged. Verified locally: `dotnet --version` against the updated `global.json` resolves to `8.0.129`.

This is the forward fix and keeps the intended v6 action bump. Reverting the action to v5 would only defer the same failure to the next bump.
