### PR TITLE
Correct inaccuracies across all repository markdown docs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -14,7 +14,7 @@ cause analysis and so on.
 Please take the time to read the CONTRIBUTING.md document for instructions on
 how to effectively ask a question or report a suspected issue:
 
-https://github.com/rabbitmq/rabbitmq-server/blob/master/CONTRIBUTING.md#github-issues
+https://github.com/rabbitmq/rabbitmq-server/blob/main/CONTRIBUTING.md#github-issues
 
 Following these rules **will save time** for both you and RabbitMQ's maintainers.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,7 +30,7 @@ mailing list. We're here to help! This is simply a reminder of what we are
 going to look for before merging your code._
 
 - [ ] I have read the `CONTRIBUTING.md` document
-- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
+- [ ] I have signed the CLA (see https://github.com/rabbitmq/cla)
 - [ ] All tests pass locally with my changes
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have added necessary documentation (if appropriate)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ The connection layer manages the TCP connection to RabbitMQ broker:
 
 #### 2. Automatic Recovery (`AutorecoveringConnection`)
 
-**Location**: `projects/RabbitMQ.Client/Impl/AutorecoveringConnection.cs`
+**Location**: `projects/RabbitMQ.Client/Impl/AutorecoveringConnection.cs` (partial class, with `AutorecoveringConnection.Recording.cs` and `AutorecoveringConnection.Recovery.cs`)
 
 Wraps `Connection` to provide automatic recovery from network failures:
 
@@ -367,17 +367,18 @@ rabbitmq-dotnet-client/
 **Location**: `projects/RabbitMQ.Client/Logging/`
 
 - **EventSource**: `RabbitMqClientEventSource` for ETW/EventPipe
-- **Counters**: Connection count, channel count, published messages
+- **Counters**: connection/channel open counts, byte and AMQP method rates
 - **Structured Logging**: Exception details with context
 
 ### Metrics
 
-Available via EventSource counters:
-- Active connections
-- Active channels
-- Messages published
-- Messages consumed
-- Bytes sent/received
+Available via EventSource counters (`net8.0` only - the counters are inside an
+`#if NET` block, so the netstandard2.0 build has none):
+
+- `total-connections-opened`, `current-open-connections`
+- `total-channels-opened`, `current-open-channels`
+- `bytes-sent-rate`, `bytes-received-rate`
+- `AMQP-method-sent-rate`, `AMQP-method-received-rate`
 
 ### Tracing
 
@@ -408,7 +409,9 @@ Configurable TLS options:
 
 - **ICredentialsProvider**: Abstraction for credential sources
 - **BasicCredentialsProvider**: Static credentials
-- **OAuth2CredentialsProvider**: Dynamic token refresh
+- **OAuth2ClientCredentialsProvider**: Dynamic token refresh (in
+  `projects/RabbitMQ.Client.OAuth2/OAuth2CredentialsProvider.cs`; note the class
+  name does not match the file name)
 
 ## Known Issues and Limitations
 
@@ -434,7 +437,10 @@ there. Current docs:
 
 - `docs/internal/connection-shutdown-and-cancellation.md` - the connection /
   channel-0 shutdown model, why cancellation during connection open could hang
-  (issue #1921), and the memory-dump-based diagnostic workflow used to find it.
+  (issue #1921), why shutdown handlers could deadlock on the main loop token
+  when MainLoop wins the close-reason race (issue #1960), which cancellation
+  token a shutdown handler actually receives on each close path, and the
+  memory-dump-based diagnostic workflow used to find these.
 
 ## Development Guidelines
 
@@ -468,7 +474,10 @@ there. Current docs:
 
 - **System.IO.Pipelines**: High-performance I/O
 - **System.Threading.RateLimiting**: Publisher confirms rate limiting
-- **System.Threading.Channels**: Consumer work queue
+- **Nullable**: Build-time only (`PrivateAssets="all"`), for nullable attributes
+
+Note: `System.Threading.Channels` backs the consumer work queue but is built into
+net8.0; it is only an explicit package reference for netstandard2.0 (below).
 
 ### .NET Standard 2.0 Additional Dependencies
 

--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -3,7 +3,7 @@
 Updating the content in the `_site` submodule (which is this repository's `gh-pages` branch) is a manual process that must be done on Windows (as of docfx `2.31`):
 
 ```
-cd C:\path\to\rabbitmq-dotnet-client`
+cd C:\path\to\rabbitmq-dotnet-client
 git submodule update --init
 pushd _site
 git remote add origin-ssh git@github.com:rabbitmq/rabbitmq-dotnet-client.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ See [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md).
 If you want to contribute a non-trivial change, please submit a signed
 copy of our [Contributor Agreement][ca-agreement] around the time you
 submit your pull request. This will make it much easier (in some
-cases, possible) for the RabbitMQ team at Pivotal to merge your
+cases, possible) for the RabbitMQ team at Broadcom to merge your
 contribution.
 
 ## Where to Ask Questions
@@ -141,5 +141,5 @@ If something isn't clear, feel free to ask on our [mailing list][rmq-users].
 [rmq-collect-env]: https://github.com/rabbitmq/support-tools/blob/master/scripts/rabbitmq-collect-env
 [git-commit-msgs]: https://chris.beams.io/posts/git-commit/
 [rmq-users]: https://groups.google.com/forum/#!forum/rabbitmq-users
-[ca-agreement]: https://cla.pivotal.io/sign/rabbitmq
+[ca-agreement]: https://github.com/rabbitmq/cla
 [github-fork]: https://help.github.com/articles/fork-a-repo/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub Actions rabbitmq-dotnet-client](https://github.com/rabbitmq/rabbitmq-dotnet-client/actions/workflows/main.yaml/badge.svg)](https://github.com/rabbitmq/rabbitmq-dotnet-client/actions/workflows/main.yaml)
 [![CodeQL](https://github.com/rabbitmq/rabbitmq-dotnet-client/workflows/CodeQL/badge.svg)](https://github.com/rabbitmq/rabbitmq-dotnet-client/actions/workflows/codeql.yml)
 
-This repository contains source code of the [RabbitMQ .NET client](https://www.rabbitmq.com/dotnet.html).
+This repository contains source code of the [RabbitMQ .NET client](https://www.rabbitmq.com/client-libraries/dotnet).
 The client is maintained by the [RabbitMQ team at Broadcom](https://github.com/rabbitmq/).
 
 

--- a/RUNNING_TESTS.md
+++ b/RUNNING_TESTS.md
@@ -2,7 +2,7 @@
 
 The RabbitMQ .NET client's test suite assumes there's a RabbitMQ node listening
 on `localhost:5672` (the default settings). TLS tests require a node listening
-on the default [TLS port](https://rabbitmq.com/ssl.html).
+on the default [TLS port](https://www.rabbitmq.com/docs/ssl).
 
 It is possible to use Visual Studio Community Edition and `dotnet.exe` in
 `PATH`, to build the client and run the test suite.
@@ -33,14 +33,14 @@ may take some time for the adapter to discover tests in the assemblies.
 
 The test suite assumes there's a RabbitMQ node running locally with all
 defaults, incl. the management plugin, and the tests will need to be able to run commands against the
-[`rabbitmqctl`](https://www.rabbitmq.com/rabbitmqctl.8.html) tool for that node.
+[`rabbitmqctl`](https://www.rabbitmq.com/docs/man/rabbitmqctl.8) tool for that node.
 Two options to accomplish this are covered below.
 
 
 ### Option One: Using a RabbitMQ Release
 
-It is possible to install and run a node using any [binary build](https://www.rabbitmq.com/download.html)
-suitable for the platform. Its [CLI tools](https://rabbitmq.com/cli.html) then must be added to `PATH` so that `rabbitmqctl` can be
+It is possible to install and run a node using any [binary build](https://www.rabbitmq.com/docs/download)
+suitable for the platform. Its [CLI tools](https://www.rabbitmq.com/docs/cli) then must be added to `PATH` so that `rabbitmqctl` can be
 invoked directly without using an absolute file path. Note that this method does *not* work on Windows.
 
 On Windows, you must run unit tests as follows (replace `X.Y.Z` with your RabbitMQ version):
@@ -52,45 +52,59 @@ $env:RABBITMQ_RABBITMQCTL_PATH='C:\Program Files\RabbitMQ Server\rabbitmq_server
 
 ### Option Two: Building a RabbitMQ Node from Source
 
-T run a RabbitMQ node [built from source](https://www.rabbitmq.com/build-server.html):
+To run a RabbitMQ node [built from source](https://www.rabbitmq.com/docs/build-server):
 
 ```shell
 git clone https://github.com/rabbitmq/rabbitmq-server.git rabbitmq-server
 cd rabbitmq-server
 
-# assumes Make is available
-make co
-cd deps/rabbit
+# assumes GNU Make is available; this also fetches dependencies
 make
+
+cd deps/rabbit
 make run-broker
 ```
 
-`rabbitmqctl` location will be computed using a relative path under the source repository,
-in this example, it should be `./rabbitmq-server/deps/rabbit/sbin/rabbitmqctl`.
+In this example `rabbitmqctl` is `./rabbitmq-server/deps/rabbit/scripts/rabbitmqctl`.
+When `RABBITMQ_RABBITMQCTL_PATH` is not set, the tests first try
+`../../../../../../rabbit/scripts/rabbitmqctl` (relative to the test output
+directory, which only resolves in an umbrella-style checkout) and otherwise fall
+back to plain `rabbitmqctl` on `PATH`.
 
-It is possible to override the location using `RABBITMQ_RABBITMQCTL_PATH`:
+Setting `RABBITMQ_RABBITMQCTL_PATH` explicitly is the reliable option:
 
 ```
-RABBITMQ_RABBITMQCTL_PATH=/path/to/rabbitmqctl dotnet test projects/Test/Unit.csproj
+RABBITMQ_RABBITMQCTL_PATH=/path/to/rabbitmqctl dotnet test projects/Test/Unit/Unit.csproj
 ```
 
 ### Option Three: Using a Docker Container
 
 It is also possible to run a RabbitMQ node in a
 [Docker](https://www.docker.com/) container.  Set the environment variable
-`RABBITMQ_RABBITMQCTL_PATH` to `DOCKER:<container_name>` (for example
-`DOCKER:rabbitmq-dotnet-client-rabbitmq`). This tells the unit tests to run the `rabbitmqctl`
-commands through Docker, in the format `docker exec rabbitmq01 rabbitmqctl
+`RABBITMQ_RABBITMQCTL_PATH` to `DOCKER:<container_name_or_id>` (for example
+`DOCKER:rabbitmq-dotnet-client-rabbitmq`). This tells the tests to run the `rabbitmqctl`
+commands through Docker, in the format `docker exec <container> rabbitmqctl
 <args>`:
 
 ```shell
-docker run -d --hostname rabbitmq01 --name rabbitmq01 -p 15672:15672 -p 5672:5672 rabbitmq:3-management
+docker run -d --hostname rabbitmq-dotnet-client-rabbitmq --name rabbitmq-dotnet-client-rabbitmq \
+    -p 15672:15672 -p 5672:5672 rabbitmq:management
 ```
 
-You should also be able to run the same script that sets up the Ubuntu 22 GitHub actions worker:
+The recommended approach, however, is to run the same script that sets up the
+GitHub Actions worker. It starts a `rabbitmq:management` container named
+`rabbitmq-dotnet-client-rabbitmq`, publishing 5671 (TLS), 5672 (AMQP) and 15672
+(management), with the TLS certificates from `.ci/certs` mounted:
 
 ```shell
 ./.ci/ubuntu/gha-setup.sh
+```
+
+Pass `toxiproxy` to also start a Toxiproxy container, which the
+`TestToxiproxy` suite requires:
+
+```shell
+./.ci/ubuntu/gha-setup.sh toxiproxy
 ```
 
 ## Running All Tests
@@ -117,12 +131,13 @@ make test
 ## Running Individual Suites or Test Cases
 
 Running individual tests and fixtures on Windows is trivial using the Visual Studio test runner.
-To run a specific tests fixture on MacOS or Linux, use the NUnit filter expressions to select the tests to be run:
+To run a specific test fixture on MacOS or Linux, use `dotnet test --filter` expressions to
+select the tests to be run:
 
 ``` shell
-dotnet test projects/Test/Unit.csproj --filter "Name~TestAmqpUriParseFail"
+dotnet test projects/Test/Unit/Unit.csproj --filter "Name~TestAmqpUriParseFail"
 
-dotnet test projects/Test/Unit.csproj --filter "FullyQualifiedName~RabbitMQ.Client.Unit.TestHeartbeats"
+dotnet test projects/Test/Integration/Integration.csproj --filter "FullyQualifiedName~TestConnectionShutdown"
 ```
 
 ## Running Tests for a Specific .NET Target
@@ -130,5 +145,5 @@ dotnet test projects/Test/Unit.csproj --filter "FullyQualifiedName~RabbitMQ.Clie
 To run tests targeting .NET 8.0:
 
 ``` shell
-dotnet test --framework net8.0 projects/Unit
+dotnet test --framework net8.0 projects/Test/Unit/Unit.csproj
 ```

--- a/projects/Applications/GH-1921/README.md
+++ b/projects/Applications/GH-1921/README.md
@@ -1,12 +1,12 @@
 # GH-1921 cancellation repro
 
-A standalone console app that reproduces the Windows-only test failures seen on the `fix/gh-1921-cancellation` branch, where a `CancellationToken` fires while a connection is being opened.
+A standalone console app that reproduces the Windows-only test failures seen while fixing issue #1921, where a `CancellationToken` fires while a connection is being opened. The fix shipped in #1936; this app is retained as a regression gate.
 
 This app is **not** part of `RabbitMQDotNetClient.sln` or `Build.csproj`, so it does not affect the main build or CI. It references the local `RabbitMQ.Client` project directly.
 
 ## Background
 
-Issue [#1921](https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/1921): `CreateConnectionAsync(token)` could hang for the full `ContinuationTimeout` when `token` fired during connection open. The fix on this branch resolves the hang on Linux (the integration test sweeps short cancellation delays and sees 0 slow attempts out of 2100), but the strengthened test failed two different ways on the `integration-win32` CI job, one per target framework:
+Issue [#1921](https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/1921): `CreateConnectionAsync(token)` could hang for the full `ContinuationTimeout` when `token` fired during connection open. The fix resolved the hang on Linux (the integration test sweeps short cancellation delays and sees 0 slow attempts out of 2100), but the strengthened test then failed two different ways on the `integration-win32` CI job, one per target framework:
 
 - **net8.0**: the attempt threw `AggregateException` wrapping a `SocketException` (`A call to WSALookupServiceEnd was made while this call was still processing. The call has been canceled.`) at ~3ms. On Windows, cancelling `Dns.GetHostAddressesAsync` (which receives the token on .NET) surfaces a `SocketException`; `EndpointResolverExtensions.SelectOneAsync` collects it and rethrows it wrapped in `AggregateException`. The test only caught `OperationCanceledException`, so the exception escaped and failed the test.
 
@@ -14,7 +14,7 @@ Issue [#1921](https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/1921): `
 
 ## Resolution
 
-Both failures are now fixed on this branch; this app was used to confirm each one natively on Windows.
+Both failures are fixed; this app was used to confirm each one natively on Windows.
 
 - **net8.0 (Failure A)** was a test-only gap: the fix was correct, but the regression test's `catch` only handled `OperationCanceledException`. The Windows DNS-cancel `SocketException` reaches the caller wrapped as `BrokerUnreachableException`, so the test now also catches that.
 

--- a/v7-MIGRATION.md
+++ b/v7-MIGRATION.md
@@ -32,11 +32,11 @@ been removed.
 ## Consuming messages
 
 When a message is delivered to your code via the
-`AsyncEventingBasicConsumer.Received` event or by sub-classing
-`DefaultAsyncConsumer`, please note that the `ReadOnlyMemory<byte>` that
+`AsyncEventingBasicConsumer.ReceivedAsync` event or by sub-classing
+`AsyncDefaultBasicConsumer`, please note that the `ReadOnlyMemory<byte>` that
 represents the message body is owned by this library, and that memory is only
-valid for application use within the context of the executing `Received` event
-or `HandleBasicDeliver` method.
+valid for application use within the context of the executing `ReceivedAsync`
+event or `HandleBasicDeliverAsync` method.
 
 If you wish to use this data _outside_ of these methods, you **MUST** copy the
 data for your use:


### PR DESCRIPTION
Stacked on top of #1965 — this PR targets `fix/gh-1960-shutdown-handler-deadlock` so the diff stays reviewable. Please merge #1965 first; I will retarget this to `main` afterwards.

An accuracy pass over every tracked `.md` file in the repository, including docs untouched by recent work. Each factual claim was verified against the code, the build files, or the live URL. Docs only — no code changes.

## Things that were actively broken

**Non-existent API names** (`v7-MIGRATION.md`) — a reader following the migration guide would not find these:

| Documented | Actual |
| --- | --- |
| `AsyncEventingBasicConsumer.Received` | `.ReceivedAsync` |
| `DefaultAsyncConsumer` | `AsyncDefaultBasicConsumer` |
| `HandleBasicDeliver` | `HandleBasicDeliverAsync` |

**Commands that cannot work** (`RUNNING_TESTS.md`):

- `projects/Test/Unit.csproj` and `projects/Unit` — neither path exists; corrected to `projects/Test/Unit/Unit.csproj`.
- "use the NUnit filter expressions" — this project uses xUnit. Corrected to `dotnet test --filter`, and the example that referenced the non-existent namespace `RabbitMQ.Client.Unit.TestHeartbeats` was replaced with a real one.
- `make co` no longer exists in `rabbitmq-server` (verified absent from the root `Makefile`, `plugins.mk`, `rabbitmq-components.mk` and `erlang.mk` — a leftover from the public-umbrella era), so the build-from-source recipe could not be followed. Rewrote it, and corrected `deps/rabbit/sbin/rabbitmqctl` → `scripts/`, which is both what that repo ships and what `RabbitMQCtl.cs` actually looks for. Also documented the real `RABBITMQ_RABBITMQCTL_PATH` fallback order.
- Docker section: `rabbitmq:3-management` → `rabbitmq:management`, and the mismatched `rabbitmq01` / `rabbitmq-dotnet-client-rabbitmq` container names made consistent. Documented what `gha-setup.sh` actually starts and its `toxiproxy` argument.
- Typo: "T run a RabbitMQ node" → "To run".

**A dead link.** `cla.pivotal.io` is NXDOMAIN, so the CLA instruction in `CONTRIBUTING.md` and in the PR template pointed nowhere. Now `https://github.com/rabbitmq/cla`, matching what `rabbitmq-server`'s own `CONTRIBUTING.md` uses. ("the CA" → "the CLA" while there.)

**A copy-paste bug** (`APIDOCS.md`): a stray backtick inside the `cd C:\path\to\...` line broke the command when pasted.

## Wrong claims in `AGENTS.md`

Four claims that contradict the code:

- The EventSource counter list was wholly wrong — it listed "Messages published" and "Messages consumed", which are not counters this client exposes. Replaced with the eight real names from `RabbitMqClientEventSource.cs`, and noted they are `net8.0`-only (the counters live inside an `#if NET` block, so the netstandard2.0 build has none).
- `OAuth2CredentialsProvider` — the actual class is `OAuth2ClientCredentialsProvider`. The class name does not match its file name, which is worth recording explicitly since it defeats a search by type name.
- `AutorecoveringConnection` is a partial class; its two other files were unlisted.
- `System.Threading.Channels` was listed as a plain runtime dependency; it is built into net8.0 and only an explicit package reference for netstandard2.0. Added the build-time `Nullable` reference.

## Stale framing and link hygiene

- `CONTRIBUTING.md`: "RabbitMQ team at Pivotal" → "at Broadcom".
- `GH-1921/README.md`: three "on this branch" references, stale since that work merged as #1936.
- `rabbitmq-server/blob/master/CONTRIBUTING.md` → `/blob/main/` (that repo's default branch is `main`).
- Six legacy `*.html` rabbitmq.com URLs → their canonical `/docs/*` targets. These still redirect, so this is future-proofing rather than a fix.

## Verified accurate, deliberately unchanged

`CODE_OF_CONDUCT.md`, `index.md`, both stub package READMEs, `Test/OAuth2/README.md` (all four `.ci/oauth2/*.sh` scripts exist), the OpenTelemetry README (`AddRabbitMQInstrumentation` exists in both overloads), `docs/internal/connection-shutdown-and-cancellation.md` (all three `InternalConstants` timeouts and every code snippet re-checked), `GH-1960/README.md` (argument parsing and `repro.ps1` parameters match `Program.cs`), and `RELEASE.md` — including `build.bat`, which is correct in the `6.x` context where it is used.

Also swept programmatically: every relative markdown link across all 20 tracked `.md` files resolves, and the `CHANGELOG.md` / `HISTORY.md` version headings are consistently ordered with no path or link errors. The 2000+ lines of generated issue titles in those two files were not audited line by line.

## Types of Changes

- [x] Documentation improvements (corrections, new content, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes (docs only; no code touched)