### PR TITLE
Fix ShutdownEventArgs.CancellationToken always-cancelled in consumer ShutdownAsync (#1888)

### DIFF
--- a/projects/RabbitMQ.Client/ConsumerDispatching/ConsumerDispatcherChannelBase.cs
+++ b/projects/RabbitMQ.Client/ConsumerDispatching/ConsumerDispatcherChannelBase.cs
@@ -223,7 +223,7 @@ namespace RabbitMQ.Client.ConsumerDispatching
 
         protected sealed override void ShutdownConsumer(IAsyncBasicConsumer consumer, ShutdownEventArgs reason)
         {
-            _writer.TryWrite(WorkStruct.CreateShutdown(consumer, reason, _shutdownCts));
+            _writer.TryWrite(WorkStruct.CreateShutdown(consumer, reason));
         }
 
         protected override Task InternalShutdownAsync()
@@ -247,7 +247,6 @@ namespace RabbitMQ.Client.ConsumerDispatching
             public readonly ShutdownEventArgs? Reason;
             public readonly WorkType WorkType;
             public readonly CancellationToken CancellationToken;
-            private readonly CancellationTokenSource? _cancellationTokenSource;
 
             private WorkStruct(WorkType type, IAsyncBasicConsumer consumer, string consumerTag, CancellationToken cancellationToken)
                 : this()
@@ -256,17 +255,21 @@ namespace RabbitMQ.Client.ConsumerDispatching
                 Consumer = consumer;
                 ConsumerTag = consumerTag;
                 CancellationToken = cancellationToken;
-                _cancellationTokenSource = null;
             }
 
-            private WorkStruct(IAsyncBasicConsumer consumer, ShutdownEventArgs reason, CancellationTokenSource? cancellationTokenSource)
+            private WorkStruct(IAsyncBasicConsumer consumer, ShutdownEventArgs reason)
                 : this()
             {
                 WorkType = WorkType.Shutdown;
                 Consumer = consumer;
                 Reason = reason;
-                CancellationToken = cancellationTokenSource?.Token ?? CancellationToken.None;
-                this._cancellationTokenSource = cancellationTokenSource;
+                // The shutdown handler's token must reflect only whether the shutdown
+                // operation itself was cancelled by the caller, so it flows directly
+                // from the shutdown reason. It must NOT be linked to the dispatcher's
+                // _shutdownCts: that source is cancelled by Quiesce() before shutdown
+                // work is dispatched (to cancel in-flight deliveries), which would make
+                // the handler's token always arrive already-cancelled (see #1888).
+                CancellationToken = reason.CancellationToken;
             }
 
             private WorkStruct(IAsyncBasicConsumer consumer, string consumerTag, ulong deliveryTag, bool redelivered,
@@ -284,7 +287,6 @@ namespace RabbitMQ.Client.ConsumerDispatching
                 Body = body;
                 Reason = null;
                 CancellationToken = cancellationToken;
-                _cancellationTokenSource = null;
             }
 
             public static WorkStruct CreateCancel(IAsyncBasicConsumer consumer, string consumerTag, CancellationTokenSource cancellationTokenSource)
@@ -302,28 +304,14 @@ namespace RabbitMQ.Client.ConsumerDispatching
                 return new WorkStruct(WorkType.ConsumeOk, consumer, consumerTag, cancellationTokenSource.Token);
             }
 
-            public static WorkStruct CreateShutdown(IAsyncBasicConsumer consumer, ShutdownEventArgs reason, CancellationTokenSource cancellationTokenSource)
+            public static WorkStruct CreateShutdown(IAsyncBasicConsumer consumer, ShutdownEventArgs reason)
             {
-                // Create a linked CTS so the shutdown args token reflects both dispatcher cancellation and any upstream token.
-                CancellationTokenSource? linked = null;
-                try
-                {
-                    if (reason.CancellationToken.CanBeCanceled)
-                    {
-                        linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationTokenSource.Token, reason.CancellationToken);
-                    }
-                }
-                catch
-                {
-                    linked = null;
-                }
-
-                CancellationToken token = linked?.Token ?? cancellationTokenSource.Token;
-                ShutdownEventArgs argsWithToken = reason.Exception != null ?
-                    new ShutdownEventArgs(reason.Initiator, reason.ReplyCode, reason.ReplyText, reason.Exception, token) :
-                    new ShutdownEventArgs(reason.Initiator, reason.ReplyCode, reason.ReplyText, reason.ClassId, reason.MethodId, reason.Cause, token);
-
-                return new WorkStruct(consumer, argsWithToken, linked);
+                // The shutdown reason already carries the correct cancellation token (the
+                // token of the close operation, if any). It must be handed to the consumer
+                // as-is: linking it to the dispatcher's _shutdownCts here would make the
+                // handler's token always arrive already-cancelled, because Quiesce()
+                // cancels _shutdownCts before shutdown work is dispatched (see #1888).
+                return new WorkStruct(consumer, reason);
             }
 
             public static WorkStruct CreateDeliver(IAsyncBasicConsumer consumer, string consumerTag, ulong deliveryTag, bool redelivered,
@@ -336,7 +324,6 @@ namespace RabbitMQ.Client.ConsumerDispatching
             public void Dispose()
             {
                 Body.Dispose();
-                _cancellationTokenSource?.Dispose();
             }
         }
 

--- a/projects/Test/Integration/TestAsyncConsumerCancellation.cs
+++ b/projects/Test/Integration/TestAsyncConsumerCancellation.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
@@ -26,20 +27,20 @@ namespace Test.Integration
 
             var tcsMessageReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var tcsReceivedCancelled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var tcsShutdownCancelled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcsShutdown = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var consumer = new AsyncEventingBasicConsumer(_channel);
 
-            consumer.ShutdownAsync += async (model, ea) =>
+            consumer.ShutdownAsync += (model, ea) =>
             {
-                try
-                {
-                    await Task.Delay(TimeSpan.FromMinutes(1), ea.CancellationToken);
-                }
-                catch (OperationCanceledException)
-                {
-                    tcsShutdownCancelled.SetResult(true);
-                }
+                /*
+                 * rabbitmq/rabbitmq-dotnet-client#1888
+                 * On a normal close (no caller token), the shutdown handler's token
+                 * must NOT be cancelled. It reflects only whether the close operation
+                 * itself was cancelled by the caller.
+                 */
+                tcsShutdown.TrySetResult(false == ea.CancellationToken.IsCancellationRequested);
+                return Task.CompletedTask;
             };
 
             consumer.ReceivedAsync += async (model, ea) =>
@@ -69,6 +70,48 @@ namespace Test.Integration
             await _channel.CloseAsync();
 
             await WaitAsync(tcsReceivedCancelled, TimeSpan.FromSeconds(5), "ReceivedAsync cancelled");
+            await WaitAsync(tcsShutdown, TimeSpan.FromSeconds(5), "ShutdownAsync invoked");
+            Assert.True(await tcsShutdown.Task,
+                "ShutdownAsync token must not be cancelled on a normal close");
+        }
+
+        [Fact]
+        public async Task TestConsumerShutdownCancellationTokenFiresWhenCloseIsCancelled()
+        {
+            string exchangeName = GenerateExchangeName();
+            string queueName = GenerateQueueName();
+            string routingKey = string.Empty;
+
+            await _channel.ExchangeDeclareAsync(exchangeName, ExchangeType.Direct);
+            await _channel.QueueDeclareAsync(queueName, false, true, true, null);
+            await _channel.QueueBindAsync(queueName, exchangeName, routingKey, null);
+
+            var tcsShutdownCancelled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var consumer = new AsyncEventingBasicConsumer(_channel);
+
+            consumer.ShutdownAsync += async (model, ea) =>
+            {
+                /*
+                 * rabbitmq/rabbitmq-dotnet-client#1888
+                 * When the caller cancels the close, that cancellation must flow into
+                 * the shutdown handler's token.
+                 */
+                try
+                {
+                    await Task.Delay(TimeSpan.FromMinutes(1), ea.CancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    tcsShutdownCancelled.SetResult(true);
+                }
+            };
+
+            await _channel.BasicConsumeAsync(queueName, false, consumer);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            await _channel.CloseAsync(cts.Token);
+
             await WaitAsync(tcsShutdownCancelled, TimeSpan.FromSeconds(5), "ShutdownAsync cancellation");
         }
     }


### PR DESCRIPTION
## Summary

Fixes #1888. The `CancellationToken` on the `ShutdownEventArgs` handed to a consumer's `ShutdownAsync` (e.g. `AsyncEventingBasicConsumer.ShutdownAsync`) was always in an `IsCancellationRequested == true` state on a normal close or server shutdown, contradicting the `AsyncEventArgs.CancellationToken` documentation that tells handlers to propagate the token to cleanup work.

## Root cause

The shutdown handler's token was built in `ConsumerDispatcherChannelBase.CreateShutdown` by linking the dispatcher's `_shutdownCts`:

```csharp
linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationTokenSource.Token, reason.CancellationToken);
```

But `_shutdownCts` is cancelled by `Quiesce()`, and `Quiesce()` always runs *before* shutdown work is dispatched, on both close paths:

- Client close: `Channel.CloseAsync` calls `ConsumerDispatcher.Quiesce()`, then later `ShutdownAsync`.
- Server/session close: `OnSessionShutdownAsync` calls `Quiesce()`, then `ConsumerDispatcher.ShutdownAsync(reason)`.

So by the time `CreateShutdown` linked `_shutdownCts`, it was already cancelled, and the handler's token was born cancelled on every shutdown.

`_shutdownCts` has a legitimate job: cancelling in-flight *deliveries* when the channel quiesces. Conflating it with the shutdown/cleanup handler's token was the bug.

## Fix

`CreateShutdown` now hands the consumer the shutdown `reason` as-is, so the handler's token is exactly `reason.CancellationToken` (the token of the close operation). It is:

- **not** cancelled on a normal close (`CloseAsync()`) or a server-initiated shutdown, and
- cancelled only when the caller cancels the close, e.g. `CloseAsync(cts.Token)`.

Delivery cancellation is unaffected: deliveries still flow through `_shutdownCts`. With the shutdown work no longer holding a linked CTS, the now-dead `WorkStruct._cancellationTokenSource` field and its `Dispose()` call are removed.

## Tests

- Updated `TestAsyncConsumerCancellation.TestConsumerCancellation` to assert the shutdown token is **not** cancelled on a plain `CloseAsync()` (it previously asserted the buggy behavior), keeping its delivery-cancellation assertion.
- Added `TestConsumerShutdownCancellationTokenFiresWhenCloseIsCancelled` covering the cancelled-close case (`CloseAsync(cts.Token)` -> handler token fires).

Verified against a local broker (net8.0): both tests pass with the fix, and the updated test fails against the pre-fix client (confirming it does not pass for the wrong reason). The broader `TestAsyncConsumer*` / `TestChannelShutdown` / `TestConnectionShutdown` suites remain green.
