### PR TITLE
Release the frame handler's closing semaphore instead of disposing it

### DIFF
--- a/docs/internal/connection-shutdown-and-cancellation.md
+++ b/docs/internal/connection-shutdown-and-cancellation.md
@@ -232,6 +232,45 @@ Two gates, in `projects/Applications/GH-1960/`:
 
 The token state in the app's output is the discriminating signal: `cancellable,not-yet` on a `Library/541` reason is the bug; `cancellable,already-cancelled` is the fix.
 
+## Issue #1968: a disposed `SemaphoreSlim` strands the second frame-handler closer
+
+This one presented as a flaky net472 test - `TestCleanClosureWithSocketClosedOutOfBand` failing after exactly 30s with a bare `OperationCanceledException` - and was filed as `S-needs-investigation`. It is a library bug, and the platform and the test were both red herrings.
+
+### The mechanism
+
+`SocketFrameHandler.CloseAsync` acquired `_closingSemaphore` and, in its `finally`, **disposed** it without ever releasing it. `SemaphoreSlim` grants disposal no special meaning for pending async waiters: a second `CloseAsync` already parked in `WaitAsync` when the first disposes the semaphore stays pending **forever**.
+
+Verified directly, and worth internalising because it is counter-intuitive - all three wait forms hang, so a timeout is not an escape hatch:
+
+| Wait form | Outcome after the semaphore is disposed |
+|---|---|
+| `WaitAsync(token)` with a 3s CTS | still pending at 8s |
+| `WaitAsync(TimeSpan.FromSeconds(3))` | still pending at 8s |
+| `WaitAsync(3s, token)` | still pending at 8s |
+
+Not even the waiter's own cancellation token releases it. `Dispose()` itself does not throw, so the first closer sees nothing wrong.
+
+### Why that reaches a user-visible 30s stall
+
+`MainLoop`'s `FinishCloseAsync` calls `_frameHandler.CloseAsync`, so it is itself one of the concurrent closers. When it lost this race it never returned, which means:
+
+1. `MainLoop` never completes, so `_mainLoopTask` never completes.
+2. `Connection.CloseAsync` waits on `_mainLoopTask` (`Connection.cs:464`) and burns its full timeout.
+3. That timeout is `InternalConstants.DefaultConnectionCloseTimeout` (30s), **not** the caller's 6s - a non-abort close floors the caller's value at 30s.
+4. On netstandard2.0 the throwing frame is `TaskExtensions.DoWaitAsync`, which is inside `#if !NET`, so it surfaces as a bare `OperationCanceledException`.
+
+Item 4 is the only platform-specific part, and it affects the *exception type*, not the hang. The 30-second duration was the tell that this tracked the close timeout rather than a merely-slow close.
+
+### The fix
+
+Release the semaphore instead of disposing it, and set `_closed` before releasing so the next waiter returns rather than repeating the close. A `WaitAsync` that faults now returns instead of proceeding - it must not run the close body without holding the semaphore. `SemaphoreSlim` only requires disposal once `AvailableWaitHandle` has been read, and this one never exposes it, so nothing leaks.
+
+`_closed` is also now `volatile`. Both `CloseAsync` and `WriteAsync` read it outside any lock, on a field written by whichever thread happens to own the close, so those reads need acquire semantics rather than a value the JIT may keep in a register. The store paired with `Release()` is already ordered by the semaphore; the fast-path reads are not. `Connection._closed` (`Connection.cs:51`) is `volatile` for the same reason.
+
+### The same anti-pattern elsewhere
+
+`MainSession.Dispose` (`_closingSemaphore`) and `Channel` (`_rpcSemaphore`, `_confirmSemaphore`) also dispose semaphores that other code paths wait on. Those are not known to strand a caller today, but the hazard is identical, and a timeout on the wait does not mitigate it. Tracked as issue #1976; audit these before adding any new concurrent path through channel or session close.
+
 ## Relevant timeouts
 
 These are easy to confuse; distinguishing which one a hang tracks is the key diagnostic signal.
@@ -283,6 +322,10 @@ This bug was intermittent (sub-millisecond timing window) and involved suspended
 `TestConnectionShutdown.TestAbortCancellationWhenMainLoopWinsCloseReasonRace_GH1960` is the deterministic counterpart to `TestAbortWithSocketClosedOutOfBandAndCancellation`. It delays before `AbortAsync` so `MainLoop` wins the reason race on every platform and TFM, rather than relying on cold-start JIT latency that only net472 provides.
 
 It asserts more than "the TCS completed": it asserts the channel shutdown handler was released **by its own cancellation token** and not by the `ConnectionShutdownAsync` fallback. Without that assertion the test would pass on a build where the handler is still parked, since the fallback also completes the TCS. Verified to fail at the 6s bar with the fix reverted.
+
+### #1968
+
+`TestConnectionShutdown.TestConcurrentFrameHandlerCloseDoesNotHang_GH1968` calls `CloseFrameHandlerAsync()` twice concurrently, which is the minimal deterministic form of the `MainLoop` race. Two direct closes are used rather than trying to time the real race, and the result is not platform-specific: verified failing at the 6s bar on net8.0/Linux with the fix reverted (`TimeoutException`), passing in ~140ms with it. The pre-fix signature is a task left in `WaitingForActivation` indefinitely.
 
 ### #1921
 

--- a/projects/RabbitMQ.Client/Impl/SocketFrameHandler.cs
+++ b/projects/RabbitMQ.Client/Impl/SocketFrameHandler.cs
@@ -55,7 +55,10 @@ namespace RabbitMQ.Client.Impl
         private readonly PipeReader _pipeReader;
         private Task? _writerTask;
 
-        private bool _closed;
+        // volatile for the unsynchronized fast-path reads at the top of
+        // CloseAsync and WriteAsync. The read inside CloseAsync's critical
+        // section is already ordered by the semaphore.
+        private volatile bool _closed;
 
         private static ReadOnlyMemory<byte> Amqp091ProtocolHeader => new byte[] { (byte)'A', (byte)'M', (byte)'Q', (byte)'P', 0, 0, 9, 1 };
 
@@ -183,6 +186,26 @@ namespace RabbitMQ.Client.Impl
             {
                 await _closingSemaphore.WaitAsync(cancellationToken)
                     .ConfigureAwait(false);
+            }
+            catch
+            {
+                /*
+                 * Either the caller's token fired or another closer disposed the
+                 * semaphore. Both mean this call does not own the close, and the
+                 * owner sets _closed. Returning is correct: it must NOT fall
+                 * through to the close body without holding the semaphore.
+                 */
+                return;
+            }
+
+            try
+            {
+                if (_closed)
+                {
+                    // A concurrent closer finished while we waited.
+                    return;
+                }
+
                 try
                 {
                     // TryComplete rather than Complete: WriteLoopAsync may have
@@ -214,17 +237,32 @@ namespace RabbitMQ.Client.Impl
                 {
                     // ignore, we are closing anyway
                 }
-            }
-            catch
-            {
-            }
-            finally
-            {
-                _closingSemaphore.Dispose();
+
 #if NET
                 _flushTimeoutCts?.Dispose();
 #endif
+            }
+            finally
+            {
+                /*
+                 * Set _closed before releasing so the next waiter sees the close
+                 * as done and returns rather than repeating it.
+                 *
+                 * The semaphore is deliberately NOT disposed. Disposing it while a
+                 * concurrent CloseAsync is parked in WaitAsync leaves that waiter
+                 * pending forever -- not even its own cancellation token releases
+                 * it, which was verified directly. MainLoop's FinishCloseAsync is
+                 * one such concurrent closer, so a frame-handler close racing it
+                 * stranded MainLoop, _mainLoopTask never completed, and
+                 * Connection.CloseAsync burned its full 30s timeout before
+                 * surfacing a bare OperationCanceledException. See issue #1968.
+                 *
+                 * SemaphoreSlim only needs disposal when AvailableWaitHandle has
+                 * been read, and this one never exposes it, so there is nothing
+                 * to reclaim.
+                 */
                 _closed = true;
+                _closingSemaphore.Release();
             }
         }
 

--- a/projects/Test/Integration/TestConnectionShutdown.cs
+++ b/projects/Test/Integration/TestConnectionShutdown.cs
@@ -100,6 +100,43 @@ namespace Test.Integration
         }
 
         [Fact]
+        public async Task TestConcurrentFrameHandlerCloseDoesNotHang_GH1968()
+        {
+            /*
+             * rabbitmq/rabbitmq-dotnet-client#1968
+             *
+             * SocketFrameHandler.CloseAsync used to dispose _closingSemaphore in its
+             * finally block without ever releasing it. A second closer already parked
+             * in WaitAsync then stayed pending forever -- a disposed SemaphoreSlim
+             * does not fault or cancel its pending async waiters, not even via their
+             * own cancellation token.
+             *
+             * That is reachable in normal operation because MainLoop's FinishCloseAsync
+             * is itself a closer. When it lost this race it never returned, so
+             * _mainLoopTask never completed and Connection.CloseAsync waited out its
+             * full 30s DefaultConnectionCloseTimeout before throwing a bare
+             * OperationCanceledException -- the 30-second net472 CI failure in #1968.
+             *
+             * Two direct closes are the minimal deterministic form of that race.
+             */
+            var c = (AutorecoveringConnection)_conn;
+
+            ValueTask first = c.CloseFrameHandlerAsync();
+            ValueTask second = c.CloseFrameHandlerAsync();
+
+            try
+            {
+                Task both = Task.WhenAll(first.AsTask(), second.AsTask());
+                await both.WaitAsync(_waitSpan);
+            }
+            finally
+            {
+                _conn = null;
+                _channel = null;
+            }
+        }
+
+        [Fact]
         public async Task TestAbortWithSocketClosedOutOfBand()
         {
             var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);


### PR DESCRIPTION
> [!NOTE]
> The root-cause investigation, the fix, and this description were produced by Claude Code, prompted and reviewed by @lukebakken. The `SemaphoreSlim` disposal behaviour was verified empirically with a standalone probe rather than inferred from documentation.

Fixes #1968.

## The bug

`SocketFrameHandler.CloseAsync` acquired `_closingSemaphore` and, in its `finally`, disposed it without ever releasing it.

`SemaphoreSlim` gives `Dispose()` no special meaning for pending async waiters. A second `CloseAsync` already parked in `WaitAsync` when the first disposes the semaphore stays pending **forever**. Verified directly with a standalone probe, and worth internalising because it is counter-intuitive:

| wait form | state 8s after the semaphore is disposed |
|---|---|
| `WaitAsync(token)`, 3s CTS | pending |
| `WaitAsync(TimeSpan.FromSeconds(3))` | pending |
| `WaitAsync(3s, token)` | pending |

Not even the waiter's own cancellation token releases it, and a timeout on the wait is not an escape hatch. `Dispose()` itself does not throw, so the disposing closer sees nothing wrong.

## Why that reaches a 30-second stall

`MainLoop`'s `FinishCloseAsync` calls `_frameHandler.CloseAsync`, so it is itself one of the concurrent closers. When it lost this race it never returned, so:

1. `MainLoop` never completes, so `_mainLoopTask` never completes.
2. `Connection.CloseAsync` waits on `_mainLoopTask` (`Connection.cs:464`) and burns its full timeout.
3. That timeout is `InternalConstants.DefaultConnectionCloseTimeout` (30s), not the caller's value, because a non-abort close floors the requested timeout.

That is the exact shape of what #1968 recorded: `TestCleanClosureWithSocketClosedOutOfBand` failing after exactly 30s with a bare `OperationCanceledException`.

**The platform was a red herring.** #1968 was filed against net472 and I originally speculated in the issue that netstandard2.0's `PipeReader.ReadAsync` stayed parked. That was wrong. The TFM determines only the *exception type*: the throwing frame `TaskExtensions.DoWaitAsync` sits inside `#if !NET`, so netstandard2.0 surfaces a bare `OperationCanceledException` where net8.0 would use the built-in `Task.WaitAsync`. The hang itself reproduces on net8.0/Linux. The 30-second duration was the tell that it tracked the close timeout rather than a merely-slow close.

## The fix

Release the semaphore instead of disposing it, and set `_closed` before releasing, so the next waiter observes the close as done and returns rather than repeating it. A `WaitAsync` that faults now returns instead of proceeding, since it must not run the close body without holding the semaphore.

The semaphore is deliberately **not** disposed. `SemaphoreSlim` only requires disposal once `AvailableWaitHandle` has been read, and this one never exposes it, so there is nothing to reclaim.

`_closed` is now `volatile`. Both `CloseAsync` and `WriteAsync` read it outside any lock, on a field written by whichever thread happens to own the close, so those reads need acquire semantics rather than a value the JIT may keep in a register. The store paired with `Release()` is already ordered by the semaphore itself; the fast-path reads are not. `Connection._closed` (`Connection.cs:51`) is `volatile` for the same reason, so this matches existing convention. `Interlocked` would be overkill here, since nothing needs read-modify-write atomicity: only one thread can reach the store, because it holds the semaphore.

## Regression test

`TestConcurrentFrameHandlerCloseDoesNotHang_GH1968` closes the frame handler twice concurrently. That is the minimal deterministic form of the `MainLoop` race and needs no platform-specific timing. Discriminating power confirmed: with the fix reverted it fails at the 6s bar with a `TimeoutException`, the second task left in `WaitingForActivation`. With the fix it passes in ~140ms.

## Verification

On net8.0 against a local broker: Integration 194 passed, SequentialIntegration 64 passed, Unit 127 passed, no failures. `TestConnectionShutdown` ran 10 consecutive times at 12/12. Both target frameworks build clean with no new warnings.

## Not in this PR

The same dispose-without-release pattern exists in `MainSession` (`_closingSemaphore`) and `Channel` (`_rpcSemaphore`, `_confirmSemaphore`, four dispose sites). Neither is known to strand a caller today, but the hazard is identical. Tracked separately as #1976 rather than widened into this fix.

Background, the probe results, and the diagnostic reasoning are written up in `docs/internal/connection-shutdown-and-cancellation.md`.
