### PR TITLE
Retry recovery when a topology operation times out

### DIFF
--- a/projects/RabbitMQ.Client/Impl/AutorecoveringConnection.Recovery.cs
+++ b/projects/RabbitMQ.Client/Impl/AutorecoveringConnection.Recovery.cs
@@ -212,6 +212,8 @@ namespace RabbitMQ.Client.Impl
                  * without being acked. With a non-zero prefetch the broker then waits forever for an
                  * acknowledgement that cannot come, and the queue stops being consumed for good -
                  * silently, on a connection and channel that both still report IsOpen.
+                 *
+                 * https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/1993
                  */
                 case OperationCanceledException:
                     return false == recoveryCancellationToken.IsCancellationRequested;

--- a/projects/RabbitMQ.Client/Impl/AutorecoveringConnection.Recovery.cs
+++ b/projects/RabbitMQ.Client/Impl/AutorecoveringConnection.Recovery.cs
@@ -165,16 +165,60 @@ namespace RabbitMQ.Client.Impl
             }
         }
 
-        private static void HandleTopologyRecoveryException(TopologyRecoveryException e)
+        private static void HandleTopologyRecoveryException(TopologyRecoveryException e,
+            CancellationToken recoveryCancellationToken)
         {
             ESLog.Error("Topology recovery exception", e);
-            if (e.InnerException is AlreadyClosedException ||
-                    (e.InnerException is OperationInterruptedException) ||
-                    (e.InnerException is TimeoutException))
+            if (ShouldRetryRecoveryAfter(e.InnerException, recoveryCancellationToken))
             {
                 throw e;
             }
             ESLog.Info($"Will not retry recovery because of {e.InnerException?.GetType().FullName}: it's not a known problem with connectivity, ignoring it", e);
+        }
+
+        /// <summary>
+        /// Decides whether a failure to recover a single topology entity means the whole recovery
+        /// attempt has to be abandoned and retried, rather than skipped over.
+        /// </summary>
+        /// <remarks>
+        /// The distinction that matters is whether the broker may still act on the request after the
+        /// client has given up on it. If it may, the client's view of the connection is no longer
+        /// trustworthy and recovery must not be reported as successful.
+        /// </remarks>
+        internal static bool ShouldRetryRecoveryAfter(Exception? topologyRecoveryInnerException,
+            CancellationToken recoveryCancellationToken)
+        {
+            switch (topologyRecoveryInnerException)
+            {
+                // Known connectivity problems. The connection is gone, so nothing was applied.
+                case AlreadyClosedException:
+                case OperationInterruptedException:
+                case TimeoutException:
+                    return true;
+
+                /*
+                 * A protocol operation that ran past ContinuationTimeout completes its continuation
+                 * as cancelled (AsyncRpcContinuation.HandleContinuationTimeout), so by type alone it
+                 * is indistinguishable from the caller cancelling recovery. Tell them apart with the
+                 * recovery token: if recovery itself was not cancelled, the operation timed out.
+                 *
+                 * A timed-out operation must be retried, because its frame is already on the wire and
+                 * the broker can still apply it after the client has stopped waiting. The case that
+                 * brought this to light is basic.consume against a quorum queue that has lost quorum:
+                 * the queue cannot answer until it elects a new leader, which can take longer than the
+                 * 20s default. Skipping it leaves the broker with a registered, active consumer that
+                 * the client never added to the channel's ConsumerDispatcher, so from then on every
+                 * delivery for that consumer tag resolves to the FallbackConsumer and is discarded
+                 * without being acked. With a non-zero prefetch the broker then waits forever for an
+                 * acknowledgement that cannot come, and the queue stops being consumed for good -
+                 * silently, on a connection and channel that both still report IsOpen.
+                 */
+                case OperationCanceledException:
+                    return false == recoveryCancellationToken.IsCancellationRequested;
+
+                default:
+                    return false;
+            }
         }
 
         private async ValueTask<bool> TryPerformAutomaticRecoveryAsync(CancellationToken cancellationToken)
@@ -341,7 +385,7 @@ namespace RabbitMQ.Client.Impl
                     }
                     else
                     {
-                        HandleTopologyRecoveryException(new TopologyRecoveryException($"Caught an exception while recovering exchange '{recordedExchange}'", ex));
+                        HandleTopologyRecoveryException(new TopologyRecoveryException($"Caught an exception while recovering exchange '{recordedExchange}'", ex), cancellationToken);
                     }
                 }
             }
@@ -432,7 +476,7 @@ namespace RabbitMQ.Client.Impl
                     }
                     else
                     {
-                        HandleTopologyRecoveryException(new TopologyRecoveryException($"Caught an exception while recovering queue '{recordedQueue}'", ex));
+                        HandleTopologyRecoveryException(new TopologyRecoveryException($"Caught an exception while recovering queue '{recordedQueue}'", ex), cancellationToken);
                     }
                 }
 
@@ -507,7 +551,7 @@ namespace RabbitMQ.Client.Impl
                     }
                     else
                     {
-                        HandleTopologyRecoveryException(new TopologyRecoveryException($"Caught an exception while recovering binding between {binding.Source} and {binding.Destination}", ex));
+                        HandleTopologyRecoveryException(new TopologyRecoveryException($"Caught an exception while recovering binding between {binding.Source} and {binding.Destination}", ex), cancellationToken);
                     }
                 }
             }
@@ -587,7 +631,7 @@ namespace RabbitMQ.Client.Impl
                     }
                     else
                     {
-                        HandleTopologyRecoveryException(new TopologyRecoveryException($"Caught an exception while recovering consumer {oldTag} on queue {consumer.Queue}", ex));
+                        HandleTopologyRecoveryException(new TopologyRecoveryException($"Caught an exception while recovering consumer {oldTag} on queue {consumer.Queue}", ex), cancellationToken);
                     }
                 }
             }

--- a/projects/Test/Integration/TestToxiproxy.cs
+++ b/projects/Test/Integration/TestToxiproxy.cs
@@ -37,7 +37,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Integration;
 using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Exceptions;
+using RabbitMQ.Client.Impl;
 using Toxiproxy.Net.Toxics;
 using Xunit;
 using Xunit.Abstractions;
@@ -730,6 +732,169 @@ namespace Test.Integration
                 // channel and connection disposal, keeping teardown fast.
                 cts.Cancel();
             }
+        }
+
+        // Regression test for https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/1993
+        //
+        // The bug: when the basic.consume issued during consumer recovery runs past
+        // ContinuationTimeout, its continuation completes as *cancelled*, so it reaches
+        // HandleTopologyRecoveryException as an OperationCanceledException rather than a
+        // TimeoutException. That type was not in the retry list, so the exception was swallowed and
+        // recovery reported success. Meanwhile the broker had registered the consumer, but the
+        // client never added it to the new channel's ConsumerDispatcher, so every subsequent
+        // delivery resolved to the FallbackConsumer and was dropped unacked. The queue silently
+        // stopped being consumed, on a connection and channel that both still report IsOpen.
+        //
+        // The fix: classify OperationCanceledException as retryable unless recovery itself was
+        // cancelled, so the recovery attempt fails, the inner connection is aborted (clearing the
+        // broker-side consumer), and the recovery loop tries again.
+        //
+        // Test strategy: stall only the recovery basic.consume, not the initial connect.
+        //   1. Connect and consume normally through the proxy.
+        //   2. Disable the proxy to sever the connection, then re-enable it so recovery can
+        //      reconnect and get as far as recovering the consumer.
+        //   3. The RecoveringConsumerAsync event fires immediately before
+        //      RecordedConsumer.RecoverAsync, so the handler adds a Rate=0 downstream
+        //      BandwidthToxic there. The recovery basic.consume goes out but its consume-ok can
+        //      never come back, so it hits the 2 s ContinuationTimeout: exactly the #1993 trigger.
+        //   4. Remove the toxic so the *next* recovery attempt can succeed.
+        //   5. Assert deliveries resume. Before the fix, recovery reported success with the
+        //      consumer never wired up and no message was ever delivered.
+        [SkippableFact]
+        [Trait("Category", "Toxiproxy")]
+        public async Task TestConsumerRecoveryContinuationTimeoutIsRetried_GH1993()
+        {
+            Skip.IfNot(AreToxiproxyTestsEnabled, "RABBITMQ_TOXIPROXY_TESTS is not set, skipping test");
+
+            ConnectionFactory cf = CreateConnectionFactory();
+            cf.Endpoint = new AmqpTcpEndpoint(_proxyHost, _proxyPort);
+            cf.AutomaticRecoveryEnabled = true;
+            cf.TopologyRecoveryEnabled = true;
+            cf.NetworkRecoveryInterval = TimeSpan.FromSeconds(1);
+            // Long enough that the initial connect and the recovery handshake complete
+            // comfortably, short enough that the stalled recovery basic.consume gives up
+            // well inside WaitSpan.
+            cf.ContinuationTimeout = TimeSpan.FromSeconds(2);
+            // Keep the broker from closing the connection while the toxic is in place.
+            cf.RequestedHeartbeat = TimeSpan.FromSeconds(600);
+
+            await using IConnection conn = await cf.CreateConnectionAsync();
+            await using IChannel ch = await conn.CreateChannelAsync();
+
+            // A non-zero prefetch is what makes the original bug permanent: the broker waits
+            // forever for acks that the dropped deliveries can never produce.
+            await ch.BasicQosAsync(0, 1, false);
+
+            // Durable and non-exclusive: this broker rejects transient non-exclusive queues
+            // (the deprecated transient_nonexcl_queues feature), and an exclusive queue would be
+            // deleted and re-declared underneath the two recovery attempts this test drives.
+            QueueDeclareOk q = await ch.QueueDeclareAsync(GenerateQueueName(), true, false, false);
+
+            try
+            {
+                await RunConsumerRecoveryContinuationTimeoutBodyAsync(cf, conn, ch, q);
+            }
+            finally
+            {
+                // The queue is durable, so it outlives the connection. Delete it even when the
+                // test fails, otherwise a failing run leaves a queue behind on the broker.
+                try
+                {
+                    await ch.QueueDeleteAsync(q.QueueName);
+                }
+                catch (Exception ex)
+                {
+                    _output.WriteLine($"[WARNING] could not delete queue {q.QueueName}: {ex}");
+                }
+            }
+
+            await ch.CloseAsync();
+            await conn.CloseAsync();
+        }
+
+        private async Task RunConsumerRecoveryContinuationTimeoutBodyAsync(ConnectionFactory cf,
+            IConnection conn, IChannel ch, QueueDeclareOk q)
+        {
+            var deliveredAfterRecoveryTcs =
+                new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var recoverySucceededTcs =
+                new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var consumer = new AsyncEventingBasicConsumer(ch);
+            consumer.ReceivedAsync += async (o, ea) =>
+            {
+                await ch.BasicAckAsync(ea.DeliveryTag, false);
+                deliveredAfterRecoveryTcs.TrySetResult(true);
+            };
+            await ch.BasicConsumeAsync(q.QueueName, false, consumer);
+
+            conn.RecoverySucceededAsync += (o, ea) =>
+            {
+                recoverySucceededTcs.TrySetResult(true);
+                return Task.CompletedTask;
+            };
+
+            // Stall the recovery basic.consume the first time a consumer is recovered. Rate=0
+            // downstream means the consume frame reaches the broker but the consume-ok never
+            // reaches the client, so the continuation times out.
+            string toxicName = $"rmq-recovery-consume-bandwidth-{Now}-{GenerateShortUuid()}";
+            int toxicAdded = 0;
+            int consumerRecoveryAttempts = 0;
+            ((AutorecoveringConnection)conn).RecoveringConsumerAsync += async (o, ea) =>
+            {
+                Interlocked.Increment(ref consumerRecoveryAttempts);
+
+                if (Interlocked.CompareExchange(ref toxicAdded, 1, 0) != 0)
+                {
+                    // Only the first recovery attempt is sabotaged; later attempts must succeed.
+                    return;
+                }
+
+                var bandwidthToxic = new BandwidthToxic
+                {
+                    Name = toxicName,
+                    Toxicity = 1.0,
+                    Stream = ToxicDirection.DownStream
+                };
+                bandwidthToxic.Attributes.Rate = 0;
+                await _toxiproxyManager.AddToxicAsync(bandwidthToxic);
+            };
+
+            // Sever the connection, then restore it so recovery can proceed.
+            await _toxiproxyManager.DisableAsync();
+            await Task.Delay(TimeSpan.FromSeconds(1));
+            await _toxiproxyManager.EnableAsync();
+
+            // Wait until the sabotaged recovery attempt has run, then clear the toxic so the
+            // retry can complete. Without the fix, no retry happens: recovery reports success
+            // after swallowing the cancellation.
+            while (Volatile.Read(ref toxicAdded) == 0)
+            {
+                await Task.Delay(100);
+            }
+
+            // The stalled basic.consume must be given time to hit ContinuationTimeout before the
+            // toxic is removed, otherwise the consume-ok arrives in time and the test is vacuous.
+            await Task.Delay(cf.ContinuationTimeout + TimeSpan.FromSeconds(1));
+            await _toxiproxyManager.RemoveToxicAsync(toxicName);
+
+            await recoverySucceededTcs.Task.WaitAsync(WaitSpan);
+
+            // The real assertion: the recovered consumer is actually wired into the new channel's
+            // ConsumerDispatcher. Before the fix this publish was delivered to the
+            // FallbackConsumer and dropped, so this wait timed out.
+            await ch.BasicPublishAsync("", q.QueueName, GetRandomBody(64));
+            await deliveredAfterRecoveryTcs.Task.WaitAsync(WaitSpan);
+
+            Assert.True(await deliveredAfterRecoveryTcs.Task);
+
+            // Guard against a vacuous pass. Delivery could also resume if the first recovery
+            // attempt had simply succeeded (toxic added too late to stall the consume), in which
+            // case this test would prove nothing about the retry. Consumer recovery must have been
+            // attempted at least twice: once sabotaged, then again after the retry.
+            Assert.True(Volatile.Read(ref consumerRecoveryAttempts) >= 2,
+                $"expected at least 2 consumer recovery attempts, saw {Volatile.Read(ref consumerRecoveryAttempts)}: " +
+                "the first attempt was not stalled, so the retry path was never exercised");
         }
 
         private static async Task PublishIgnoringErrorsAsync(IChannel ch, string queueName, byte[] body,

--- a/projects/Test/Unit/TestTopologyRecoveryExceptionClassification.cs
+++ b/projects/Test/Unit/TestTopologyRecoveryExceptionClassification.cs
@@ -1,0 +1,105 @@
+// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2026 Broadcom. All Rights Reserved.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       https://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v2.0:
+//
+//---------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//  Copyright (c) 2007-2026 Broadcom. All Rights Reserved.
+//---------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using RabbitMQ.Client.Exceptions;
+using RabbitMQ.Client.Impl;
+using Xunit;
+
+namespace Test.Unit
+{
+    /// <summary>
+    /// Covers how topology recovery classifies a failure to recover a single entity: skip it and
+    /// carry on, or abandon the whole recovery attempt and retry it.
+    /// </summary>
+    public class TestTopologyRecoveryExceptionClassification
+    {
+        private static readonly ShutdownEventArgs s_shutdownArgs =
+            new ShutdownEventArgs(ShutdownInitiator.Peer, Constants.ConnectionForced, "test");
+
+        [Fact]
+        public void TestConnectivityExceptionsAreRetried()
+        {
+            var notCancelled = CancellationToken.None;
+
+            Assert.True(AutorecoveringConnection.ShouldRetryRecoveryAfter(
+                new AlreadyClosedException(s_shutdownArgs), notCancelled));
+            Assert.True(AutorecoveringConnection.ShouldRetryRecoveryAfter(
+                new OperationInterruptedException(s_shutdownArgs), notCancelled));
+            Assert.True(AutorecoveringConnection.ShouldRetryRecoveryAfter(
+                new TimeoutException(), notCancelled));
+        }
+
+        // rabbitmq/rabbitmq-dotnet-client: a protocol operation that ran past ContinuationTimeout
+        // completes its continuation as cancelled, so it arrives here as an
+        // OperationCanceledException rather than a TimeoutException. It must still be retried: the
+        // frame is already on the wire and the broker can apply it after the client gave up. Getting
+        // this wrong leaves a consumer registered on the broker that the client never wired up, and
+        // the queue silently stops being consumed.
+        [Fact]
+        public void TestOperationCanceledIsRetriedWhenRecoveryWasNotCancelled()
+        {
+            Assert.True(AutorecoveringConnection.ShouldRetryRecoveryAfter(
+                new OperationCanceledException(), CancellationToken.None));
+            Assert.True(AutorecoveringConnection.ShouldRetryRecoveryAfter(
+                new TaskCanceledException(), CancellationToken.None));
+        }
+
+        [Fact]
+        public void TestOperationCanceledIsNotRetriedWhenRecoveryWasCancelled()
+        {
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            // Recovery itself is being torn down (the connection is closing). Retrying would be
+            // pointless and would fight the shutdown.
+            Assert.False(AutorecoveringConnection.ShouldRetryRecoveryAfter(
+                new OperationCanceledException(), cts.Token));
+            Assert.False(AutorecoveringConnection.ShouldRetryRecoveryAfter(
+                new TaskCanceledException(), cts.Token));
+        }
+
+        [Fact]
+        public void TestUnrelatedExceptionsAreNotRetried()
+        {
+            // e.g. a queue that now fails an equivalence check, or a bug in a user callback. Retrying
+            // cannot help, so recovery skips the entity and carries on, as it does today.
+            Assert.False(AutorecoveringConnection.ShouldRetryRecoveryAfter(
+                new ArgumentException("nope"), CancellationToken.None));
+            Assert.False(AutorecoveringConnection.ShouldRetryRecoveryAfter(
+                null, CancellationToken.None));
+        }
+    }
+}

--- a/projects/Test/Unit/TestTopologyRecoveryExceptionClassification.cs
+++ b/projects/Test/Unit/TestTopologyRecoveryExceptionClassification.cs
@@ -44,6 +44,9 @@ namespace Test.Unit
     /// Covers how topology recovery classifies a failure to recover a single entity: skip it and
     /// carry on, or abandon the whole recovery attempt and retry it.
     /// </summary>
+    /// <remarks>
+    /// See https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/1993
+    /// </remarks>
     public class TestTopologyRecoveryExceptionClassification
     {
         private static readonly ShutdownEventArgs s_shutdownArgs =
@@ -62,14 +65,14 @@ namespace Test.Unit
                 new TimeoutException(), notCancelled));
         }
 
-        // rabbitmq/rabbitmq-dotnet-client: a protocol operation that ran past ContinuationTimeout
-        // completes its continuation as cancelled, so it arrives here as an
-        // OperationCanceledException rather than a TimeoutException. It must still be retried: the
-        // frame is already on the wire and the broker can apply it after the client gave up. Getting
-        // this wrong leaves a consumer registered on the broker that the client never wired up, and
-        // the queue silently stops being consumed.
+        // A protocol operation that ran past ContinuationTimeout completes its continuation as
+        // cancelled, so it arrives here as an OperationCanceledException rather than a
+        // TimeoutException. It must still be retried: the frame is already on the wire and the
+        // broker can apply it after the client gave up. Getting this wrong leaves a consumer
+        // registered on the broker that the client never wired up, and the queue silently stops
+        // being consumed. See #1993.
         [Fact]
-        public void TestOperationCanceledIsRetriedWhenRecoveryWasNotCancelled()
+        public void TestOperationCanceledIsRetriedWhenRecoveryWasNotCancelled_GH1993()
         {
             Assert.True(AutorecoveringConnection.ShouldRetryRecoveryAfter(
                 new OperationCanceledException(), CancellationToken.None));
@@ -78,7 +81,7 @@ namespace Test.Unit
         }
 
         [Fact]
-        public void TestOperationCanceledIsNotRetriedWhenRecoveryWasCancelled()
+        public void TestOperationCanceledIsNotRetriedWhenRecoveryWasCancelled_GH1993()
         {
             using var cts = new CancellationTokenSource();
             cts.Cancel();


### PR DESCRIPTION
Fixes #1993

Topology recovery silently loses a consumer when the basic.consume it issues does not complete within ContinuationTimeout (20s by default).

An RPC that exceeds ContinuationTimeout completes its continuation as cancelled, so it reaches HandleTopologyRecoveryException as an OperationCanceledException. That type was not in the retry list, so recovery logged "Will not retry recovery because of
System.Threading.Tasks.TaskCanceledException: it's not a known problem with connectivity, ignoring it", skipped the consumer, and went on to report success: "Connection recovery completed" was logged and RecoverySucceededAsync fired.

The broker had not given up, though. basic.consume was already on the wire, so once the queue became available the broker registered an active consumer and started delivering to it. The client had abandoned that RPC, so the late basic.consume-ok was discarded and the consumer was never added to the new channel's ConsumerDispatcher. Every subsequent delivery for that consumer tag then resolved to the FallbackConsumer, which logs at Info level and drops the message without acking it. With a non-zero prefetch the broker waits forever for an acknowledgement that can never come, so the queue stops being consumed altogether - silently, on a connection and channel that both still report IsOpen, with no exception and no event the application can observe.

This is straightforward to hit with quorum queues: while a quorum queue has no leader it cannot answer basic.consume, and electing one can take longer than 20s. It was found on a 3-node cluster where two nodes were killed in quick succession, briefly losing quorum. Measured there, recovery needed 24.2s - only just over the default.

Treat an OperationCanceledException during topology recovery as retryable unless recovery itself was cancelled. A timed-out operation may still be applied by the broker after the client stops waiting, so the client's view of the connection can no longer be trusted and recovery must not be declared successful. Failing the attempt aborts the connection, which clears any consumer the broker did register, and the next attempt re-establishes the topology cleanly.

The exception type is deliberately left alone. The catch (OperationCanceledException) blocks around each RPC are what call RpcContinuationQueue.RpcCanceled, which is what keeps a late reply from being matched to the wrong continuation, and the existing continuation tests assert that a timeout surfaces as an OperationCanceledException.

Verified end to end against RabbitMQ 4.2.0:

  - a 3-node cluster running the reported workload, killing two nodes ~2s apart so quorum is lost. Before: the consumer stops permanently, one message stuck unacked, queue grows without bound. After: the first recovery attempt fails on the timeout, the next succeeds 5s later, and the application resumes and drains the backlog. No deliveries reach the FallbackConsumer.

  - a single-node reproduction that delays the reply to topology recovery's basic.consume past ContinuationTimeout. Before: 3 of 6 messages delivered. After: 6 of 6.