### PR TITLE
Bump the dependencies not subject to the version floor rule (#1969)

### DIFF
--- a/projects/Benchmarks/WireFormatting/MethodFraming.cs
+++ b/projects/Benchmarks/WireFormatting/MethodFraming.cs
@@ -49,7 +49,7 @@ namespace RabbitMQ.Benchmarks
         public ushort Channel { get; set; }
 
         [Benchmark]
-        internal OutgoingFrame BasicAckWrite() => Framing.SerializeToFrames(ref _basicAck, Channel);
+        public int BasicAckWrite() => Framing.SerializeToFrames(ref _basicAck, Channel).Size;
     }
 
     [Config(typeof(Config))]
@@ -71,13 +71,13 @@ namespace RabbitMQ.Benchmarks
         public int FrameMax { get; set; }
 
         [Benchmark]
-        internal OutgoingFrame BasicPublishWriteNonEmpty() => Framing.SerializeToFrames(ref _basicPublish, ref _properties, _body, bodyOwner: null, Channel, FrameMax);
+        public int BasicPublishWriteNonEmpty() => Framing.SerializeToFrames(ref _basicPublish, ref _properties, _body, bodyOwner: null, Channel, FrameMax).Size;
 
         [Benchmark]
-        internal OutgoingFrame BasicPublishWrite() => Framing.SerializeToFrames(ref _basicPublish, ref _propertiesEmpty, _bodyEmpty, bodyOwner: null, Channel, FrameMax);
+        public int BasicPublishWrite() => Framing.SerializeToFrames(ref _basicPublish, ref _propertiesEmpty, _bodyEmpty, bodyOwner: null, Channel, FrameMax).Size;
 
         [Benchmark]
-        internal OutgoingFrame BasicPublishMemoryWrite() => Framing.SerializeToFrames(ref _basicPublishMemory, ref _propertiesEmpty, _bodyEmpty, bodyOwner: null, Channel, FrameMax);
+        public int BasicPublishMemoryWrite() => Framing.SerializeToFrames(ref _basicPublishMemory, ref _propertiesEmpty, _bodyEmpty, bodyOwner: null, Channel, FrameMax).Size;
     }
 
     [Config(typeof(Config))]
@@ -90,6 +90,6 @@ namespace RabbitMQ.Benchmarks
         public ushort Channel { get; set; }
 
         [Benchmark]
-        internal OutgoingFrame ChannelCloseWrite() => Framing.SerializeToFrames(ref _channelClose, Channel);
+        public int ChannelCloseWrite() => Framing.SerializeToFrames(ref _channelClose, Channel).Size;
     }
 }

--- a/projects/Directory.Packages.props
+++ b/projects/Directory.Packages.props
@@ -36,7 +36,20 @@
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="System.Threading.RateLimiting" Version="8.0.0" />
     <PackageVersion Include="System.Reflection.Metadata" Version="10.0.10" />
-    <PackageVersion Include="WireMock.Net" Version="2.13.0" />
+    <!--
+      Note: do NOT upgrade WireMock.Net past 2.1.0 while System.Text.Json is pinned at
+      8.0.5 above. Only projects/Test/OAuth2 uses WireMock, and on net472 it drags in
+      System.Text.Json through two transitive paths, both of which trip NU1605:
+      * 2.2.0 and later: Scriban.Signed -> System.Text.Json >= 10.0.8, and
+        JsonPath.Net -> Json.More.Net -> System.Text.Json >= 10.0.5.
+      Since System.Text.Json is a floor for RabbitMQ.Client.OAuth2 consumers it cannot
+      move to satisfy a test-only package, so WireMock is what stays put.
+
+      This only breaks on Windows: the test projects add net472 there, and the
+      System.Text.Json PackageReference in the OAuth2 test project is itself
+      net472-only, so a Linux build resolves neither and restores clean.
+    -->
+    <PackageVersion Include="WireMock.Net" Version="2.1.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/projects/Directory.Packages.props
+++ b/projects/Directory.Packages.props
@@ -3,13 +3,23 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageVersion Include="EasyNetQ.Management.Client" Version="3.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageVersion Include="EasyNetQ.Management.Client" Version="3.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="Nullable" Version="1.3.1" />
+    <!--
+      Note: do NOT upgrade the OpenTelemetry.Api dependency unless necessary.
+      1.15.3 is the oldest version without known vulnerabilities: GHSA-g94r-2vxg-569j
+      affects >= 0.5.0-beta.2, < 1.15.3. See
+      https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/1728#issuecomment-5124632838
+    -->
     <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
+    <!--
+      Note: test-only (SequentialIntegration), but kept in step with OpenTelemetry.Api
+      above so the tests exercise the same OpenTelemetry version the library ships against.
+    -->
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
-    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="10.0.10" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.4" />
     <!--
       Note: do NOT upgrade the System.IO.Pipelines dependency unless necessary
@@ -17,22 +27,59 @@
     -->
     <PackageVersion Include="System.IO.Pipelines" Version="8.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <!--
+      Note: do NOT upgrade the System.Text.Json dependency unless necessary.
+      RabbitMQ.Client.OAuth2 references this, so it is a floor for consumers even
+      though the test projects use it too.
+    -->
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="System.Threading.RateLimiting" Version="8.0.0" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="8.0.0" />
-    <PackageVersion Include="WireMock.Net" Version="1.6.9" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="10.0.10" />
+    <PackageVersion Include="WireMock.Net" Version="2.13.0" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageVersion Include="Xunit.SkippableFact" Version="1.5.23" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework)=='netstandard2.0'">
     <!--
-      Note: do NOT upgrade these dependencies unless necessary
+      Note: do NOT upgrade these dependencies unless necessary.
+
+      A PackageVersion here is a *floor* imposed on every downstream consumer, since
+      NuGet resolves to the lowest applicable version. For a shipping library that means
+      the correct choice is the oldest supported version without known vulnerabilities,
+      not the newest: a needlessly high floor constrains consumers who combine this
+      client with other libraries. "Necessary" therefore means a vulnerability or an API
+      this client actually needs, not merely that a newer version exists.
+
+      These are also the netstandard2.0-only dependencies, so they are exactly the ones
+      reaching the consumers least able to absorb a bump: .NET Framework, where net462 is
+      the minimum supported version.
+
       See:
       * https://github.com/rabbitmq/rabbitmq-dotnet-client/pull/1481#pullrequestreview-1847905299
+        (where this rule was argued out and adopted)
       * https://github.com/rabbitmq/rabbitmq-dotnet-client/pull/1594
+        (which walked back an automated `dotnet outdated -u` bump to match)
+    -->
+    <!--
+      System.Memory in particular must stay at 4.5.5, and bumping it in isolation
+      would accomplish nothing anyway: System.IO.Pipelines 8.0.0 already depends on
+      System.Memory 4.5.5 on both netstandard2.0 and net462, so that is the version a
+      consumer resolves whether or not it is listed here. Verified against the released
+      RabbitMQ.Client 7.2.1: consumers resolve exactly 4.5.5 on net472 and netstandard2.0.
+
+      The reference is kept even though it is redundant, because the client uses Span
+      and Memory directly. Listing it keeps that requirement explicit rather than
+      leaving the floor to be moved silently by a future System.IO.Pipelines bump.
+
+      4.5.5 has no known vulnerabilities and is not deprecated, so there is no reason to
+      move. Going to 4.6.x would raise three transitive floors for every netstandard2.0
+      and net462 consumer with no benefit: System.Buffers 4.5.1 -> 4.6.1,
+      System.Numerics.Vectors 4.4.0 -> 4.6.1, and, most disruptively,
+      System.Runtime.CompilerServices.Unsafe 4.5.3 -> 6.1.2. 4.6.x also replaces
+      lib/net461 with lib/net462.
     -->
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Threading.Channels" Version="8.0.0" />
@@ -40,8 +87,22 @@
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsPackable)'=='true'">
+    <!--
+      Note: do NOT upgrade PublicApiAnalyzers past 3.3.4 while global.json pins the
+      8.0.x SDK. The analyzer runs inside csc, so it is capped by the compiler that
+      SDK ships (Roslyn 4.8), and the next release after 3.3.4 is 4.14.0:
+      * 5.0.0 and later reference Roslyn 4.12 and fail with CS9057.
+      * 4.14.0 needs System.Collections.Immutable 9.0.0 in the compiler host and
+        fails to load with CS8032.
+      Raising this therefore requires moving to a newer SDK first.
+    -->
     <GlobalPackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <GlobalPackageReference Include="MinVer" Version="6.0.0" />
+    <!--
+      Note: do NOT upgrade SourceLink past 10.0.110. 10.0.200 added a transitive
+      dependency on System.IO.Hashing, which requires System.Memory >= 4.6.3 and so
+      trips NU1605 against the deliberate System.Memory 4.5.5 pin above.
+    -->
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.110" />
+    <GlobalPackageReference Include="MinVer" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/projects/RabbitMQ.Client.OAuth2-NuGet/RabbitMQ.Client.OAuth2.csproj
+++ b/projects/RabbitMQ.Client.OAuth2-NuGet/RabbitMQ.Client.OAuth2.csproj
@@ -68,7 +68,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="[6.0.0,)" PrivateAssets="All" />
+    <!--
+      Kept in step with the MinVer version in projects/Directory.Packages.props. This
+      project sets ManagePackageVersionsCentrally to false, so that file does not
+      apply here and the version has to be repeated.
+
+      PrivateAssets="All" is what keeps MinVer, a build-time only tool, out of the
+      generated nuspec. Note that it leaked into the shipped RabbitMQ.Client.OAuth2
+      2.0.0 package as a real dependency despite this; that was a pack-time issue
+      since resolved, but it is worth checking the nuspec after changing this.
+    -->
+    <PackageReference Include="MinVer" Version="[7.0.0,)" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/projects/Test/OAuth2/OAuth2.csproj
+++ b/projects/Test/OAuth2/OAuth2.csproj
@@ -36,4 +36,16 @@
     <PackageReference Include="WireMock.Net" />
   </ItemGroup>
 
+  <!--
+    RequestFormMatcher uses HttpUtility from System.Web, which is not part of the
+    default net472 reference set. This used to compile only by accident: WireMock.Net
+    1.6.9 pulled in Scriban.Signed 2.1.4, whose nuspec declares a System.Web
+    frameworkAssembly, so the reference arrived transitively. Newer Scriban dropped
+    that declaration, so reference it directly rather than depending on a test
+    package's dependency graph.
+  -->
+  <ItemGroup Condition="'$(TargetFramework)'=='net472'">
+    <Reference Include="System.Web" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Closes #1969 items 2 through 4. Item 1, the shipping-library floor sign-off, was resolved on the issue itself.

Bumps every dependency not subject to the version floor rule, and leaves every one that is. A `PackageVersion` in `projects/Directory.Packages.props` is a floor on every downstream consumer, since NuGet resolves to the lowest applicable version, so anything referenced by `RabbitMQ.Client`, `RabbitMQ.Client.OAuth2` or `RabbitMQ.Client.OpenTelemetry` is untouched. Test, benchmark, sample and build-time packages track latest.

Verified that both shipping packages' nuspec dependency sets are byte for byte identical before and after, by diffing the `<dependencies>` block from the packed nupkgs against a pre-change baseline. No consumer-visible floor moves.

## Bumped

Test, benchmark or sample only:

| Package | From | To |
|---|---|---|
| BenchmarkDotNet | 0.14.0 | 0.15.8 |
| EasyNetQ.Management.Client | 3.0.0 | 3.0.1 |
| Microsoft.NET.Test.Sdk | 17.12.0 | 18.8.1 |
| System.Collections.Immutable | 8.0.0 | 10.0.10 |
| System.Reflection.Metadata | 8.0.0 | 10.0.10 |
| WireMock.Net | 1.6.9 | 2.1.0 |
| xunit | 2.9.2 | 2.9.3 |
| xunit.runner.visualstudio | 2.8.2 | 3.1.5 |
| Xunit.SkippableFact | 1.5.23 | 1.5.61 |

Build-time only:

| Package | From | To |
|---|---|---|
| Microsoft.SourceLink.GitHub | 8.0.0 | 10.0.110 |
| MinVer | 6.0.0 | 7.0.0 |

`MinVer` is also bumped in `projects/RabbitMQ.Client.OAuth2-NuGet`, which sets `ManagePackageVersionsCentrally` to `false` and carries its own versions.

`projects/toxiproxy-netcore` picks up rabbitmq/toxiproxy-netcore@91840ed: `coverlet.collector` 8.0.0 -> 10.0.1, `Microsoft.NET.Test.Sdk` 18.3.0 -> 18.8.1. Its suite passes 40 of 40 against a local Toxiproxy server.

## Three packages are capped, not merely stale

Each reason is recorded in the props file so the investigation is not repeated.

**`Microsoft.CodeAnalysis.PublicApiAnalyzers` stays at 3.3.4.** It runs inside `csc`, so it is capped by the compiler the SDK in `global.json` ships (Roslyn 4.8). There is no release between 3.3.4 and 4.14.0, and both sides of the gap fail: 5.x references Roslyn 4.12 and fails with `CS9057`, while 4.14.0 needs `System.Collections.Immutable` 9.0.0 in the compiler host and fails to load with `CS8032`. Raising it requires a newer SDK first, which arguably belongs with #1424.

**`Microsoft.SourceLink.GitHub` stops at 10.0.110.** 10.0.200 added a transitive `System.IO.Hashing` dependency requiring `System.Memory >= 4.6.3`, tripping `NU1605` against the deliberate 4.5.5 pin. Bisected: absent at 10.0.102 and 10.0.110, first appears at 10.0.200.

**`WireMock.Net` stops at 2.1.0.** 2.2.0 and later reach `System.Text.Json` through `Scriban.Signed` (>= 10.0.8) and `JsonPath.Net -> Json.More.Net` (>= 10.0.5), both downgrades against the 8.0.5 pin. `System.Text.Json` is a floor for `RabbitMQ.Client.OAuth2` consumers, so it cannot move for a test-only package. Bisected by restore: 2.2.0 through 2.13.0 all trip it.

## Source changes

Two, both in test or benchmark projects.

`BenchmarkDotNet` 0.15.x adds analyzer `BDN1103`, which rejects non-public benchmark methods. Five in `projects/Benchmarks/WireFormatting/MethodFraming.cs` were `internal` only because they returned the internal `OutgoingFrame`. They now return its `Size` as an `int`, keeping the measured work identical.

The OAuth2 test project now references `System.Web` directly. `RequestFormMatcher` uses `HttpUtility`, which is not in the default net472 reference set and compiled only because WireMock 1.6.9 pulled in `Scriban.Signed` 2.1.4, whose nuspec declares a `System.Web` frameworkAssembly. Newer Scriban dropped that, so the reference is now explicit rather than inherited from a test package's graph.

Both net472 issues were Windows-only, which is why they surfaced in CI rather than locally: the test projects add net472 only on Windows, and the `System.Text.Json` reference in the OAuth2 test project is itself net472-only.

## Comments

Item 4 asked that the "do NOT upgrade" comments stay accurate. They now record why, since some were thinner than the reasoning behind them.

The `netstandard2.0` block header states the floor rule and cites [#1481](https://github.com/rabbitmq/rabbitmq-dotnet-client/pull/1481#pullrequestreview-1847905299), where it was argued out, and #1594, which walked back an automated bump to match.

`System.Memory` gets a fuller note, because the interesting fact was missing: `System.IO.Pipelines` 8.0.0 already depends on `System.Memory` 4.5.5 on both netstandard2.0 and net462, so 4.5.5 is what a consumer resolves whether or not it is listed. Confirmed against released 7.2.1 on net472 and netstandard2.0. Bumping it in isolation would only raise three transitive floors for .NET Framework consumers: `System.Buffers` 4.5.1 -> 4.6.1, `System.Numerics.Vectors` 4.4.0 -> 4.6.1, `System.Runtime.CompilerServices.Unsafe` 4.5.3 -> 6.1.2. The redundant reference is kept so a future Pipelines bump cannot move the floor silently.

`OpenTelemetry.Api` carries the GHSA-g94r-2vxg-569j citation establishing 1.15.3 as the oldest permissible version.

## Verification

* Release build of the solution and the full `Build.csproj` traversal: 0 warnings, 0 errors, on both Linux and Windows.
* Shipping nuspec dependency sets identical to baseline for both packages.
* Unit suite 127 of 127, and identically 127 of 127 before the bump. This mattered because `xunit.runner.visualstudio` 2 -> 3 and `Microsoft.NET.Test.Sdk` 17 -> 18 are majors that can silently change test discovery.
* OAuth2 suite 10 passed, with 2 failures from an absent broker, identical before the bump.
* `dotnet format --verify-no-changes` clean. `RabbitMQ.Client.OAuth2-NuGet` packs cleanly with MinVer correctly absent from the nuspec.

Integration and SequentialIntegration are left to CI.

## Still open on #1969

The `System.Diagnostics.DiagnosticSource` 9.0.4 versus 10.0.0 question is not addressed here. `OpenTelemetry.Api` 1.15.3 requires `>= 10.0.0`, so OpenTelemetry consumers resolve 10.0.0 regardless of the pin while direct `RabbitMQ.Client` consumers get 9.0.4. Nothing is broken; options are in [#1728](https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/1728#issuecomment-5124632838).
