### PR TITLE
Do not dispose SemaphoreSlim fields with concurrent waiters

### DIFF
--- a/docs/internal/connection-shutdown-and-cancellation.md
+++ b/docs/internal/connection-shutdown-and-cancellation.md
@@ -267,9 +267,34 @@ Release the semaphore instead of disposing it, and set `_closed` before releasin
 
 `_closed` is also now `volatile`. Both `CloseAsync` and `WriteAsync` read it outside any lock, on a field written by whichever thread happens to own the close, so those reads need acquire semantics rather than a value the JIT may keep in a register. The store paired with `Release()` is already ordered by the semaphore; the fast-path reads are not. `Connection._closed` (`Connection.cs:51`) is `volatile` for the same reason.
 
-### The same anti-pattern elsewhere
+## Issue #1976: the same anti-pattern everywhere else
 
-`MainSession.Dispose` (`_closingSemaphore`) and `Channel` (`_rpcSemaphore`, `_confirmSemaphore`) also dispose semaphores that other code paths wait on. Those are not known to strand a caller today, but the hazard is identical, and a timeout on the wait does not mitigate it. Tracked as issue #1976; audit these before adding any new concurrent path through channel or session close.
+#1968 fixed one instance. An audit for the rest found **six** `SemaphoreSlim` fields in the client and **seven** disposal calls across three types - two more sites than the issue's own audit claimed, because it recorded `AutorecoveringConnection`'s two semaphores as never disposed when in fact both were.
+
+| Field | Disposed in | Concurrent waiters |
+|---|---|---|
+| `MainSession._closingSemaphore` | `MainSession.Dispose` | `SetSessionClosingAsync` |
+| `Channel._rpcSemaphore` | `Dispose(bool)` and `DisposeAsyncCoreAsync` | ~20 RPC sites |
+| `Channel._confirmSemaphore` | `Dispose(bool)` and `DisposeAsyncCoreAsync` | publish path, shutdown cleanup |
+| `AutorecoveringConnection._recordedEntitiesSemaphore` | `DisposeAsync` | ~30 recording sites |
+| `AutorecoveringConnection._channelsSemaphore` | `DisposeAsync` | 4 sites |
+| `SocketFrameHandler._closingSemaphore` | (fixed in #1968) | `CloseAsync` |
+
+All seven disposal calls were removed. Proving no waiter can be parked at each of these sites is more expensive than simply not disposing, and there is nothing to reclaim: `SemaphoreSlim` only requires disposal once `AvailableWaitHandle` has been read, and no site in this client ever exposes it.
+
+`MainSession._closingSemaphore` is the closest analogue of #1968 and reachable the same way. `Connection.DisposeAsync` disposes the session after `AbortAsync` (`Connection.cs:594`), while `MainLoop`'s `FinishCloseAsync` independently calls `SetSessionClosingAsync`; if the latter is parked on the semaphore when disposal runs, `MainLoop` never returns. The `DefaultConnectionAbortTimeout` on that wait does not mitigate it - see the table above.
+
+`Channel`'s two are worth noting for the same reason. `_rpcSemaphore` is awaited under the continuation's linked token, so `ContinuationTimeout` will not shake a stranded RPC loose. `_confirmSemaphore` is awaited during shutdown cleanup with a 5s timeout added *specifically* so a stuck semaphore cannot block shutdown - reasoning that does not survive the semaphore being disposed rather than merely held.
+
+`_recoveryCancellationTokenSource.Dispose()` in `AutorecoveringConnection.DisposeAsync` was deliberately **kept**. A `CancellationTokenSource` is genuinely different: it owns a timer and registrations that need reclaiming, and cancelling it already released anything waiting on its token.
+
+`MainSession._disposed` is now `volatile`, matching `_closing` and `_closeIsServerInitiated` beside it - `SetSessionClosingAsync` reads it from whichever thread reaches it, and disposal writes it from another.
+
+### Testing this
+
+`projects/Test/Integration/TestSemaphoreDisposal.cs`. The race is not deterministically forceable from the public API at every site, so the tests assert the invariant that makes it impossible: after a full dispose, every semaphore is still usable. `Wait(0)` throws `ObjectDisposedException` on a disposed instance and returns immediately otherwise, so it detects disposal without blocking - note that `CurrentCount` does *not* throw and cannot be used for this. A third test reflects over the assembly and fails if the set of `SemaphoreSlim` fields changes, so adding one forces a decision about its disposal.
+
+Two things to know if you extend these tests. `AutorecoveringChannel.DisposeAsync` does not dispose its inner channel, so disposing the `IChannel` that `CreateChannelAsync` returns never reaches `Channel`'s dispose path at all - the test disposes `InnerChannel` directly. And use `BindingFlags.DeclaredOnly` when enumerating: `_rpcSemaphore` is `protected`, so `RecoveryAwareChannel` otherwise reports it a second time.
 
 ## Relevant timeouts
 
@@ -326,6 +351,10 @@ It asserts more than "the TCS completed": it asserts the channel shutdown handle
 ### #1968
 
 `TestConnectionShutdown.TestConcurrentFrameHandlerCloseDoesNotHang_GH1968` calls `CloseFrameHandlerAsync()` twice concurrently, which is the minimal deterministic form of the `MainLoop` race. Two direct closes are used rather than trying to time the real race, and the result is not platform-specific: verified failing at the 6s bar on net8.0/Linux with the fix reverted (`TimeoutException`), passing in ~140ms with it. The pre-fix signature is a task left in `WaitingForActivation` indefinitely.
+
+### #1976
+
+`projects/Test/Integration/TestSemaphoreDisposal.cs` - see "Testing this" under #1976 above. Verified to fail with the fix reverted, naming all five reachable disposal sites across the two runtime tests, while `SocketFrameHandler._closingSemaphore` still passes because #1968 already fixed it.
 
 ### #1921
 

--- a/projects/RabbitMQ.Client/Impl/AutorecoveringConnection.cs
+++ b/projects/RabbitMQ.Client/Impl/AutorecoveringConnection.cs
@@ -341,9 +341,25 @@ namespace RabbitMQ.Client.Impl
             {
                 try
                 {
+                    /*
+                     * _recordedEntitiesSemaphore and _channelsSemaphore are
+                     * deliberately NOT disposed. Disposing a SemaphoreSlim while
+                     * another task is parked in WaitAsync leaves that waiter pending
+                     * forever: it does not fault, it does not cancel, and neither the
+                     * waiter's own token nor its wait timeout releases it. Both are
+                     * awaited from the recording and recovery paths, which run
+                     * concurrently with disposal, and a recovery attempt parked on
+                     * either one would never return. Issue #1968 is the confirmed
+                     * instance of this pattern.
+                     *
+                     * _recoveryCancellationTokenSource is still disposed: unlike
+                     * SemaphoreSlim here, a CancellationTokenSource owns a timer and
+                     * registrations that need reclaiming, and cancelling it above
+                     * already released anything waiting on its token.
+                     *
+                     * See issue #1976.
+                     */
                     _channels.Clear();
-                    _recordedEntitiesSemaphore.Dispose();
-                    _channelsSemaphore.Dispose();
                     _recoveryCancellationTokenSource.Dispose();
                 }
                 catch

--- a/projects/RabbitMQ.Client/Impl/Channel.cs
+++ b/projects/RabbitMQ.Client/Impl/Channel.cs
@@ -602,8 +602,8 @@ namespace RabbitMQ.Client.Impl
                 {
                     try
                     {
-                        _rpcSemaphore.Dispose();
-                        _confirmSemaphore.Dispose();
+                        // _rpcSemaphore and _confirmSemaphore are deliberately not
+                        // disposed here. See DisposeAsyncCoreAsync and issue #1976.
                         MaybeSetExceptionOnConfirmsTcs();
                     }
                     catch
@@ -664,15 +664,30 @@ namespace RabbitMQ.Client.Impl
             }
             finally
             {
-                try
-                {
-                    _rpcSemaphore.Dispose();
-                    _confirmSemaphore.Dispose();
-                }
-                catch
-                {
-                }
-
+                /*
+                 * _rpcSemaphore and _confirmSemaphore are deliberately NOT disposed.
+                 * Disposing a SemaphoreSlim while another task is parked in WaitAsync
+                 * leaves that waiter pending forever: it does not fault, it does not
+                 * cancel, and neither the waiter's own token nor its wait timeout
+                 * releases it.
+                 *
+                 * Both have concurrent waiters. _rpcSemaphore is awaited by every RPC
+                 * on this channel under the continuation's linked token, so disposing
+                 * it during an in-flight RPC strands that RPC permanently and the
+                 * ContinuationTimeout does not shake it loose. _confirmSemaphore is
+                 * awaited on the publish path and, during shutdown cleanup, with a 5s
+                 * timeout added specifically so a stuck semaphore cannot block
+                 * shutdown - reasoning that does not survive the semaphore being
+                 * disposed rather than merely held.
+                 *
+                 * Issue #1968 is the confirmed instance of this pattern: the same
+                 * dispose-without-release on SocketFrameHandler's semaphore stranded
+                 * MainLoop and cost a full 30s connection-close timeout.
+                 *
+                 * SemaphoreSlim only needs disposal once AvailableWaitHandle has been
+                 * read, and neither of these ever exposes it, so there is nothing to
+                 * reclaim. See issue #1976.
+                 */
                 _disposed = true;
             }
         }

--- a/projects/RabbitMQ.Client/Impl/MainSession.cs
+++ b/projects/RabbitMQ.Client/Impl/MainSession.cs
@@ -47,7 +47,11 @@ namespace RabbitMQ.Client.Impl
         private volatile bool _closeIsServerInitiated;
         private volatile bool _closing;
         private readonly SemaphoreSlim _closingSemaphore = new SemaphoreSlim(1, 1);
-        private bool _disposed = false;
+
+        // volatile to match _closing and _closeIsServerInitiated above: read in
+        // SetSessionClosingAsync from whichever thread reaches it, written by
+        // whichever thread disposes.
+        private volatile bool _disposed = false;
 
         public MainSession(Connection connection, uint maxBodyLength)
             : base(connection, 0, maxBodyLength)
@@ -137,17 +141,25 @@ namespace RabbitMQ.Client.Impl
                 return;
             }
 
-            try
-            {
-                _closingSemaphore.Dispose();
-            }
-            catch
-            {
-            }
-            finally
-            {
-                _disposed = true;
-            }
+            /*
+             * _closingSemaphore is deliberately NOT disposed. Disposing a
+             * SemaphoreSlim while another task is parked in WaitAsync leaves that
+             * waiter pending forever: it does not fault, it does not cancel, and
+             * neither the waiter's own token nor its wait timeout releases it.
+             *
+             * That is reachable here. Connection.DisposeAsync calls this after
+             * AbortAsync, while MainLoop's FinishCloseAsync independently calls
+             * SetSessionClosingAsync; if the latter is parked on the semaphore when
+             * this runs, MainLoop never returns. That is exactly the mechanism that
+             * stranded MainLoop in issue #1968, where Connection.CloseAsync then
+             * burned its full 30s timeout. The DefaultConnectionAbortTimeout on the
+             * wait does not mitigate it.
+             *
+             * SemaphoreSlim only needs disposal once AvailableWaitHandle has been
+             * read, and this one never exposes it, so there is nothing to reclaim.
+             * See issue #1976.
+             */
+            _disposed = true;
         }
     }
 }

--- a/projects/Test/Integration/TestSemaphoreDisposal.cs
+++ b/projects/Test/Integration/TestSemaphoreDisposal.cs
@@ -1,0 +1,247 @@
+// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2026 Broadcom. All Rights Reserved.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       https://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v2.0:
+//
+//---------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//  Copyright (c) 2007-2026 Broadcom. All Rights Reserved.
+//---------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Impl;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Test.Integration
+{
+    /// <summary>
+    /// rabbitmq/rabbitmq-dotnet-client#1976
+    ///
+    /// Disposing a <see cref="SemaphoreSlim"/> while another task is parked in
+    /// <c>WaitAsync</c> leaves that waiter pending forever: it does not fault, it
+    /// does not cancel, and neither the waiter's own cancellation token nor its
+    /// wait timeout releases it. Issue #1968 is the confirmed instance - the same
+    /// dispose-without-release on <c>SocketFrameHandler</c>'s semaphore stranded
+    /// MainLoop and cost a full 30s connection-close timeout on net472 CI.
+    ///
+    /// The client's remaining semaphores all have waiters that can still be
+    /// running when disposal begins, so none of them may be disposed. The race is
+    /// not deterministically forceable from the public API for every site, so
+    /// these tests assert the invariant that makes the race impossible: after a
+    /// full dispose, every semaphore is still usable. <c>Wait(0)</c> throws
+    /// <see cref="ObjectDisposedException"/> on a disposed instance and returns
+    /// normally otherwise, so it detects disposal without blocking. Note that
+    /// <c>CurrentCount</c> does not throw, so it cannot be used for this.
+    /// </summary>
+    public class TestSemaphoreDisposal : IntegrationFixture
+    {
+        public TestSemaphoreDisposal(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task TestChannelSemaphoresAreNotDisposed_GH1976()
+        {
+            /*
+             * _rpcSemaphore is awaited by every RPC on the channel under the
+             * continuation's linked token, so disposing it during an in-flight RPC
+             * strands that RPC permanently - the ContinuationTimeout does not shake
+             * it loose. _confirmSemaphore is awaited on the publish path and, during
+             * shutdown cleanup, with a 5s timeout added specifically so a stuck
+             * semaphore cannot block shutdown, which is reasoning that does not
+             * survive the semaphore being disposed rather than merely held.
+             *
+             * Note that AutorecoveringChannel.DisposeAsync does not dispose its inner
+             * channel, so disposing the IChannel handed back by CreateChannelAsync
+             * would never reach Channel's dispose path. Dispose the inner channel
+             * directly, which is what a non-recovering connection does.
+             */
+            IChannel channel = await _conn.CreateChannelAsync(_createChannelOptions);
+            RecoveryAwareChannel inner = ((AutorecoveringChannel)channel).InnerChannel;
+
+            await channel.CloseAsync();
+            await inner.DisposeAsync();
+            await channel.DisposeAsync();
+
+            AssertSemaphoresUsable(inner, "_rpcSemaphore", "_confirmSemaphore");
+        }
+
+        [Fact]
+        public async Task TestConnectionSemaphoresAreNotDisposed_GH1976()
+        {
+            /*
+             * _recordedEntitiesSemaphore and _channelsSemaphore are awaited from the
+             * recording and recovery paths, which run concurrently with disposal. A
+             * recovery attempt parked on either one would never return.
+             *
+             * MainSession._closingSemaphore is the closest analogue of #1968:
+             * Connection.DisposeAsync disposes the session after AbortAsync, while
+             * MainLoop's FinishCloseAsync independently calls SetSessionClosingAsync.
+             * If the latter is parked on the semaphore when disposal runs, MainLoop
+             * never returns.
+             *
+             * SocketFrameHandler._closingSemaphore is checked here too: that is the
+             * one #1968 actually fixed, so this keeps a regression test on it.
+             */
+            ConnectionFactory cf = CreateConnectionFactory();
+            var conn = (AutorecoveringConnection)await CreateConnectionAsyncWithRetries(cf);
+            IChannel channel = await conn.CreateChannelAsync(_createChannelOptions);
+
+            Connection innerConnection = GetFieldValue<Connection>(conn, "_innerConnection");
+            MainSession session0 = GetFieldValue<MainSession>(innerConnection, "_session0");
+            var channel0 = GetFieldValue<Channel>(innerConnection, "_channel0");
+            IFrameHandler frameHandler = innerConnection.FrameHandler;
+
+            await channel.CloseAsync();
+            await channel.DisposeAsync();
+            await conn.CloseAsync();
+            await conn.DisposeAsync();
+
+            AssertSemaphoresUsable(new Dictionary<object, string[]>
+            {
+                { conn, new[] { "_recordedEntitiesSemaphore", "_channelsSemaphore" } },
+                { session0, new[] { "_closingSemaphore" } },
+                { channel0, new[] { "_rpcSemaphore", "_confirmSemaphore" } },
+                { frameHandler, new[] { "_closingSemaphore" } }
+            });
+        }
+
+        [Fact]
+        public void TestNoSemaphoreSlimFieldIsDisposedAnywhere_GH1976()
+        {
+            /*
+             * A guard against the anti-pattern coming back somewhere the two tests
+             * above do not reach. Every SemaphoreSlim field in the client is listed
+             * here so that adding one is a deliberate act; SemaphoreSlim only needs
+             * disposal once AvailableWaitHandle has been read, and no site in the
+             * client ever exposes it.
+             */
+            var expected = new SortedSet<string>
+            {
+                "RabbitMQ.Client.Impl.AutorecoveringConnection._channelsSemaphore",
+                "RabbitMQ.Client.Impl.AutorecoveringConnection._recordedEntitiesSemaphore",
+                "RabbitMQ.Client.Impl.Channel._confirmSemaphore",
+                "RabbitMQ.Client.Impl.Channel._rpcSemaphore",
+                "RabbitMQ.Client.Impl.MainSession._closingSemaphore",
+                "RabbitMQ.Client.Impl.SocketFrameHandler._closingSemaphore"
+            };
+
+            var actual = new SortedSet<string>();
+            foreach (Type type in typeof(IChannel).Assembly.GetTypes())
+            {
+                foreach (FieldInfo field in type.GetFields(BindingFlags.DeclaredOnly |
+                    BindingFlags.Instance | BindingFlags.Static |
+                    BindingFlags.Public | BindingFlags.NonPublic))
+                {
+                    if (field.FieldType == typeof(SemaphoreSlim))
+                    {
+                        actual.Add($"{type.FullName}.{field.Name}");
+                    }
+                }
+            }
+
+            var added = new SortedSet<string>(actual);
+            added.ExceptWith(expected);
+            var removed = new SortedSet<string>(expected);
+            removed.ExceptWith(actual);
+
+            if (added.Count > 0 || removed.Count > 0)
+            {
+                Assert.Fail("the set of SemaphoreSlim fields in RabbitMQ.Client changed. " +
+                    "Confirm the new field is never disposed while a waiter can be parked " +
+                    "in WaitAsync (see #1976), add it to the assertions in this file, then " +
+                    $"update this list.{Environment.NewLine}" +
+                    $"added: {string.Join(", ", added)}{Environment.NewLine}" +
+                    $"removed: {string.Join(", ", removed)}");
+            }
+        }
+
+        private static void AssertSemaphoresUsable(object target, params string[] fieldNames)
+        {
+            AssertSemaphoresUsable(new Dictionary<object, string[]> { { target, fieldNames } });
+        }
+
+        /// <summary>
+        /// Every field is probed before asserting so that a failure names all of the
+        /// disposed semaphores, not just the first one.
+        /// </summary>
+        private static void AssertSemaphoresUsable(IDictionary<object, string[]> targets)
+        {
+            var disposedFields = new List<string>();
+
+            foreach (KeyValuePair<object, string[]> target in targets)
+            {
+                foreach (string fieldName in target.Value)
+                {
+                    SemaphoreSlim semaphore = GetFieldValue<SemaphoreSlim>(target.Key, fieldName);
+
+                    bool entered = false;
+                    try
+                    {
+                        entered = semaphore.Wait(0);
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        disposedFields.Add($"{target.Key.GetType().Name}.{fieldName}");
+                    }
+                    finally
+                    {
+                        if (entered)
+                        {
+                            semaphore.Release();
+                        }
+                    }
+                }
+            }
+
+            if (disposedFields.Count > 0)
+            {
+                Assert.Fail($"disposed after a full dispose: {string.Join(", ", disposedFields)}. " +
+                    "Disposing a SemaphoreSlim strands any waiter parked in WaitAsync forever. " +
+                    "See #1976.");
+            }
+        }
+
+        private static T GetFieldValue<T>(object target, string fieldName)
+        {
+            Type type = target.GetType();
+            FieldInfo field = null;
+
+            while (type is not null && field is null)
+            {
+                field = type.GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+                type = type.BaseType;
+            }
+
+            Assert.NotNull(field);
+            return Assert.IsType<T>(field.GetValue(target));
+        }
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Reviewed and steered by @lukebakken; the code, tests, and doc update were written by Claude Code.

Disposing a `SemaphoreSlim` while another task is parked in `WaitAsync` leaves that waiter pending forever - it does not fault, does not cancel, and neither the waiter's own token nor its wait timeout releases it. #1968 was one confirmed instance: the same dispose-without-release on `SocketFrameHandler`'s semaphore stranded `MainLoop` and burned a full 30s connection-close timeout.

This removes every remaining instance. An audit found six `SemaphoreSlim` fields and seven disposal calls across three types, all with waiters that can still be running when disposal begins:

| Field | Disposed in | Concurrent waiters |
|---|---|---|
| `MainSession._closingSemaphore` | `Dispose()` | `SetSessionClosingAsync` |
| `Channel._rpcSemaphore` | `Dispose(bool)`, `DisposeAsyncCoreAsync` | ~20 RPC sites |
| `Channel._confirmSemaphore` | `Dispose(bool)`, `DisposeAsyncCoreAsync` | publish path, shutdown cleanup |
| `AutorecoveringConnection._recordedEntitiesSemaphore` | `DisposeAsync` | ~30 recording sites |
| `AutorecoveringConnection._channelsSemaphore` | `DisposeAsync` | 4 sites |

That is two more sites than the issue's own audit found: it recorded the two `AutorecoveringConnection` semaphores as never disposed, but both were disposed at `AutorecoveringConnection.cs:345-346`. Proving no waiter can be parked at each site is more expensive than not disposing, and there is nothing to reclaim - `SemaphoreSlim` only needs disposal once `AvailableWaitHandle` has been read, and no site in this client ever exposes it.

`_recoveryCancellationTokenSource.Dispose()` is kept: a `CancellationTokenSource` owns a timer and registrations that need reclaiming, and cancelling it already released anything waiting on its token.

`MainSession._disposed` becomes `volatile` to match `_closing` and `_closeIsServerInitiated` beside it.

## Tests

`TestSemaphoreDisposal` asserts the invariant that makes the race impossible - after a full dispose, every semaphore is still usable - since the race is not deterministically forceable from the public API at every site. `Wait(0)` throws `ObjectDisposedException` on a disposed instance and returns immediately otherwise, so it detects disposal without blocking. A third test reflects over the assembly and fails if the set of `SemaphoreSlim` fields changes, so adding one forces a decision about its disposal.

Verified failing with the fix reverted: the two runtime tests name all five reachable disposal sites, while `SocketFrameHandler._closingSemaphore` still passes because #1968 already fixed it.

## Verification

- Client and OpenTelemetry build clean on net8.0 and netstandard2.0 with `-warnaserror`.
- Unit 147, Integration 197 (13 skipped), SequentialIntegration 64 (3 skipped), all passing.

Background and the probe results are written up in `docs/internal/connection-shutdown-and-cancellation.md` under "Issue #1976: the same anti-pattern everywhere else".

Fixes #1976
