### PR TITLE
Fix spurious RPC continuation timeouts under concurrent load (#1964)

### DIFF
--- a/projects/RabbitMQ.Client/Impl/AsyncRpcContinuations.cs
+++ b/projects/RabbitMQ.Client/Impl/AsyncRpcContinuations.cs
@@ -64,7 +64,13 @@ namespace RabbitMQ.Client.Impl
              * version of CancellationTokenSource can't be reset prior to checking
              * in to the ObjectPool
              */
-            _continuationTimeoutCancellationTokenSource = new CancellationTokenSource(continuationTimeout);
+            // rabbitmq/rabbitmq-dotnet-client#1964
+            // Deliberately unarmed: StartTimeout() arms it once the operation can
+            // actually be issued. Arming here would charge the wait for the channel's
+            // RPC semaphore against the operation's own budget, and it could not be
+            // undone afterwards, because CancelAfter on an already-cancelled source
+            // does nothing.
+            _continuationTimeoutCancellationTokenSource = new CancellationTokenSource();
             _continuationTimeoutCancellationToken = _continuationTimeoutCancellationTokenSource.Token;
 
 #if NET
@@ -94,24 +100,31 @@ namespace RabbitMQ.Client.Impl
         }
 
         /// <summary>
-        /// Restart the continuation timeout, discarding any time already elapsed.
+        /// Start the continuation timeout. Called once the operation is able to run,
+        /// which is immediately after the channel's RPC semaphore has been acquired.
         /// </summary>
         /// <remarks>
         /// <para>
-        /// The timeout starts at construction so that waiting for the channel's RPC
-        /// semaphore is bounded. Once the semaphore is acquired the operation has not
-        /// yet been sent, so the time spent queued behind other RPCs must not be
-        /// charged against it. Callers restart the timeout at that point, giving the
-        /// operation itself the full <c>ContinuationTimeout</c>.
+        /// The timeout deliberately does not start at construction. Only one RPC runs
+        /// per channel at a time, so a caller may sit behind an arbitrary number of
+        /// queued operations before its own method frame can be written. Charging that
+        /// queueing delay against the operation makes concurrent operations on one
+        /// channel time out spuriously under load, and contradicts the documented
+        /// meaning of <c>IConnectionFactory.ContinuationTimeout</c>: "Amount of time
+        /// protocol operations (e.g. queue.declare) are allowed to take" - the
+        /// operation, not the wait ahead of it.
         /// </para>
         /// <para>
-        /// See rabbitmq/rabbitmq-dotnet-client#1964. Doing otherwise makes concurrent
-        /// operations on one channel time out spuriously under load, because a
-        /// continuation can exhaust its entire budget before its method frame is
-        /// written.
+        /// This does not let a caller block forever. Whichever operation holds the
+        /// semaphore has its own timeout armed, so it releases within roughly
+        /// <c>ContinuationTimeout</c> of acquiring it, and the caller's own
+        /// <c>CancellationToken</c> still aborts the wait at any point.
+        /// </para>
+        /// <para>
+        /// See rabbitmq/rabbitmq-dotnet-client#1964.
         /// </para>
         /// </remarks>
-        public void RestartTimeout()
+        public void StartTimeout()
         {
             try
             {
@@ -119,7 +132,7 @@ namespace RabbitMQ.Client.Impl
             }
             catch (ObjectDisposedException)
             {
-                // The continuation is already done with; nothing to reschedule.
+                // The continuation is already done with; nothing to schedule.
             }
         }
 

--- a/projects/RabbitMQ.Client/Impl/AsyncRpcContinuations.cs
+++ b/projects/RabbitMQ.Client/Impl/AsyncRpcContinuations.cs
@@ -93,6 +93,36 @@ namespace RabbitMQ.Client.Impl
             }
         }
 
+        /// <summary>
+        /// Restart the continuation timeout, discarding any time already elapsed.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The timeout starts at construction so that waiting for the channel's RPC
+        /// semaphore is bounded. Once the semaphore is acquired the operation has not
+        /// yet been sent, so the time spent queued behind other RPCs must not be
+        /// charged against it. Callers restart the timeout at that point, giving the
+        /// operation itself the full <c>ContinuationTimeout</c>.
+        /// </para>
+        /// <para>
+        /// See rabbitmq/rabbitmq-dotnet-client#1964. Doing otherwise makes concurrent
+        /// operations on one channel time out spuriously under load, because a
+        /// continuation can exhaust its entire budget before its method frame is
+        /// written.
+        /// </para>
+        /// </remarks>
+        public void RestartTimeout()
+        {
+            try
+            {
+                _continuationTimeoutCancellationTokenSource.CancelAfter(_continuationTimeout);
+            }
+            catch (ObjectDisposedException)
+            {
+                // The continuation is already done with; nothing to reschedule.
+            }
+        }
+
         public ConfiguredTaskAwaitable<T>.ConfiguredTaskAwaiter GetAwaiter()
         {
             return _tcsConfiguredTaskAwaitable.GetAwaiter();

--- a/projects/RabbitMQ.Client/Impl/AsyncRpcContinuations.cs
+++ b/projects/RabbitMQ.Client/Impl/AsyncRpcContinuations.cs
@@ -121,6 +121,15 @@ namespace RabbitMQ.Client.Impl
         /// <c>CancellationToken</c> still aborts the wait at any point.
         /// </para>
         /// <para>
+        /// Call this as the first statement inside the <c>try</c> whose <c>finally</c>
+        /// releases the channel's RPC semaphore, not between the wait and the <c>try</c>.
+        /// A throw from here would otherwise leak the semaphore permanently and deadlock
+        /// every subsequent RPC on the channel. Nothing can throw today, since
+        /// <c>ObjectDisposedException</c> is caught below and the constructor already
+        /// validated the same <c>TimeSpan</c>, so this is about not leaving the hazard
+        /// lying around.
+        /// </para>
+        /// <para>
         /// See rabbitmq/rabbitmq-dotnet-client#1964.
         /// </para>
         /// </remarks>

--- a/projects/RabbitMQ.Client/Impl/Channel.PublisherConfirms.cs
+++ b/projects/RabbitMQ.Client/Impl/Channel.PublisherConfirms.cs
@@ -125,6 +125,11 @@ namespace RabbitMQ.Client.Impl
                 bool enqueued = false;
                 var k = new ConfirmSelectAsyncRpcContinuation(ContinuationTimeout, cancellationToken);
 
+                // There is no semaphore wait to exclude here, since the caller already
+                // holds it, so the timeout starts right away. It must still be started
+                // explicitly: continuations are constructed unarmed. See #1964.
+                k.StartTimeout();
+
                 try
                 {
                     if (_nextPublishSeqNo == 0UL)

--- a/projects/RabbitMQ.Client/Impl/Channel.PublisherConfirms.cs
+++ b/projects/RabbitMQ.Client/Impl/Channel.PublisherConfirms.cs
@@ -125,13 +125,13 @@ namespace RabbitMQ.Client.Impl
                 bool enqueued = false;
                 var k = new ConfirmSelectAsyncRpcContinuation(ContinuationTimeout, cancellationToken);
 
-                // There is no semaphore wait to exclude here, since the caller already
-                // holds it, so the timeout starts right away. It must still be started
-                // explicitly: continuations are constructed unarmed. See #1964.
-                k.StartTimeout();
-
                 try
                 {
+                    // There is no semaphore wait to exclude here, since the caller already
+                    // holds it, so the timeout starts right away. It must still be started
+                    // explicitly: continuations are constructed unarmed. See #1964.
+                    k.StartTimeout();
+
                     if (_nextPublishSeqNo == 0UL)
                     {
                         if (_publisherConfirmationTrackingEnabled)

--- a/projects/RabbitMQ.Client/Impl/Channel.cs
+++ b/projects/RabbitMQ.Client/Impl/Channel.cs
@@ -990,11 +990,18 @@ namespace RabbitMQ.Client.Impl
                 {
                     enqueued = Enqueue(k);
 
+                    // rabbitmq/rabbitmq-dotnet-client#1964
+                    // Send before the try whose catch records a timed-out RPC, so a write
+                    // failure (cancellation, IOException, AlreadyClosedException) does not
+                    // record an entry for a request that never reached the wire. Order-based
+                    // late-response matching would then desync permanently. Only a failure
+                    // while awaiting the response, by which point the frame is sent, should
+                    // record.
+                    await ModelSendAsync(in method, k.CancellationToken)
+                        .ConfigureAwait(false);
+
                     try
                     {
-                        await ModelSendAsync(in method, k.CancellationToken)
-                            .ConfigureAwait(false);
-
                         AssertResultIsTrue(await k);
                     }
                     catch
@@ -1426,11 +1433,17 @@ namespace RabbitMQ.Client.Impl
                 {
                     enqueued = Enqueue(k);
 
+                    // rabbitmq/rabbitmq-dotnet-client#1964
+                    // Send before the try whose catch records a timed-out RPC, so a
+                    // cancellation during the write does not record an entry for a request
+                    // that never reached the wire. Order-based late-response matching would
+                    // then desync permanently. Only a cancellation while awaiting the
+                    // response, by which point the frame is sent, should record.
+                    await ModelSendAsync(in method, k.CancellationToken)
+                        .ConfigureAwait(false);
+
                     try
                     {
-                        await ModelSendAsync(in method, k.CancellationToken)
-                            .ConfigureAwait(false);
-
                         QueueDeclareOk result = await k;
                         if (false == passive)
                         {

--- a/projects/RabbitMQ.Client/Impl/Channel.cs
+++ b/projects/RabbitMQ.Client/Impl/Channel.cs
@@ -996,12 +996,9 @@ namespace RabbitMQ.Client.Impl
                     enqueued = Enqueue(k);
 
                     // rabbitmq/rabbitmq-dotnet-client#1964
-                    // Send before the try whose catch records a timed-out RPC, so a write
-                    // failure (cancellation, IOException, AlreadyClosedException) does not
-                    // record an entry for a request that never reached the wire. Order-based
-                    // late-response matching would then desync permanently. Only a failure
-                    // while awaiting the response, by which point the frame is sent, should
-                    // record.
+                    // Send outside the try: cancelling the write must not record a
+                    // timed-out RPC for a request that never reached the wire, which
+                    // would desync order-based late-response matching permanently.
                     await ModelSendAsync(in method, k.CancellationToken)
                         .ConfigureAwait(false);
 
@@ -1009,7 +1006,7 @@ namespace RabbitMQ.Client.Impl
                     {
                         AssertResultIsTrue(await k);
                     }
-                    catch
+                    catch (OperationCanceledException)
                     {
                         _continuationQueue.RpcCanceled(k.ResponseReceived, k.HandledProtocolCommandIds);
                         throw;
@@ -1052,7 +1049,7 @@ namespace RabbitMQ.Client.Impl
                 {
                     return await k;
                 }
-                catch
+                catch (OperationCanceledException)
                 {
                     _continuationQueue.RpcCanceled(k.ResponseReceived, k.HandledProtocolCommandIds);
                     throw;
@@ -1448,11 +1445,9 @@ namespace RabbitMQ.Client.Impl
                     enqueued = Enqueue(k);
 
                     // rabbitmq/rabbitmq-dotnet-client#1964
-                    // Send before the try whose catch records a timed-out RPC, so a
-                    // cancellation during the write does not record an entry for a request
-                    // that never reached the wire. Order-based late-response matching would
-                    // then desync permanently. Only a cancellation while awaiting the
-                    // response, by which point the frame is sent, should record.
+                    // Send outside the try: cancelling the write must not record a
+                    // timed-out RPC for a request that never reached the wire, which
+                    // would desync order-based late-response matching permanently.
                     await ModelSendAsync(in method, k.CancellationToken)
                         .ConfigureAwait(false);
 

--- a/projects/RabbitMQ.Client/Impl/Channel.cs
+++ b/projects/RabbitMQ.Client/Impl/Channel.cs
@@ -223,9 +223,10 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            k.StartTimeout();
             try
             {
+                k.StartTimeout();
+
                 ChannelShutdownAsync += k.OnConnectionShutdownAsync;
                 enqueued = Enqueue(k);
                 ConsumerDispatcher.Quiesce();
@@ -290,9 +291,10 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            k.StartTimeout();
             try
             {
+                k.StartTimeout();
+
                 enqueued = Enqueue(k);
 
                 try
@@ -336,9 +338,10 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            k.StartTimeout();
             try
             {
+                k.StartTimeout();
+
                 enqueued = Enqueue(k);
 
                 try
@@ -384,9 +387,10 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            k.StartTimeout();
             try
             {
+                k.StartTimeout();
+
                 enqueued = Enqueue(k);
 
                 var method = new ChannelOpen();
@@ -975,9 +979,10 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            k.StartTimeout();
             try
             {
+                k.StartTimeout();
+
                 var method = new BasicCancel(consumerTag, noWait);
 
                 if (noWait)
@@ -1033,9 +1038,10 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            k.StartTimeout();
             try
             {
+                k.StartTimeout();
+
                 enqueued = Enqueue(k);
 
                 var method = new BasicConsume(queue, consumerTag, noLocal, autoAck, exclusive, false, arguments);
@@ -1069,9 +1075,10 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            k.StartTimeout();
             try
             {
+                k.StartTimeout();
+
                 enqueued = Enqueue(k);
 
                 var method = new BasicGet(queue, autoAck);
@@ -1125,9 +1132,10 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            k.StartTimeout();
             try
             {
+                k.StartTimeout();
+
                 enqueued = Enqueue(k);
 
                 byte[] newSecretBytes = Encoding.UTF8.GetBytes(newSecret);
@@ -1161,9 +1169,10 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            k.StartTimeout();
             try
             {
+                k.StartTimeout();
+
                 enqueued = Enqueue(k);
 
                 var method = new BasicQos(prefetchSize, prefetchCount, global);
@@ -1197,9 +1206,10 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            k.StartTimeout();
             try
             {
+                k.StartTimeout();
+
                 var method = new ExchangeBind(destination, source, routingKey, noWait, arguments);
 
                 if (noWait)
@@ -1251,9 +1261,10 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            k.StartTimeout();
             try
             {
+                k.StartTimeout();
+
                 var method = new ExchangeDeclare(exchange, type, passive, durable, autoDelete, false, noWait, arguments);
                 if (noWait)
                 {
@@ -1296,9 +1307,10 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            k.StartTimeout();
             try
             {
+                k.StartTimeout();
+
                 var method = new ExchangeDelete(exchange, ifUnused, Nowait: noWait);
 
                 if (noWait)
@@ -1343,9 +1355,10 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            k.StartTimeout();
             try
             {
+                k.StartTimeout();
+
                 var method = new ExchangeUnbind(destination, source, routingKey, noWait, arguments);
 
                 if (noWait)
@@ -1411,9 +1424,10 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            k.StartTimeout();
             try
             {
+                k.StartTimeout();
+
                 var method = new QueueDeclare(queue, passive, durable, exclusive, autoDelete, noWait, arguments);
 
                 if (noWait)
@@ -1476,9 +1490,10 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            k.StartTimeout();
             try
             {
+                k.StartTimeout();
+
                 var method = new QueueBind(queue, exchange, routingKey, noWait, arguments);
 
                 if (noWait)
@@ -1538,9 +1553,10 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            k.StartTimeout();
             try
             {
+                k.StartTimeout();
+
                 var method = new QueueDelete(queue, ifUnused, ifEmpty, noWait);
 
                 if (noWait)
@@ -1584,9 +1600,10 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            k.StartTimeout();
             try
             {
+                k.StartTimeout();
+
                 enqueued = Enqueue(k);
 
                 var method = new QueuePurge(queue, false);
@@ -1620,9 +1637,10 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            k.StartTimeout();
             try
             {
+                k.StartTimeout();
+
                 enqueued = Enqueue(k);
 
                 var method = new QueueUnbind(queue, exchange, routingKey, arguments);
@@ -1654,9 +1672,10 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            k.StartTimeout();
             try
             {
+                k.StartTimeout();
+
                 enqueued = Enqueue(k);
 
                 var method = new TxCommit();
@@ -1688,9 +1707,10 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            k.StartTimeout();
             try
             {
+                k.StartTimeout();
+
                 enqueued = Enqueue(k);
 
                 var method = new TxRollback();
@@ -1722,9 +1742,10 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            k.StartTimeout();
             try
             {
+                k.StartTimeout();
+
                 enqueued = Enqueue(k);
 
                 var method = new TxSelect();

--- a/projects/RabbitMQ.Client/Impl/Channel.cs
+++ b/projects/RabbitMQ.Client/Impl/Channel.cs
@@ -222,6 +222,10 @@ namespace RabbitMQ.Client.Impl
 
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
+
+            // The operation has not been sent yet, so time spent queued behind other
+            // RPCs must not count against its timeout. See #1964.
+            k.RestartTimeout();
             try
             {
                 ChannelShutdownAsync += k.OnConnectionShutdownAsync;
@@ -287,6 +291,10 @@ namespace RabbitMQ.Client.Impl
 
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
+
+            // The operation has not been sent yet, so time spent queued behind other
+            // RPCs must not count against its timeout. See #1964.
+            k.RestartTimeout();
             try
             {
                 enqueued = Enqueue(k);
@@ -331,6 +339,10 @@ namespace RabbitMQ.Client.Impl
 
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
+
+            // The operation has not been sent yet, so time spent queued behind other
+            // RPCs must not count against its timeout. See #1964.
+            k.RestartTimeout();
             try
             {
                 enqueued = Enqueue(k);
@@ -377,6 +389,10 @@ namespace RabbitMQ.Client.Impl
 
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
+
+            // The operation has not been sent yet, so time spent queued behind other
+            // RPCs must not count against its timeout. See #1964.
+            k.RestartTimeout();
             try
             {
                 enqueued = Enqueue(k);
@@ -966,6 +982,10 @@ namespace RabbitMQ.Client.Impl
 
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
+
+            // The operation has not been sent yet, so time spent queued behind other
+            // RPCs must not count against its timeout. See #1964.
+            k.RestartTimeout();
             try
             {
                 var method = new BasicCancel(consumerTag, noWait);
@@ -1015,6 +1035,10 @@ namespace RabbitMQ.Client.Impl
 
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
+
+            // The operation has not been sent yet, so time spent queued behind other
+            // RPCs must not count against its timeout. See #1964.
+            k.RestartTimeout();
             try
             {
                 enqueued = Enqueue(k);
@@ -1049,6 +1073,10 @@ namespace RabbitMQ.Client.Impl
 
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
+
+            // The operation has not been sent yet, so time spent queued behind other
+            // RPCs must not count against its timeout. See #1964.
+            k.RestartTimeout();
             try
             {
                 enqueued = Enqueue(k);
@@ -1103,6 +1131,10 @@ namespace RabbitMQ.Client.Impl
 
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
+
+            // The operation has not been sent yet, so time spent queued behind other
+            // RPCs must not count against its timeout. See #1964.
+            k.RestartTimeout();
             try
             {
                 enqueued = Enqueue(k);
@@ -1137,6 +1169,10 @@ namespace RabbitMQ.Client.Impl
 
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
+
+            // The operation has not been sent yet, so time spent queued behind other
+            // RPCs must not count against its timeout. See #1964.
+            k.RestartTimeout();
             try
             {
                 enqueued = Enqueue(k);
@@ -1171,6 +1207,10 @@ namespace RabbitMQ.Client.Impl
 
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
+
+            // The operation has not been sent yet, so time spent queued behind other
+            // RPCs must not count against its timeout. See #1964.
+            k.RestartTimeout();
             try
             {
                 var method = new ExchangeBind(destination, source, routingKey, noWait, arguments);
@@ -1223,6 +1263,10 @@ namespace RabbitMQ.Client.Impl
 
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
+
+            // The operation has not been sent yet, so time spent queued behind other
+            // RPCs must not count against its timeout. See #1964.
+            k.RestartTimeout();
             try
             {
                 var method = new ExchangeDeclare(exchange, type, passive, durable, autoDelete, false, noWait, arguments);
@@ -1266,6 +1310,10 @@ namespace RabbitMQ.Client.Impl
 
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
+
+            // The operation has not been sent yet, so time spent queued behind other
+            // RPCs must not count against its timeout. See #1964.
+            k.RestartTimeout();
             try
             {
                 var method = new ExchangeDelete(exchange, ifUnused, Nowait: noWait);
@@ -1311,6 +1359,10 @@ namespace RabbitMQ.Client.Impl
 
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
+
+            // The operation has not been sent yet, so time spent queued behind other
+            // RPCs must not count against its timeout. See #1964.
+            k.RestartTimeout();
             try
             {
                 var method = new ExchangeUnbind(destination, source, routingKey, noWait, arguments);
@@ -1377,6 +1429,10 @@ namespace RabbitMQ.Client.Impl
 
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
+
+            // The operation has not been sent yet, so time spent queued behind other
+            // RPCs must not count against its timeout. See #1964.
+            k.RestartTimeout();
             try
             {
                 var method = new QueueDeclare(queue, passive, durable, exclusive, autoDelete, noWait, arguments);
@@ -1434,6 +1490,10 @@ namespace RabbitMQ.Client.Impl
 
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
+
+            // The operation has not been sent yet, so time spent queued behind other
+            // RPCs must not count against its timeout. See #1964.
+            k.RestartTimeout();
             try
             {
                 var method = new QueueBind(queue, exchange, routingKey, noWait, arguments);
@@ -1494,6 +1554,10 @@ namespace RabbitMQ.Client.Impl
 
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
+
+            // The operation has not been sent yet, so time spent queued behind other
+            // RPCs must not count against its timeout. See #1964.
+            k.RestartTimeout();
             try
             {
                 var method = new QueueDelete(queue, ifUnused, ifEmpty, noWait);
@@ -1538,6 +1602,10 @@ namespace RabbitMQ.Client.Impl
 
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
+
+            // The operation has not been sent yet, so time spent queued behind other
+            // RPCs must not count against its timeout. See #1964.
+            k.RestartTimeout();
             try
             {
                 enqueued = Enqueue(k);
@@ -1572,6 +1640,10 @@ namespace RabbitMQ.Client.Impl
 
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
+
+            // The operation has not been sent yet, so time spent queued behind other
+            // RPCs must not count against its timeout. See #1964.
+            k.RestartTimeout();
             try
             {
                 enqueued = Enqueue(k);
@@ -1604,6 +1676,10 @@ namespace RabbitMQ.Client.Impl
 
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
+
+            // The operation has not been sent yet, so time spent queued behind other
+            // RPCs must not count against its timeout. See #1964.
+            k.RestartTimeout();
             try
             {
                 enqueued = Enqueue(k);
@@ -1636,6 +1712,10 @@ namespace RabbitMQ.Client.Impl
 
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
+
+            // The operation has not been sent yet, so time spent queued behind other
+            // RPCs must not count against its timeout. See #1964.
+            k.RestartTimeout();
             try
             {
                 enqueued = Enqueue(k);
@@ -1668,6 +1748,10 @@ namespace RabbitMQ.Client.Impl
 
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
+
+            // The operation has not been sent yet, so time spent queued behind other
+            // RPCs must not count against its timeout. See #1964.
+            k.RestartTimeout();
             try
             {
                 enqueued = Enqueue(k);

--- a/projects/RabbitMQ.Client/Impl/Channel.cs
+++ b/projects/RabbitMQ.Client/Impl/Channel.cs
@@ -223,9 +223,7 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            // The operation has not been sent yet, so time spent queued behind other
-            // RPCs must not count against its timeout. See #1964.
-            k.RestartTimeout();
+            k.StartTimeout();
             try
             {
                 ChannelShutdownAsync += k.OnConnectionShutdownAsync;
@@ -292,9 +290,7 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            // The operation has not been sent yet, so time spent queued behind other
-            // RPCs must not count against its timeout. See #1964.
-            k.RestartTimeout();
+            k.StartTimeout();
             try
             {
                 enqueued = Enqueue(k);
@@ -340,9 +336,7 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            // The operation has not been sent yet, so time spent queued behind other
-            // RPCs must not count against its timeout. See #1964.
-            k.RestartTimeout();
+            k.StartTimeout();
             try
             {
                 enqueued = Enqueue(k);
@@ -390,9 +384,7 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            // The operation has not been sent yet, so time spent queued behind other
-            // RPCs must not count against its timeout. See #1964.
-            k.RestartTimeout();
+            k.StartTimeout();
             try
             {
                 enqueued = Enqueue(k);
@@ -983,9 +975,7 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            // The operation has not been sent yet, so time spent queued behind other
-            // RPCs must not count against its timeout. See #1964.
-            k.RestartTimeout();
+            k.StartTimeout();
             try
             {
                 var method = new BasicCancel(consumerTag, noWait);
@@ -1036,9 +1026,7 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            // The operation has not been sent yet, so time spent queued behind other
-            // RPCs must not count against its timeout. See #1964.
-            k.RestartTimeout();
+            k.StartTimeout();
             try
             {
                 enqueued = Enqueue(k);
@@ -1074,9 +1062,7 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            // The operation has not been sent yet, so time spent queued behind other
-            // RPCs must not count against its timeout. See #1964.
-            k.RestartTimeout();
+            k.StartTimeout();
             try
             {
                 enqueued = Enqueue(k);
@@ -1132,9 +1118,7 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            // The operation has not been sent yet, so time spent queued behind other
-            // RPCs must not count against its timeout. See #1964.
-            k.RestartTimeout();
+            k.StartTimeout();
             try
             {
                 enqueued = Enqueue(k);
@@ -1170,9 +1154,7 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            // The operation has not been sent yet, so time spent queued behind other
-            // RPCs must not count against its timeout. See #1964.
-            k.RestartTimeout();
+            k.StartTimeout();
             try
             {
                 enqueued = Enqueue(k);
@@ -1208,9 +1190,7 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            // The operation has not been sent yet, so time spent queued behind other
-            // RPCs must not count against its timeout. See #1964.
-            k.RestartTimeout();
+            k.StartTimeout();
             try
             {
                 var method = new ExchangeBind(destination, source, routingKey, noWait, arguments);
@@ -1264,9 +1244,7 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            // The operation has not been sent yet, so time spent queued behind other
-            // RPCs must not count against its timeout. See #1964.
-            k.RestartTimeout();
+            k.StartTimeout();
             try
             {
                 var method = new ExchangeDeclare(exchange, type, passive, durable, autoDelete, false, noWait, arguments);
@@ -1311,9 +1289,7 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            // The operation has not been sent yet, so time spent queued behind other
-            // RPCs must not count against its timeout. See #1964.
-            k.RestartTimeout();
+            k.StartTimeout();
             try
             {
                 var method = new ExchangeDelete(exchange, ifUnused, Nowait: noWait);
@@ -1360,9 +1336,7 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            // The operation has not been sent yet, so time spent queued behind other
-            // RPCs must not count against its timeout. See #1964.
-            k.RestartTimeout();
+            k.StartTimeout();
             try
             {
                 var method = new ExchangeUnbind(destination, source, routingKey, noWait, arguments);
@@ -1430,9 +1404,7 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            // The operation has not been sent yet, so time spent queued behind other
-            // RPCs must not count against its timeout. See #1964.
-            k.RestartTimeout();
+            k.StartTimeout();
             try
             {
                 var method = new QueueDeclare(queue, passive, durable, exclusive, autoDelete, noWait, arguments);
@@ -1491,9 +1463,7 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            // The operation has not been sent yet, so time spent queued behind other
-            // RPCs must not count against its timeout. See #1964.
-            k.RestartTimeout();
+            k.StartTimeout();
             try
             {
                 var method = new QueueBind(queue, exchange, routingKey, noWait, arguments);
@@ -1555,9 +1525,7 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            // The operation has not been sent yet, so time spent queued behind other
-            // RPCs must not count against its timeout. See #1964.
-            k.RestartTimeout();
+            k.StartTimeout();
             try
             {
                 var method = new QueueDelete(queue, ifUnused, ifEmpty, noWait);
@@ -1603,9 +1571,7 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            // The operation has not been sent yet, so time spent queued behind other
-            // RPCs must not count against its timeout. See #1964.
-            k.RestartTimeout();
+            k.StartTimeout();
             try
             {
                 enqueued = Enqueue(k);
@@ -1641,9 +1607,7 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            // The operation has not been sent yet, so time spent queued behind other
-            // RPCs must not count against its timeout. See #1964.
-            k.RestartTimeout();
+            k.StartTimeout();
             try
             {
                 enqueued = Enqueue(k);
@@ -1677,9 +1641,7 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            // The operation has not been sent yet, so time spent queued behind other
-            // RPCs must not count against its timeout. See #1964.
-            k.RestartTimeout();
+            k.StartTimeout();
             try
             {
                 enqueued = Enqueue(k);
@@ -1713,9 +1675,7 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            // The operation has not been sent yet, so time spent queued behind other
-            // RPCs must not count against its timeout. See #1964.
-            k.RestartTimeout();
+            k.StartTimeout();
             try
             {
                 enqueued = Enqueue(k);
@@ -1749,9 +1709,7 @@ namespace RabbitMQ.Client.Impl
             await _rpcSemaphore.WaitAsync(k.CancellationToken)
                 .ConfigureAwait(false);
 
-            // The operation has not been sent yet, so time spent queued behind other
-            // RPCs must not count against its timeout. See #1964.
-            k.RestartTimeout();
+            k.StartTimeout();
             try
             {
                 enqueued = Enqueue(k);

--- a/projects/RabbitMQ.Client/Impl/RpcContinuationQueue.cs
+++ b/projects/RabbitMQ.Client/Impl/RpcContinuationQueue.cs
@@ -30,9 +30,9 @@
 //---------------------------------------------------------------------------
 
 using System;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using RabbitMQ.Client.Events;
@@ -69,24 +69,35 @@ namespace RabbitMQ.Client.Impl
 
         private const int CommandIdBufferLength = 2;
 
-        // Two ProtocolCommandId values (each uint) unioned with a single long
-        // so that Interlocked.Exchange can read/write both atomically.
-        // Since ProtocolCommandId : uint has no zero-valued member,
-        // default(LastTimedOutCommandIds).RawValue == 0L means "no timed-out command".
-        [StructLayout(LayoutKind.Explicit)]
-        private struct LastTimedOutCommandIds
-        {
-            [FieldOffset(0)]
-            public ProtocolCommandId First;
-            [FieldOffset(sizeof(ProtocolCommandId))]
-            public ProtocolCommandId Second;
-            [FieldOffset(0)]
-            public long RawValue;
-        }
-
         private static readonly EmptyRpcContinuation s_tmp = new EmptyRpcContinuation();
-        private long _lastTimedOutCommandIds;
+
+        // rabbitmq/rabbitmq-dotnet-client#1964
+        // Every timed-out RPC leaves a late response in flight, and several can be
+        // outstanding at once: the channel's RPC semaphore serializes requests, but
+        // nothing makes the broker's replies arrive before the next request is sent.
+        // A single-slot record therefore loses responses, and the survivors get
+        // matched against an unrelated continuation ("Received unexpected command
+        // of type ...!"). Queue one entry per timed-out RPC instead.
+        private readonly ConcurrentQueue<TimedOutRpc> _timedOutRpcs = new ConcurrentQueue<TimedOutRpc>();
+
         private IRpcContinuation _outstandingRpc = s_tmp;
+
+        private readonly struct TimedOutRpc
+        {
+            public TimedOutRpc(ProtocolCommandId first, ProtocolCommandId second)
+            {
+                First = first;
+                Second = second;
+            }
+
+            public ProtocolCommandId First { get; }
+            public ProtocolCommandId Second { get; }
+
+            public bool Matches(ProtocolCommandId commandId)
+            {
+                return commandId == First || (Second != default && commandId == Second);
+            }
+        }
 
         ///<summary>Enqueue a continuation, marking a pending RPC.</summary>
         ///<remarks>
@@ -118,6 +129,14 @@ namespace RabbitMQ.Client.Impl
         ///</remarks>
         public void HandleChannelShutdown(ShutdownEventArgs reason)
         {
+            // No further frames will arrive on this channel, so any late responses
+            // still being waited for will never show up. Drop them so that a recovered
+            // channel does not start out expecting to discard commands.
+            // Note: ConcurrentQueue<T>.Clear() is not available on netstandard2.0.
+            while (_timedOutRpcs.TryDequeue(out _))
+            {
+            }
+
             using (IRpcContinuation c = Next())
             {
                 c.HandleChannelShutdown(reason);
@@ -171,34 +190,29 @@ namespace RabbitMQ.Client.Impl
             // (e.g. BasicGetOk/BasicGetEmpty, ConnectionSecure/ConnectionTune)
             Debug.Assert(protocolCommandIds.Length is > 0 and <= CommandIdBufferLength);
 
-            var ids = new LastTimedOutCommandIds
-            {
-                First = protocolCommandIds[0],
-                Second = protocolCommandIds.Length > 1 ? protocolCommandIds[1] : default
-            };
+            var timedOut = new TimedOutRpc(
+                protocolCommandIds[0],
+                protocolCommandIds.Length > 1 ? protocolCommandIds[1] : default);
 
-            Interlocked.Exchange(ref _lastTimedOutCommandIds, ids.RawValue);
+            _timedOutRpcs.Enqueue(timedOut);
         }
 
         public bool ShouldIgnoreCommand(ProtocolCommandId commandId)
         {
             // rabbitmq/rabbitmq-dotnet-client#1802
             // This keeps track of ProtocolCommandId values from previous RPC
-            // commands that have timed out.
-            //
-            // Consume the timed-out state unconditionally, even when commandId does
-            // not match. This is safe because AMQP 0-9-1 enforces strict request-response
-            // ordering on a channel, so a late response is always the very next
-            // incoming command.
-            long raw = Interlocked.Exchange(ref _lastTimedOutCommandIds, 0L);
-
-            if (raw == 0L)
+            // commands that have timed out, so that their late responses are
+            // discarded rather than matched against a later continuation.
+            // AMQP 0-9-1 enforces strict request-response ordering on a channel, so late
+            // responses arrive in the order the requests were sent. Only the oldest
+            // outstanding entry can match; consume it either way, since a non-match means
+            // that response is never coming.
+            if (_timedOutRpcs.TryDequeue(out TimedOutRpc timedOut))
             {
-                return false;
+                return timedOut.Matches(commandId);
             }
 
-            var ids = new LastTimedOutCommandIds { RawValue = raw };
-            return commandId == ids.First || (ids.Second != default && commandId == ids.Second);
+            return false;
         }
     }
 }

--- a/projects/RabbitMQ.Client/Impl/RpcContinuationQueue.cs
+++ b/projects/RabbitMQ.Client/Impl/RpcContinuationQueue.cs
@@ -216,10 +216,16 @@ namespace RabbitMQ.Client.Impl
             // that particular late response, so it would surface as "Received unexpected
             // command of type ...!" exactly as it did before #1802.
             //
-            // Best effort: RpcCanceled is only reached from the RPC-issuing path, which is
-            // serialized on the channel's RPC semaphore, so at most one caller trims here.
-            while (_timedOutRpcs.Count > MaxTimedOutRpcs && _timedOutRpcs.TryDequeue(out _))
+            // A single dequeue is sufficient, and that is an invariant rather than a
+            // shortcut: every call site holds the channel's RPC semaphore, a
+            // SemaphoreSlim(1, 1), and enqueues exactly one entry, while dequeues run on
+            // the receive path and only ever shrink the queue. So the bound can be exceeded
+            // by at most one, and a loop here would imply an overshoot that cannot happen.
+            // Count is not a cheap field read once the queue spans segments, but this runs
+            // only when an RPC has just timed out, which is already an exceptional path.
+            if (_timedOutRpcs.Count > MaxTimedOutRpcs)
             {
+                _timedOutRpcs.TryDequeue(out _);
             }
         }
 

--- a/projects/RabbitMQ.Client/Impl/RpcContinuationQueue.cs
+++ b/projects/RabbitMQ.Client/Impl/RpcContinuationQueue.cs
@@ -90,7 +90,7 @@ namespace RabbitMQ.Client.Impl
         // A single-slot record therefore loses responses, and the survivors get
         // matched against an unrelated continuation ("Received unexpected command
         // of type ...!"). Queue one entry per timed-out RPC instead.
-        private readonly ConcurrentQueue<TimedOutRpc> _timedOutRpcs = new ConcurrentQueue<TimedOutRpc>();
+        private ConcurrentQueue<TimedOutRpc> _timedOutRpcs = new ConcurrentQueue<TimedOutRpc>();
 
         private IRpcContinuation _outstandingRpc = s_tmp;
 
@@ -145,10 +145,12 @@ namespace RabbitMQ.Client.Impl
             // never be consumed: this queue belongs to a single Channel, and a channel
             // being recovered gets a brand new one. Release them rather than keeping them
             // alive for as long as something holds a reference to the dead channel.
-            // Note: ConcurrentQueue<T>.Clear() is not available on netstandard2.0.
-            while (_timedOutRpcs.TryDequeue(out _))
-            {
-            }
+            //
+            // Detach the whole queue rather than draining it. A concurrent RpcCanceled may
+            // still enqueue into the detached instance, which is harmless precisely because
+            // those records no longer need to be observed. This also avoids depending on
+            // ConcurrentQueue<T>.Clear(), which does not exist on netstandard2.0.
+            Interlocked.Exchange(ref _timedOutRpcs, new ConcurrentQueue<TimedOutRpc>());
 
             using (IRpcContinuation c = Next())
             {

--- a/projects/RabbitMQ.Client/Impl/RpcContinuationQueue.cs
+++ b/projects/RabbitMQ.Client/Impl/RpcContinuationQueue.cs
@@ -141,9 +141,10 @@ namespace RabbitMQ.Client.Impl
         ///</remarks>
         public void HandleChannelShutdown(ShutdownEventArgs reason)
         {
-            // No further frames will arrive on this channel, so any late responses
-            // still being waited for will never show up. Drop them so that a recovered
-            // channel does not start out expecting to discard commands.
+            // No further frames will arrive on this channel, so the recorded entries can
+            // never be consumed: this queue belongs to a single Channel, and a channel
+            // being recovered gets a brand new one. Release them rather than keeping them
+            // alive for as long as something holds a reference to the dead channel.
             // Note: ConcurrentQueue<T>.Clear() is not available on netstandard2.0.
             while (_timedOutRpcs.TryDequeue(out _))
             {

--- a/projects/RabbitMQ.Client/Impl/RpcContinuationQueue.cs
+++ b/projects/RabbitMQ.Client/Impl/RpcContinuationQueue.cs
@@ -69,6 +69,18 @@ namespace RabbitMQ.Client.Impl
 
         private const int CommandIdBufferLength = 2;
 
+        // rabbitmq/rabbitmq-dotnet-client#1964
+        // Upper bound on recorded timed-out RPCs. Entries are only removed by an inbound
+        // command or by channel shutdown, so a channel that receives no frames at all (a
+        // publish-only channel with publisher confirmations disabled) would otherwise grow
+        // this without limit while RPCs keep timing out against an unresponsive broker.
+        //
+        // The bound is deliberately generous. Only one RPC runs per channel at a time, so
+        // with the default 20 second ContinuationTimeout a channel can record roughly three
+        // entries per minute, and reaching this many takes about three quarters of an hour
+        // of uninterrupted timeouts. A channel in that state has much larger problems.
+        private const int MaxTimedOutRpcs = 128;
+
         private static readonly EmptyRpcContinuation s_tmp = new EmptyRpcContinuation();
 
         // rabbitmq/rabbitmq-dotnet-client#1964
@@ -195,6 +207,19 @@ namespace RabbitMQ.Client.Impl
                 protocolCommandIds.Length > 1 ? protocolCommandIds[1] : default);
 
             _timedOutRpcs.Enqueue(timedOut);
+
+            // rabbitmq/rabbitmq-dotnet-client#1964
+            // Keep the record bounded. The oldest entry is the one whose response is most
+            // overdue and so the least likely to still arrive, which makes it the right one
+            // to give up on. Dropping it costs only that this library no longer recognizes
+            // that particular late response, so it would surface as "Received unexpected
+            // command of type ...!" exactly as it did before #1802.
+            //
+            // Best effort: RpcCanceled is only reached from the RPC-issuing path, which is
+            // serialized on the channel's RPC semaphore, so at most one caller trims here.
+            while (_timedOutRpcs.Count > MaxTimedOutRpcs && _timedOutRpcs.TryDequeue(out _))
+            {
+            }
         }
 
         public bool ShouldIgnoreCommand(ProtocolCommandId commandId)

--- a/projects/RabbitMQ.Client/Impl/RpcContinuationQueue.cs
+++ b/projects/RabbitMQ.Client/Impl/RpcContinuationQueue.cs
@@ -203,6 +203,18 @@ namespace RabbitMQ.Client.Impl
             // This keeps track of ProtocolCommandId values from previous RPC
             // commands that have timed out, so that their late responses are
             // discarded rather than matched against a later continuation.
+
+            // rabbitmq/rabbitmq-dotnet-client#1964
+            // Server-originated frames are not part of the request-response stream and
+            // interleave freely with it, so they must not consume an entry. Doing so
+            // discarded the record of a timed-out RPC whenever a delivery or an ack
+            // happened to arrive first, and the late response then reached an unrelated
+            // continuation, which is the very failure this record exists to prevent.
+            if (IsServerOriginated(commandId))
+            {
+                return false;
+            }
+
             // AMQP 0-9-1 enforces strict request-response ordering on a channel, so late
             // responses arrive in the order the requests were sent. Only the oldest
             // outstanding entry can match; consume it either way, since a non-match means
@@ -213,6 +225,56 @@ namespace RabbitMQ.Client.Impl
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Whether the broker sends this command of its own accord, rather than as the
+        /// response to a request this channel made.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Derived from the <c>switch</c> in <c>Channel.DispatchCommandAsync</c>, which is
+        /// the authority on this distinction: <c>Channel.HandleCommandAsync</c> calls
+        /// <c>ShouldIgnoreCommand</c> and then <c>DispatchCommandAsync</c>, and the latter
+        /// returns <c>true</c> for exactly those commands it handles itself and <c>false</c>
+        /// from its <c>default</c> case, meaning "this is an RPC response, hand it to the
+        /// outstanding continuation". The list below is that switch's cases, minus the three
+        /// exceptions named next.
+        /// </para>
+        /// <para>
+        /// <c>ChannelCloseOk</c>, <c>ConnectionSecure</c> and <c>ConnectionTune</c> are
+        /// deliberately absent even though <c>DispatchCommandAsync</c> handles them. They
+        /// are also genuine RPC responses: <c>ChannelCloseAsyncRpcContinuation</c> names the
+        /// first as its expected reply, and <c>ConnectionSecureOrTuneAsyncRpcContinuation</c>
+        /// names the other two. They can therefore arrive late like any other reply and must
+        /// still be absorbable, so deciding membership purely from "does dispatch handle it"
+        /// would silently stop absorbing them.
+        /// </para>
+        /// <para>
+        /// So: keep this in step with <c>DispatchCommandAsync</c> when commands are added
+        /// there, but ask of each one whether any continuation ever waits on it, not just
+        /// whether dispatch handles it.
+        /// </para>
+        /// </remarks>
+        private static bool IsServerOriginated(ProtocolCommandId commandId)
+        {
+            switch (commandId)
+            {
+                case ProtocolCommandId.BasicAck:
+                case ProtocolCommandId.BasicCancel:
+                case ProtocolCommandId.BasicDeliver:
+                case ProtocolCommandId.BasicNack:
+                case ProtocolCommandId.BasicReturn:
+                case ProtocolCommandId.ChannelClose:
+                case ProtocolCommandId.ChannelFlow:
+                case ProtocolCommandId.ConnectionBlocked:
+                case ProtocolCommandId.ConnectionClose:
+                case ProtocolCommandId.ConnectionStart:
+                case ProtocolCommandId.ConnectionUnblocked:
+                    return true;
+                default:
+                    return false;
+            }
         }
     }
 }

--- a/projects/Test/Unit/TestAsyncRpcContinuation.cs
+++ b/projects/Test/Unit/TestAsyncRpcContinuation.cs
@@ -1,0 +1,103 @@
+// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2026 Broadcom. All Rights Reserved.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       https://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v2.0:
+//
+//---------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//  Copyright (c) 2007-2026 Broadcom. All Rights Reserved.
+//---------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using RabbitMQ.Client.Framing;
+using RabbitMQ.Client.Impl;
+using Xunit;
+
+namespace Test.Unit
+{
+    public class TestAsyncRpcContinuation
+    {
+        // rabbitmq/rabbitmq-dotnet-client#1964
+        // A continuation's timeout starts at construction, which bounds the wait for
+        // the channel's RPC semaphore. Once the semaphore is acquired the operation
+        // still has not been sent, so the time spent queued must not be charged
+        // against it. Channel restarts the timeout at that point.
+        private static readonly TimeSpan s_continuationTimeout = TimeSpan.FromSeconds(2);
+        private static readonly TimeSpan s_simulatedSemaphoreWait = TimeSpan.FromSeconds(1);
+
+        [Fact]
+        public async Task TestRestartTimeout_GivesTheOperationTheFullTimeout()
+        {
+            using var k = new SimpleAsyncRpcContinuation(ProtocolCommandId.ExchangeDeclareOk,
+                s_continuationTimeout, CancellationToken.None);
+
+            var stopwatch = Stopwatch.StartNew();
+
+            await Task.Delay(s_simulatedSemaphoreWait);
+
+            // Precondition: the continuation must still be live, otherwise the delay
+            // above overran the timeout and the test measures nothing
+            Assert.False(k.CancellationToken.IsCancellationRequested);
+
+            k.RestartTimeout();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await k);
+
+            stopwatch.Stop();
+
+            // Without the restart the continuation expires at s_continuationTimeout.
+            // With it, the deadline moves out by the time spent queued.
+            TimeSpan floor = s_continuationTimeout + (s_simulatedSemaphoreWait / 2);
+            Assert.True(stopwatch.Elapsed > floor,
+                $"expected the continuation to survive past {floor}, but it expired after {stopwatch.Elapsed}");
+        }
+
+        [Fact]
+        public async Task TestRestartTimeout_StillTimesOut()
+        {
+            using var k = new SimpleAsyncRpcContinuation(ProtocolCommandId.ExchangeDeclareOk,
+                s_continuationTimeout, CancellationToken.None);
+
+            k.RestartTimeout();
+
+            // Restarting must not disarm the timeout, only reschedule it
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await k);
+        }
+
+        [Fact]
+        public void TestRestartTimeout_AfterDisposeDoesNotThrow()
+        {
+            var k = new SimpleAsyncRpcContinuation(ProtocolCommandId.ExchangeDeclareOk,
+                s_continuationTimeout, CancellationToken.None);
+            k.Dispose();
+
+            // A continuation that has already completed may still be restarted by a
+            // racing caller; that must not surface an ObjectDisposedException
+            k.RestartTimeout();
+        }
+    }
+}

--- a/projects/Test/Unit/TestAsyncRpcContinuation.cs
+++ b/projects/Test/Unit/TestAsyncRpcContinuation.cs
@@ -46,6 +46,12 @@ namespace Test.Unit
         // arbitrary number of queued operations before its own frame is written. The
         // continuation timeout therefore does not start at construction; Channel starts
         // it once the RPC semaphore has been acquired and the operation can run.
+        //
+        // These are wall-clock tests, so they are written so that load can only ever make
+        // them pass: every assertion is one-sided in the safe direction. The simulated wait
+        // is comfortably longer than the timeout, and the one elapsed-time assertion has a
+        // floor rather than a ceiling, so a delay that overruns is harmless while a timer
+        // that fires early cannot happen. Do not tighten these towards each other.
         private static readonly TimeSpan s_continuationTimeout = TimeSpan.FromSeconds(2);
         private static readonly TimeSpan s_simulatedSemaphoreWait = TimeSpan.FromSeconds(5);
 

--- a/projects/Test/Unit/TestAsyncRpcContinuation.cs
+++ b/projects/Test/Unit/TestAsyncRpcContinuation.cs
@@ -49,6 +49,10 @@ namespace Test.Unit
         private static readonly TimeSpan s_continuationTimeout = TimeSpan.FromSeconds(2);
         private static readonly TimeSpan s_simulatedSemaphoreWait = TimeSpan.FromSeconds(1);
 
+        // Half of s_simulatedSemaphoreWait, stated rather than divided: the TimeSpan
+        // division operators do not exist on net472, which Unit also targets.
+        private static readonly TimeSpan s_restartMargin = TimeSpan.FromMilliseconds(500);
+
         [Fact]
         public async Task TestRestartTimeout_GivesTheOperationTheFullTimeout()
         {
@@ -71,7 +75,7 @@ namespace Test.Unit
 
             // Without the restart the continuation expires at s_continuationTimeout.
             // With it, the deadline moves out by the time spent queued.
-            TimeSpan floor = s_continuationTimeout + (s_simulatedSemaphoreWait / 2);
+            TimeSpan floor = s_continuationTimeout + s_restartMargin;
             Assert.True(stopwatch.Elapsed > floor,
                 $"expected the continuation to survive past {floor}, but it expired after {stopwatch.Elapsed}");
         }

--- a/projects/Test/Unit/TestAsyncRpcContinuation.cs
+++ b/projects/Test/Unit/TestAsyncRpcContinuation.cs
@@ -42,66 +42,95 @@ namespace Test.Unit
     public class TestAsyncRpcContinuation
     {
         // rabbitmq/rabbitmq-dotnet-client#1964
-        // A continuation's timeout starts at construction, which bounds the wait for
-        // the channel's RPC semaphore. Once the semaphore is acquired the operation
-        // still has not been sent, so the time spent queued must not be charged
-        // against it. Channel restarts the timeout at that point.
+        // Only one RPC runs per channel at a time, so a caller can sit behind an
+        // arbitrary number of queued operations before its own frame is written. The
+        // continuation timeout therefore does not start at construction; Channel starts
+        // it once the RPC semaphore has been acquired and the operation can run.
         private static readonly TimeSpan s_continuationTimeout = TimeSpan.FromSeconds(2);
-        private static readonly TimeSpan s_simulatedSemaphoreWait = TimeSpan.FromSeconds(1);
-
-        // Half of s_simulatedSemaphoreWait, stated rather than divided: the TimeSpan
-        // division operators do not exist on net472, which Unit also targets.
-        private static readonly TimeSpan s_restartMargin = TimeSpan.FromMilliseconds(500);
+        private static readonly TimeSpan s_simulatedSemaphoreWait = TimeSpan.FromSeconds(5);
 
         [Fact]
-        public async Task TestRestartTimeout_GivesTheOperationTheFullTimeout()
+        public async Task TestTimeoutDoesNotStartAtConstruction()
         {
             using var k = new SimpleAsyncRpcContinuation(ProtocolCommandId.ExchangeDeclareOk,
                 s_continuationTimeout, CancellationToken.None);
 
-            var stopwatch = Stopwatch.StartNew();
+            // Stand in for a long wait on the channel's RPC semaphore. This is more
+            // than twice s_continuationTimeout, so an armed-at-construction
+            // continuation would already be cancelled by now.
+            await Task.Delay(s_simulatedSemaphoreWait);
+
+            Assert.False(k.CancellationToken.IsCancellationRequested);
+        }
+
+        [Fact]
+        public async Task TestStartTimeoutGivesTheOperationTheFullTimeout()
+        {
+            using var k = new SimpleAsyncRpcContinuation(ProtocolCommandId.ExchangeDeclareOk,
+                s_continuationTimeout, CancellationToken.None);
 
             await Task.Delay(s_simulatedSemaphoreWait);
 
-            // Precondition: the continuation must still be live, otherwise the delay
-            // above overran the timeout and the test measures nothing
-            Assert.False(k.CancellationToken.IsCancellationRequested);
-
-            k.RestartTimeout();
+            var stopwatch = Stopwatch.StartNew();
+            k.StartTimeout();
 
             await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await k);
 
             stopwatch.Stop();
 
-            // Without the restart the continuation expires at s_continuationTimeout.
-            // With it, the deadline moves out by the time spent queued.
-            TimeSpan floor = s_continuationTimeout + s_restartMargin;
+            // The operation gets the full budget measured from StartTimeout, not from
+            // construction. Allow generous slack for timer resolution and CI load; the
+            // point is that the queueing delay was not charged to the operation, which
+            // would show up as expiry well under s_continuationTimeout.
+            TimeSpan floor = TimeSpan.FromMilliseconds(1500);
             Assert.True(stopwatch.Elapsed > floor,
-                $"expected the continuation to survive past {floor}, but it expired after {stopwatch.Elapsed}");
+                $"expected the operation to get its full timeout from StartTimeout, " +
+                $"but it expired after only {stopwatch.Elapsed}");
         }
 
         [Fact]
-        public async Task TestRestartTimeout_StillTimesOut()
+        public async Task TestStartTimeoutStillTimesOut()
         {
             using var k = new SimpleAsyncRpcContinuation(ProtocolCommandId.ExchangeDeclareOk,
                 s_continuationTimeout, CancellationToken.None);
 
-            k.RestartTimeout();
+            k.StartTimeout();
 
-            // Restarting must not disarm the timeout, only reschedule it
+            // Starting the timeout must actually arm it, otherwise a stuck operation
+            // would hang its caller forever
             await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await k);
         }
 
         [Fact]
-        public void TestRestartTimeout_AfterDisposeDoesNotThrow()
+        public void TestStartTimeoutAfterDisposeDoesNotThrow()
         {
             var k = new SimpleAsyncRpcContinuation(ProtocolCommandId.ExchangeDeclareOk,
                 s_continuationTimeout, CancellationToken.None);
             k.Dispose();
 
-            // A continuation that has already completed may still be restarted by a
+            // A continuation that has already completed may still be started by a
             // racing caller; that must not surface an ObjectDisposedException
-            k.RestartTimeout();
+            k.StartTimeout();
+        }
+
+        [Fact]
+        public void TestCallerTokenStillCancelsBeforeTimeoutStarts()
+        {
+            using var cts = new CancellationTokenSource();
+            using var k = new SimpleAsyncRpcContinuation(ProtocolCommandId.ExchangeDeclareOk,
+                s_continuationTimeout, cts.Token);
+
+            // Before StartTimeout the caller's own token is the only thing bounding the
+            // wait for the RPC semaphore, so it must still surface through the token
+            // Channel passes to WaitAsync.
+            cts.Cancel();
+
+            Assert.True(k.CancellationToken.IsCancellationRequested);
+
+            // Note: this deliberately does not await k. The continuation's task is
+            // completed by a response, a channel shutdown, or the timeout callback, and
+            // the caller's token is not registered against it. That is why StartTimeout
+            // must be called before the operation is awaited, which Channel always does.
         }
     }
 }

--- a/projects/Test/Unit/TestRpcContinuationQueue.cs
+++ b/projects/Test/Unit/TestRpcContinuationQueue.cs
@@ -31,6 +31,8 @@
 
 using System;
 using System.Threading;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Framing;
 using RabbitMQ.Client.Impl;
 using Xunit;
@@ -157,6 +159,60 @@ namespace Test.Unit
             queue.RpcCanceled(true, [ProtocolCommandId.QueueDeclareOk]);
             // Since responseReceived=true, no command IDs should be recorded
             Assert.False(queue.ShouldIgnoreCommand(ProtocolCommandId.QueueDeclareOk));
+        }
+
+        // rabbitmq/rabbitmq-dotnet-client#1964
+        // Consecutive timeouts each leave a late response in flight. A single-slot
+        // record kept only the newest, so the older responses were matched against
+        // an unrelated continuation ("Received unexpected command of type ...!").
+        [Fact]
+        public void TestShouldIgnoreCommand_ConsecutiveTimeouts_IgnoresEveryLateResponse()
+        {
+            RpcContinuationQueue queue = new RpcContinuationQueue();
+
+            queue.RpcCanceled(false, [ProtocolCommandId.ExchangeDeclareOk]);
+            queue.RpcCanceled(false, [ProtocolCommandId.QueueDeclareOk]);
+            queue.RpcCanceled(false, [ProtocolCommandId.BasicGetOk, ProtocolCommandId.BasicGetEmpty]);
+
+            // Late responses arrive in the order the requests were sent
+            Assert.True(queue.ShouldIgnoreCommand(ProtocolCommandId.ExchangeDeclareOk));
+            Assert.True(queue.ShouldIgnoreCommand(ProtocolCommandId.QueueDeclareOk));
+            Assert.True(queue.ShouldIgnoreCommand(ProtocolCommandId.BasicGetEmpty));
+
+            // All three have now been absorbed
+            Assert.False(queue.ShouldIgnoreCommand(ProtocolCommandId.ExchangeDeclareOk));
+        }
+
+        [Fact]
+        public void TestShouldIgnoreCommand_ConsecutiveTimeouts_SameCommandId()
+        {
+            RpcContinuationQueue queue = new RpcContinuationQueue();
+
+            queue.RpcCanceled(false, [ProtocolCommandId.ExchangeDeclareOk]);
+            queue.RpcCanceled(false, [ProtocolCommandId.ExchangeDeclareOk]);
+
+            Assert.True(queue.ShouldIgnoreCommand(ProtocolCommandId.ExchangeDeclareOk));
+            Assert.True(queue.ShouldIgnoreCommand(ProtocolCommandId.ExchangeDeclareOk));
+            Assert.False(queue.ShouldIgnoreCommand(ProtocolCommandId.ExchangeDeclareOk));
+        }
+
+        [Fact]
+        public void TestHandleChannelShutdown_DiscardsPendingTimedOutCommands()
+        {
+            RpcContinuationQueue queue = new RpcContinuationQueue();
+
+            queue.RpcCanceled(false, [ProtocolCommandId.ExchangeDeclareOk]);
+            queue.RpcCanceled(false, [ProtocolCommandId.QueueDeclareOk]);
+
+            queue.HandleChannelShutdown(new ShutdownEventArgs(ShutdownInitiator.Library,
+                Constants.ReplySuccess, "test shutdown"));
+
+            // No further frames arrive on a shut down channel, so a recovered channel
+            // must not start out expecting to discard commands. Probe the newest entry
+            // first: probing the oldest would consume the sole slot of a single-entry
+            // implementation and mask a missing drain.
+            Assert.False(queue.ShouldIgnoreCommand(ProtocolCommandId.QueueDeclareOk));
+            Assert.False(queue.ShouldIgnoreCommand(ProtocolCommandId.ExchangeDeclareOk));
         }
     }
 }

--- a/projects/Test/Unit/TestRpcContinuationQueue.cs
+++ b/projects/Test/Unit/TestRpcContinuationQueue.cs
@@ -244,6 +244,55 @@ namespace Test.Unit
             Assert.True(queue.ShouldIgnoreCommand(ProtocolCommandId.ConnectionTune));
         }
 
+        // rabbitmq/rabbitmq-dotnet-client#1964
+        // Entries are only removed by an inbound command or by channel shutdown, so a
+        // channel that receives no frames at all would grow this record without limit
+        // while RPCs keep timing out. The record is capped, dropping the oldest entries.
+        [Fact]
+        public void TestRpcCanceled_IsBounded()
+        {
+            RpcContinuationQueue queue = new RpcContinuationQueue();
+
+            const int recorded = 500;
+            for (int i = 0; i < recorded; i++)
+            {
+                queue.RpcCanceled(false, [ProtocolCommandId.ExchangeDeclareOk]);
+            }
+
+            // Drain by feeding matching responses until the record is empty. An unbounded
+            // record would absorb all 500.
+            int absorbed = 0;
+            while (queue.ShouldIgnoreCommand(ProtocolCommandId.ExchangeDeclareOk))
+            {
+                absorbed++;
+                Assert.True(absorbed <= recorded,
+                    "draining did not terminate, so the record is not bounded");
+            }
+
+            Assert.True(absorbed < recorded,
+                $"expected the record to be capped, but it absorbed all {absorbed} entries");
+        }
+
+        [Fact]
+        public void TestRpcCanceled_BoundDropsTheOldestEntries()
+        {
+            RpcContinuationQueue queue = new RpcContinuationQueue();
+
+            // One distinguishable entry first, so it is the oldest and therefore the first
+            // to be given up on once the bound is exceeded.
+            queue.RpcCanceled(false, [ProtocolCommandId.QueueDeclareOk]);
+
+            for (int i = 0; i < 500; i++)
+            {
+                queue.RpcCanceled(false, [ProtocolCommandId.ExchangeDeclareOk]);
+            }
+
+            // If the oldest entry had survived it would still be at the head, and matching
+            // ExchangeDeclareOk against it would consume it and return false. Returning
+            // true proves it was dropped rather than something newer.
+            Assert.True(queue.ShouldIgnoreCommand(ProtocolCommandId.ExchangeDeclareOk));
+        }
+
         [Fact]
         public void TestHandleChannelShutdown_DiscardsPendingTimedOutCommands()
         {

--- a/projects/Test/Unit/TestRpcContinuationQueue.cs
+++ b/projects/Test/Unit/TestRpcContinuationQueue.cs
@@ -304,9 +304,9 @@ namespace Test.Unit
             queue.HandleChannelShutdown(new ShutdownEventArgs(ShutdownInitiator.Library,
                 Constants.ReplySuccess, "test shutdown"));
 
-            // No further frames arrive on a shut down channel, so a recovered channel
-            // must not start out expecting to discard commands. Probe the newest entry
-            // first: probing the oldest would consume the sole slot of a single-entry
+            // No further frames arrive on a shut down channel, so the recorded entries can
+            // never be consumed and are released instead. Probe the newest entry first:
+            // probing the oldest would consume the sole slot of a single-entry
             // implementation and mask a missing drain.
             Assert.False(queue.ShouldIgnoreCommand(ProtocolCommandId.QueueDeclareOk));
             Assert.False(queue.ShouldIgnoreCommand(ProtocolCommandId.ExchangeDeclareOk));

--- a/projects/Test/Unit/TestRpcContinuationQueue.cs
+++ b/projects/Test/Unit/TestRpcContinuationQueue.cs
@@ -104,7 +104,8 @@ namespace Test.Unit
         {
             RpcContinuationQueue queue = new RpcContinuationQueue();
             queue.RpcCanceled(false, [ProtocolCommandId.QueueDeclareOk]);
-            Assert.False(queue.ShouldIgnoreCommand(ProtocolCommandId.BasicAck));
+            // Another RPC response, so the mismatch path is what is exercised here
+            Assert.False(queue.ShouldIgnoreCommand(ProtocolCommandId.ExchangeDeclareOk));
         }
 
         [Fact]
@@ -128,7 +129,8 @@ namespace Test.Unit
         {
             RpcContinuationQueue queue = new RpcContinuationQueue();
             queue.RpcCanceled(false, [ProtocolCommandId.BasicGetOk, ProtocolCommandId.BasicGetEmpty]);
-            Assert.False(queue.ShouldIgnoreCommand(ProtocolCommandId.BasicAck));
+            // Another RPC response, so the mismatch path is what is exercised here
+            Assert.False(queue.ShouldIgnoreCommand(ProtocolCommandId.ExchangeDeclareOk));
         }
 
         [Fact]
@@ -146,8 +148,9 @@ namespace Test.Unit
         {
             RpcContinuationQueue queue = new RpcContinuationQueue();
             queue.RpcCanceled(false, [ProtocolCommandId.QueueDeclareOk]);
-            // Consume with a non-matching command ID
-            Assert.False(queue.ShouldIgnoreCommand(ProtocolCommandId.BasicAck));
+            // Consume with a non-matching command ID. It must be another RPC response:
+            // a server-originated frame deliberately does not consume an entry (#1964).
+            Assert.False(queue.ShouldIgnoreCommand(ProtocolCommandId.ExchangeDeclareOk));
             // Now the timed-out state is consumed, any check returns false
             Assert.False(queue.ShouldIgnoreCommand(ProtocolCommandId.QueueDeclareOk));
         }
@@ -194,6 +197,51 @@ namespace Test.Unit
             Assert.True(queue.ShouldIgnoreCommand(ProtocolCommandId.ExchangeDeclareOk));
             Assert.True(queue.ShouldIgnoreCommand(ProtocolCommandId.ExchangeDeclareOk));
             Assert.False(queue.ShouldIgnoreCommand(ProtocolCommandId.ExchangeDeclareOk));
+        }
+
+        // rabbitmq/rabbitmq-dotnet-client#1964
+        // Server-originated frames interleave freely with the request-response stream.
+        // Consuming an entry for one of them discarded the record of a timed-out RPC,
+        // so its late response then reached an unrelated continuation.
+        [Theory]
+        [InlineData(ProtocolCommandId.BasicDeliver)]
+        [InlineData(ProtocolCommandId.BasicAck)]
+        [InlineData(ProtocolCommandId.BasicNack)]
+        [InlineData(ProtocolCommandId.BasicReturn)]
+        [InlineData(ProtocolCommandId.BasicCancel)]
+        [InlineData(ProtocolCommandId.ChannelFlow)]
+        [InlineData(ProtocolCommandId.ConnectionBlocked)]
+        [InlineData(ProtocolCommandId.ConnectionUnblocked)]
+        // Note: internal because ProtocolCommandId is internal; xUnit discovers it either way
+        internal void TestShouldIgnoreCommand_ServerOriginatedFrameDoesNotConsumeEntry(
+            ProtocolCommandId serverOriginated)
+        {
+            RpcContinuationQueue queue = new RpcContinuationQueue();
+            queue.RpcCanceled(false, [ProtocolCommandId.QueueDeclareOk]);
+
+            Assert.False(queue.ShouldIgnoreCommand(serverOriginated));
+
+            // The timed-out RPC's record must survive, otherwise its late response is
+            // matched against whichever continuation is outstanding by then
+            Assert.True(queue.ShouldIgnoreCommand(ProtocolCommandId.QueueDeclareOk));
+        }
+
+        [Fact]
+        public void TestShouldIgnoreCommand_ChannelCloseOkStillAbsorbed()
+        {
+            // ChannelCloseOk is dispatched by Channel, but it is a real RPC response and
+            // so may arrive late like any other
+            RpcContinuationQueue queue = new RpcContinuationQueue();
+            queue.RpcCanceled(false, [ProtocolCommandId.ChannelCloseOk]);
+            Assert.True(queue.ShouldIgnoreCommand(ProtocolCommandId.ChannelCloseOk));
+        }
+
+        [Fact]
+        public void TestShouldIgnoreCommand_ConnectionSecureAndTuneStillAbsorbed()
+        {
+            RpcContinuationQueue queue = new RpcContinuationQueue();
+            queue.RpcCanceled(false, [ProtocolCommandId.ConnectionSecure, ProtocolCommandId.ConnectionTune]);
+            Assert.True(queue.ShouldIgnoreCommand(ProtocolCommandId.ConnectionTune));
         }
 
         [Fact]


### PR DESCRIPTION
> [!NOTE]
> This description was written by Claude (Anthropic's Claude Code), which also did the investigation and wrote the fix, under the direction of @lukebakken, who reviewed and approved each commit before it was made. The measurements and test results are from actual runs, not estimates.

Fixes #1964.

## Problem

Three bugs, all in the same area. The issue framed the cause as concurrent RPCs on one channel, but `_rpcSemaphore` does serialize them, so that is not the defect.

**1. The continuation timeout was charged for time the operation could not run.** `AsyncRpcContinuation` armed its `CancellationTokenSource(continuationTimeout)` in the constructor, and every RPC method in `Channel` constructs the continuation *before* awaiting `_rpcSemaphore.WaitAsync`. So the queueing delay behind other operations was billed to the operation. Measured with 256 concurrent `ExchangeDeclareAsync` calls on one channel: 9 ms uncontended, but p50 100 ms and max 196 ms against a 200 ms budget. The broker was not slow. This also contradicts the documented meaning of `ContinuationTimeout`, "amount of time protocol operations are allowed to take" - the operation, not the queue ahead of it.

**2. Single-slot late-response tracking lost responses.** Each timeout leaves a late response in flight, and several can be outstanding at once: the semaphore serializes *requests*, but nothing makes the broker's reply arrive before the next request is sent. The #1802 machinery recorded only one entry, so each new `RpcCanceled` overwrote the previous one and the unabsorbed `-Ok` was matched against an unrelated continuation, giving `Received unexpected command of type ExchangeDeclareOk!`. Confirmed with temporary instrumentation that printed the overwrite and the resulting failure in the same run.

**3. Server-originated frames consumed the record.** `Channel.HandleCommandAsync` calls `ShouldIgnoreCommand` for *every* incoming command, so a `basic.deliver`, `basic.ack` or `channel.flow` arriving between a timeout and its late response consumed the record of that timed-out RPC. Not new in this branch - the single-slot code on `main` consumed its slot unconditionally too, under the same false invariant.

## Fix

**Timeout accounting.** The timeout source is now constructed unarmed, and `StartTimeout()` arms it once the semaphore is held. Two details make this more than a rename: `CancelAfter` cannot un-cancel, so leaving it armed at construction and merely withholding the token from `WaitAsync` would not work; and a continuation that never calls `StartTimeout()` has no timeout at all, which was the case for `MaybeConfirmSelectAsync`. All 22 construction sites now pair one-to-one with a `StartTimeout()` call. This does not introduce unbounded waiting, since whoever holds the semaphore has its own timeout armed. `BasicPublishAsync` does not take the semaphore, so the publish hot path is untouched.

**Late-response tracking.** Replaces the single-slot union struct with a `ConcurrentQueue<TimedOutRpc>`, one entry per timed-out RPC, bounded at 128. AMQP 0-9-1 enforces strict request-response ordering, so late responses arrive in send order and only the oldest entry can match; `TryDequeue` consumes it either way, since a non-match means that response is never coming.

**Server-originated frames.** `ShouldIgnoreCommand` now skips the queue for commands the broker sends of its own accord. The list is derived from the switch in `DispatchCommandAsync`, which is authoritative because it returns `false` only from its `default` case, meaning "this is an RPC response". `ChannelCloseOk`, `ConnectionSecure` and `ConnectionTune` are deliberately excluded even though dispatch handles them, because continuations name them as expected replies and they must stay absorbable. The docstring records that reasoning and the maintenance rule.

## Tests

All three bugs reproduce with no broker at all, since `RpcContinuationQueue` and `SimpleAsyncRpcContinuation` are visible to `Unit`. 13 new unit tests cover: the timeout being unarmed until the operation can run, the full budget being granted at `StartTimeout`, the dispose race, consecutive timeouts absorbing every late response in send order, the bound dropping oldest-first, the shutdown drain, 8 server-originated frame cases, and the deliberate exclusions staying absorbable.

Each was checked by reverting the relevant part of the fix and re-running, not by assuming. Two notes:

- Three pre-existing tests used `BasicAck` as their "non-matching command ID", which encoded bug 3: after the guard they would pass via the early-out rather than the mismatch path they are named for. Switched to `ExchangeDeclareOk`.
- `TestCallerTokenStillCancelsBeforeTimeoutStarts` initially hung, exposing a design limit worth stating: the continuation's task is completed only by a response, a shutdown, or the timeout callback, and the caller's token is not registered against it. Production is safe because `StartTimeout()` always precedes the await, but that is an invariant rather than an accident, and the test documents it.

## Verification

One Linux box, Toxiproxy enabled.

- **Unit** 145 passed. **Integration** 200 passed / 6 skipped on two consecutive full runs; `main` on the same box gives 197 passed / **3 failed**, failing exactly `TestConcurrentQueueDeclare`, `TestConcurrentQueueDeclareAndBindAsync` and `TestConcurrentExchangeDeclareAndDelete`. **SequentialIntegration** 64 passed / 3 skipped.
- **`TestRpcContinuationTimeout_GH1802`** passes 5/5 in isolation. This one matters most: it is the regression test for the exact #1802 mechanism replaced here, and it is Toxiproxy-gated so it does not run unless `RABBITMQ_TOXIPROXY_TESTS` is set.
- **Standalone 256-operation reproducer:** 2 mismatches in 6 runs before, 0 in 8 after.
- Clean build on both TFMs with `--no-incremental`: 0 warnings, 0 errors. `dotnet format --verify-no-changes` clean.

Skips are TLS trust store, max message body size and heartbeat cases, environmental on this box. One caveat, since this PR is about a flaky test: an intermediate full run showed `TestRpcContinuationTimeout_GH1802` and `TestQueueRecoveryWithManyQueues` failing, and both passed in the two later full runs. I attribute those to load on this box rather than to the change, and note it rather than reporting only the clean runs.
