### PR TITLE
Restore channel continuation timeout before cleanup close in TestRpcContinuationTimeout_GH1802 (#1958)

### DIFF
--- a/projects/Test/Integration/TestToxiproxy.cs
+++ b/projects/Test/Integration/TestToxiproxy.cs
@@ -436,6 +436,7 @@ namespace Test.Integration
             await Task.Delay(TimeSpan.FromSeconds(1));
 
             bool sawContinuationTimeout = false;
+            TimeSpan originalContinuationTimeout = ch.ContinuationTimeout;
             try
             {
                 ch.ContinuationTimeout = TimeSpan.FromMilliseconds(5);
@@ -444,6 +445,13 @@ namespace Test.Integration
             catch (OperationCanceledException)
             {
                 sawContinuationTimeout = true;
+            }
+            finally
+            {
+                // Restore the continuation timeout so the cleanup CloseAsync below
+                // does not race the channel.close-ok round-trip against the 5 ms
+                // window used to force the timeout under test (see #1958).
+                ch.ContinuationTimeout = originalContinuationTimeout;
             }
 
             await _toxiproxyManager.RemoveToxicAsync(toxicName);


### PR DESCRIPTION
## Summary

Fixes #1958. `TestToxiproxy.TestRpcContinuationTimeout_GH1802` fails intermittently with `TaskCanceledException`. The failure is in the test's own cleanup, not the behavior under test: the assertion (`sawContinuationTimeout`) has already passed by the time the exception escapes.

## Root cause

The test lowers the per-channel continuation timeout to 5 ms to force the RPC continuation timeout it is verifying, but never restores it:

```csharp
ch.ContinuationTimeout = TimeSpan.FromMilliseconds(5);   // to force the timeout under test
QueueDeclareOk q = await ch.QueueDeclareAsync();         // times out as intended
...
await ch.CloseAsync();                                    // cleanup: still runs with 5 ms timeout
```

The cleanup `CloseAsync()` therefore has to complete its `channel.close-ok` round-trip within 5 ms. On a loaded runner that round-trip exceeds 5 ms, the continuation at `Channel.CloseAsync` times out, and `TaskCanceledException` fails the test after the real assertion already succeeded.

## Fix

Capture the original `ContinuationTimeout` and restore it in a `finally`, so the 5 ms window scopes only to the operation under test and the cleanup close runs with a normal timeout. Test-only change; no client code is touched.

## Verification

Ran against a local broker + Toxiproxy (net8.0):

- With the fix: 15/15 runs passed.
- Without the fix (same environment): failed 9+ of ~12 runs, confirming the flake reproduces heavily and the fix eliminates it (i.e. the fix does not pass for the wrong reason).
