### PR TITLE
Accept ObjectDisposedException in TestCleanClosureWithSocketClosedOutOfBand (#1974)

### DIFF
--- a/projects/Test/Integration/TestConnectionShutdown.cs
+++ b/projects/Test/Integration/TestConnectionShutdown.cs
@@ -70,7 +70,16 @@ namespace Test.Integration
             }
             catch (AlreadyClosedException ex)
             {
-                Assert.IsAssignableFrom<IOException>(ex.InnerException);
+                /*
+                 * Both are legitimate for a socket closed out of band, since the type
+                 * depends on whether the close beat the main loop's next read. .NET
+                 * always wraps the ObjectDisposedException in an IOException, but .NET
+                 * Framework does not, so on net472 the bare one surfaces. See
+                 * ClosingLoopAsync, which likewise catches both.
+                 * https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/1974
+                 */
+                Assert.True(ex.InnerException is IOException or ObjectDisposedException,
+                    $"unexpected inner exception: {ex.InnerException}");
             }
             catch (ChannelClosedException)
             {


### PR DESCRIPTION
Fixes #1974.

> [!NOTE]
> Stacked on `fix/gh-1968-clean-closure-timeout`, which adds the repro script used to verify this. Retarget to `main` once that branch merges. The diff shown here is the single assertion change.

`TestCleanClosureWithSocketClosedOutOfBand` failed deterministically on net472 in Release builds:

```
Assert.IsAssignableFrom() Failure: Value is an incompatible type
Expected: typeof(System.IO.IOException)
Actual:   typeof(System.ObjectDisposedException)
```

The assertion was stricter than the client it exercises. `AlreadyClosedException.InnerException` is `ShutdownEventArgs.Exception`, passed through by `OperationInterruptedException`, so it is whatever `NetworkStream` threw when the main loop's read hit the socket the test closed out of band via `CloseFrameHandlerAsync()`. That type depends on how the close interleaved with the read:

| ordering | exception |
|---|---|
| socket closed before the read starts | `IOException` wrapping `ObjectDisposedException` |
| read already pending, then socket closed | `IOException` |
| pipe reader completed first | `InvalidOperationException` |

.NET always wraps the `ObjectDisposedException` in an `IOException`, so net8.0 passes either way. .NET Framework does not, so on net472 the bare one reaches the assertion. Release builds lose that race consistently.

`Connection.ClosingLoopAsync` already catches `ObjectDisposedException` and `IOException` in separate blocks on this same path, so accepting both here matches what the client already considers expected.

## Verification

On Windows, net472, on a tree cleaned with `git clean -xffd` so no stale binaries were involved:

| configuration | before | after |
|---|---|---|
| Debug | 5 of 5 pass | 5 of 5 pass |
| Release | 5 of 5 **fail** | 5 of 5 pass |

All 11 `TestConnectionShutdown` tests pass in Release on net8.0. The failure is reproducible only on .NET Framework, which is also why CI never caught it: `integration-win32` builds Debug only. Building Release for net472 in CI would surface this class of bug, but that is deliberately not proposed here.

This also unblocks #1968, an intermittent `OperationCanceledException` from the same test. While this assertion failed at around 85ms the run never reached the close timeout, so no flake rate could be measured in Release.

---

*Authored with the assistance of Claude Code. The exception orderings above were verified by running each case, and the pass and fail rates come from actual net472 runs.*
