### PR TITLE
Await connection.open-ok before completing connection creation

### DIFF
--- a/projects/RabbitMQ.Client/Impl/AsyncRpcContinuations.cs
+++ b/projects/RabbitMQ.Client/Impl/AsyncRpcContinuations.cs
@@ -318,6 +318,14 @@ namespace RabbitMQ.Client.Impl
         }
     }
 
+    internal sealed class ConnectionOpenAsyncRpcContinuation : SimpleAsyncRpcContinuation
+    {
+        public ConnectionOpenAsyncRpcContinuation(TimeSpan continuationTimeout, CancellationToken cancellationToken)
+            : base(ProtocolCommandId.ConnectionOpenOk, continuationTimeout, cancellationToken)
+        {
+        }
+    }
+
     internal sealed class BasicCancelAsyncRpcContinuation : SimpleAsyncRpcContinuation
     {
         private readonly string _consumerTag;

--- a/projects/RabbitMQ.Client/Impl/AsyncRpcContinuations.cs
+++ b/projects/RabbitMQ.Client/Impl/AsyncRpcContinuations.cs
@@ -318,14 +318,6 @@ namespace RabbitMQ.Client.Impl
         }
     }
 
-    internal sealed class ConnectionOpenAsyncRpcContinuation : SimpleAsyncRpcContinuation
-    {
-        public ConnectionOpenAsyncRpcContinuation(TimeSpan continuationTimeout, CancellationToken cancellationToken)
-            : base(ProtocolCommandId.ConnectionOpenOk, continuationTimeout, cancellationToken)
-        {
-        }
-    }
-
     internal sealed class BasicCancelAsyncRpcContinuation : SimpleAsyncRpcContinuation
     {
         private readonly string _consumerTag;

--- a/projects/RabbitMQ.Client/Impl/Channel.cs
+++ b/projects/RabbitMQ.Client/Impl/Channel.cs
@@ -275,11 +275,51 @@ namespace RabbitMQ.Client.Impl
 
         internal async ValueTask ConnectionOpenAsync(string virtualHost, CancellationToken cancellationToken)
         {
-            using var timeoutTokenSource = new CancellationTokenSource(HandshakeContinuationTimeout);
-            using var lts = CancellationTokenSource.CreateLinkedTokenSource(timeoutTokenSource.Token, cancellationToken);
-            var method = new ConnectionOpen(virtualHost);
-            // Note: must be awaited or else the timeoutTokenSource instance will be disposed
-            await ModelSendAsync(in method, lts.Token).ConfigureAwait(false);
+            bool enqueued = false;
+            bool semaphoreAcquired = false;
+            var k = new ConnectionOpenAsyncRpcContinuation(HandshakeContinuationTimeout, cancellationToken);
+
+            try
+            {
+                await _rpcSemaphore.WaitAsync(k.CancellationToken)
+                    .ConfigureAwait(false);
+                semaphoreAcquired = true;
+
+                k.StartTimeout();
+
+                enqueued = Enqueue(k);
+
+                try
+                {
+                    var method = new ConnectionOpen(virtualHost);
+                    await ModelSendAsync(in method, k.CancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch (AlreadyClosedException)
+                {
+                    // let continuation throw OperationInterruptedException,
+                    // which is a much more suitable exception before connection
+                    // negotiation finishes
+                }
+
+                try
+                {
+                    AssertResultIsTrue(await k);
+                }
+                catch (OperationCanceledException)
+                {
+                    _continuationQueue.RpcCanceled(k.ResponseReceived, k.HandledProtocolCommandIds);
+                    throw;
+                }
+            }
+            finally
+            {
+                MaybeDisposeContinuation(enqueued, k);
+                if (semaphoreAcquired)
+                {
+                    _rpcSemaphore.Release();
+                }
+            }
         }
 
         internal async ValueTask<ConnectionSecureOrTune> ConnectionSecureOkAsync(byte[] response,

--- a/projects/RabbitMQ.Client/Impl/Channel.cs
+++ b/projects/RabbitMQ.Client/Impl/Channel.cs
@@ -280,6 +280,11 @@ namespace RabbitMQ.Client.Impl
             var k = new SimpleAsyncRpcContinuation(ProtocolCommandId.ConnectionOpenOk,
                 HandshakeContinuationTimeout, cancellationToken);
 
+            // Unlike the sibling Connection*Async methods, the semaphore is
+            // acquired inside the try (guarded by semaphoreAcquired) so that a
+            // cancellation of WaitAsync during connection open still reaches the
+            // finally and disposes k. Acquiring it outside the try, as the
+            // siblings do, leaks k's CancellationTokenSource on that path.
             try
             {
                 await _rpcSemaphore.WaitAsync(k.CancellationToken)

--- a/projects/RabbitMQ.Client/Impl/Channel.cs
+++ b/projects/RabbitMQ.Client/Impl/Channel.cs
@@ -277,7 +277,8 @@ namespace RabbitMQ.Client.Impl
         {
             bool continuationEnqueued = false;
             bool semaphoreAcquired = false;
-            var k = new ConnectionOpenAsyncRpcContinuation(HandshakeContinuationTimeout, cancellationToken);
+            var k = new SimpleAsyncRpcContinuation(ProtocolCommandId.ConnectionOpenOk,
+                HandshakeContinuationTimeout, cancellationToken);
 
             try
             {

--- a/projects/RabbitMQ.Client/Impl/Channel.cs
+++ b/projects/RabbitMQ.Client/Impl/Channel.cs
@@ -275,7 +275,7 @@ namespace RabbitMQ.Client.Impl
 
         internal async ValueTask ConnectionOpenAsync(string virtualHost, CancellationToken cancellationToken)
         {
-            bool enqueued = false;
+            bool continuationEnqueued = false;
             bool semaphoreAcquired = false;
             var k = new ConnectionOpenAsyncRpcContinuation(HandshakeContinuationTimeout, cancellationToken);
 
@@ -283,11 +283,11 @@ namespace RabbitMQ.Client.Impl
             {
                 await _rpcSemaphore.WaitAsync(k.CancellationToken)
                     .ConfigureAwait(false);
-                semaphoreAcquired = true;
+                Volatile.Write(ref semaphoreAcquired, true);
 
                 k.StartTimeout();
 
-                enqueued = Enqueue(k);
+                continuationEnqueued = Enqueue(k);
 
                 try
                 {
@@ -314,8 +314,8 @@ namespace RabbitMQ.Client.Impl
             }
             finally
             {
-                MaybeDisposeContinuation(enqueued, k);
-                if (semaphoreAcquired)
+                MaybeDisposeContinuation(continuationEnqueued, k);
+                if (Volatile.Read(ref semaphoreAcquired))
                 {
                     _rpcSemaphore.Release();
                 }

--- a/projects/RabbitMQ.Client/Impl/Channel.cs
+++ b/projects/RabbitMQ.Client/Impl/Channel.cs
@@ -283,7 +283,7 @@ namespace RabbitMQ.Client.Impl
             {
                 await _rpcSemaphore.WaitAsync(k.CancellationToken)
                     .ConfigureAwait(false);
-                Volatile.Write(ref semaphoreAcquired, true);
+                semaphoreAcquired = true;
 
                 k.StartTimeout();
 
@@ -315,7 +315,7 @@ namespace RabbitMQ.Client.Impl
             finally
             {
                 MaybeDisposeContinuation(continuationEnqueued, k);
-                if (Volatile.Read(ref semaphoreAcquired))
+                if (semaphoreAcquired)
                 {
                     _rpcSemaphore.Release();
                 }

--- a/projects/Test/Unit/TestConnectionOpen.cs
+++ b/projects/Test/Unit/TestConnectionOpen.cs
@@ -1,0 +1,324 @@
+// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2026 Broadcom. All Rights Reserved.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       https://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v2.0:
+//
+//---------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//  Copyright (c) 2007-2026 Broadcom. All Rights Reserved.
+//---------------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using RabbitMQ.Client.Exceptions;
+using RabbitMQ.Client.Framing;
+using RabbitMQ.Client.Impl;
+using Xunit;
+
+using ImplChannel = RabbitMQ.Client.Impl.Channel;
+
+namespace Test.Unit
+{
+    public class TestConnectionOpen
+    {
+        [Fact]
+        public async Task TestConnectionOpenWaitsForConnectionOpenOkAsync()
+        {
+            using var session = new TestSession();
+            var channel = CreateChannel(session);
+
+            try
+            {
+                Task openTask = channel.ConnectionOpenAsync("/", CancellationToken.None).AsTask();
+
+                Assert.Equal(ProtocolCommandId.ConnectionOpen,
+                    await session.ReadTransmittedCommandAsync());
+                Assert.False(openTask.IsCompleted);
+
+                await session.DeliverCommandAsync(ProtocolCommandId.ConnectionOpenOk);
+                await openTask.WaitAsync(TimingFixture.TestTimeout);
+            }
+            finally
+            {
+                await DisposeChannelAsync(session, channel);
+            }
+        }
+
+        [Fact]
+        public async Task TestConnectionOpenHandlesImmediateConnectionOpenOkAsync()
+        {
+            using var session = new TestSession(respondToConnectionOpen: true);
+            var channel = CreateChannel(session);
+
+            try
+            {
+                await channel.ConnectionOpenAsync("/", CancellationToken.None).AsTask()
+                    .WaitAsync(TimingFixture.TestTimeout);
+
+                Assert.Equal(ProtocolCommandId.ConnectionOpen,
+                    await session.ReadTransmittedCommandAsync());
+            }
+            finally
+            {
+                await DisposeChannelAsync(session, channel);
+            }
+        }
+
+        [Fact]
+        public async Task TestConnectionOpenPropagatesSessionShutdownAsync()
+        {
+            using var session = new TestSession();
+            var channel = CreateChannel(session);
+
+            try
+            {
+                Task openTask = channel.ConnectionOpenAsync("/", CancellationToken.None).AsTask();
+                Assert.Equal(ProtocolCommandId.ConnectionOpen,
+                    await session.ReadTransmittedCommandAsync());
+
+                var reason = new ShutdownEventArgs(ShutdownInitiator.Peer, 530,
+                    "connection open rejected", classId: 20, methodId: 10);
+                await session.CloseAsync(reason);
+
+                OperationInterruptedException exception =
+                    await Assert.ThrowsAsync<OperationInterruptedException>(() => openTask);
+                Assert.Same(reason, exception.ShutdownReason);
+            }
+            finally
+            {
+                await DisposeChannelAsync(session, channel);
+            }
+        }
+
+        [Fact]
+        public async Task TestConnectionOpenTimeoutDoesNotCorruptNextRpcAsync()
+        {
+            using var session = new TestSession();
+            var channel = CreateChannel(session);
+            channel.HandshakeContinuationTimeout = TimingFixture.TimingInterval;
+
+            try
+            {
+                Task firstOpenTask = channel.ConnectionOpenAsync("/", CancellationToken.None).AsTask();
+                Assert.Equal(ProtocolCommandId.ConnectionOpen,
+                    await session.ReadTransmittedCommandAsync());
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => firstOpenTask);
+
+                await session.DeliverCommandAsync(ProtocolCommandId.ConnectionOpenOk);
+
+                Task secondOpenTask = channel.ConnectionOpenAsync("/", CancellationToken.None).AsTask();
+                Assert.Equal(ProtocolCommandId.ConnectionOpen,
+                    await session.ReadTransmittedCommandAsync());
+                Assert.False(secondOpenTask.IsCompleted);
+
+                await session.DeliverCommandAsync(ProtocolCommandId.ConnectionOpenOk);
+                await secondOpenTask.WaitAsync(TimingFixture.TestTimeout);
+            }
+            finally
+            {
+                await DisposeChannelAsync(session, channel);
+            }
+        }
+
+        [Fact]
+        public async Task TestConnectionOpenCanceledWhileWaitingForRpcSemaphoreDoesNotSendAsync()
+        {
+            using var session = new TestSession();
+            TestChannel channel = CreateChannel(session);
+
+            try
+            {
+                await channel.AcquireRpcSemaphoreAsync();
+                try
+                {
+                    using var cts = new CancellationTokenSource();
+                    cts.Cancel();
+
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                        channel.ConnectionOpenAsync("/", cts.Token).AsTask());
+                    Assert.Equal(0, session.TransmittedCommandCount);
+                }
+                finally
+                {
+                    // This also proves that the cancelled waiter did not release a permit it
+                    // never acquired: doing so would make this Release throw SemaphoreFullException.
+                    channel.ReleaseRpcSemaphore();
+                }
+
+                Task openTask = channel.ConnectionOpenAsync("/", CancellationToken.None).AsTask();
+                Assert.Equal(ProtocolCommandId.ConnectionOpen,
+                    await session.ReadTransmittedCommandAsync());
+                await session.DeliverCommandAsync(ProtocolCommandId.ConnectionOpenOk);
+                await openTask.WaitAsync(TimingFixture.TestTimeout);
+            }
+            finally
+            {
+                await DisposeChannelAsync(session, channel);
+            }
+        }
+
+        private static TestChannel CreateChannel(TestSession session)
+            => new TestChannel(session, new CreateChannelOptions(
+                publisherConfirmationsEnabled: false,
+                publisherConfirmationTrackingEnabled: false));
+
+        private static async Task DisposeChannelAsync(TestSession session, ImplChannel channel)
+        {
+            await session.CloseAsync(new ShutdownEventArgs(ShutdownInitiator.Library,
+                Constants.ReplySuccess, "test teardown"));
+            await channel.DisposeAsync();
+        }
+
+        private sealed class TestChannel : ImplChannel
+        {
+            public TestChannel(ISession session, CreateChannelOptions createChannelOptions)
+                : base(session, createChannelOptions)
+            {
+            }
+
+            public Task AcquireRpcSemaphoreAsync() => _rpcSemaphore.WaitAsync();
+
+            public void ReleaseRpcSemaphore() => _rpcSemaphore.Release();
+        }
+
+        private sealed class TestSession : ISession, IDisposable
+        {
+            private readonly bool _respondToConnectionOpen;
+            private readonly ConcurrentQueue<ProtocolCommandId> _transmittedCommands =
+                new ConcurrentQueue<ProtocolCommandId>();
+            private readonly SemaphoreSlim _transmittedCommandSignal = new SemaphoreSlim(0);
+            private AsyncEventHandler<ShutdownEventArgs>? _sessionShutdownAsync;
+
+            public TestSession(bool respondToConnectionOpen = false)
+            {
+                _respondToConnectionOpen = respondToConnectionOpen;
+            }
+
+            public ushort ChannelNumber => 0;
+
+            public ShutdownEventArgs? CloseReason { get; private set; }
+
+            public CommandReceivedAction? CommandReceived { get; set; }
+
+            public Connection Connection => throw new NotSupportedException();
+
+            public bool IsOpen => CloseReason is null;
+
+            public int TransmittedCommandCount => _transmittedCommands.Count;
+
+            public event AsyncEventHandler<ShutdownEventArgs> SessionShutdownAsync
+            {
+                add => _sessionShutdownAsync += value;
+                remove => _sessionShutdownAsync -= value;
+            }
+
+            public Task CloseAsync(ShutdownEventArgs reason, bool notify = true)
+            {
+                if (CloseReason is not null)
+                {
+                    return Task.CompletedTask;
+                }
+
+                CloseReason = reason;
+                return notify ? NotifySessionShutdownAsync(reason) : Task.CompletedTask;
+            }
+
+            public Task HandleFrameAsync(InboundFrame frame, CancellationToken cancellationToken)
+                => throw new NotSupportedException();
+
+            public Task NotifyAsync(CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return CloseReason is null
+                    ? throw new InvalidOperationException("The session is still open.")
+                    : NotifySessionShutdownAsync(CloseReason);
+            }
+
+            public ValueTask TransmitAsync<T>(in T cmd, CancellationToken cancellationToken)
+                where T : struct, IOutgoingAmqpMethod
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                _transmittedCommands.Enqueue(cmd.ProtocolCommandId);
+                _transmittedCommandSignal.Release();
+
+                if (_respondToConnectionOpen &&
+                    cmd.ProtocolCommandId == ProtocolCommandId.ConnectionOpen)
+                {
+                    return new ValueTask(DeliverCommandAsync(ProtocolCommandId.ConnectionOpenOk));
+                }
+
+                return default;
+            }
+
+            public ValueTask TransmitAsync<TMethod, THeader>(in TMethod cmd, in THeader header,
+                ReadOnlyMemory<byte> body, IDisposable? bodyOwner, CancellationToken cancellationToken)
+                where TMethod : struct, IOutgoingAmqpMethod
+                where THeader : IAmqpHeader
+            {
+                bodyOwner?.Dispose();
+                throw new NotSupportedException();
+            }
+
+            public async Task<ProtocolCommandId> ReadTransmittedCommandAsync()
+            {
+                Assert.True(await _transmittedCommandSignal.WaitAsync(TimingFixture.TestTimeout));
+                Assert.True(_transmittedCommands.TryDequeue(out ProtocolCommandId commandId));
+                return commandId;
+            }
+
+            public Task DeliverCommandAsync(ProtocolCommandId commandId)
+            {
+                CommandReceivedAction commandReceived = CommandReceived ??
+                    throw new InvalidOperationException("No command receiver is registered.");
+                return commandReceived(new IncomingCommand { CommandId = commandId },
+                    CancellationToken.None);
+            }
+
+            public void Dispose()
+            {
+                _transmittedCommandSignal.Dispose();
+            }
+
+            private async Task NotifySessionShutdownAsync(ShutdownEventArgs reason)
+            {
+                AsyncEventHandler<ShutdownEventArgs>? handlers = _sessionShutdownAsync;
+                if (handlers is null)
+                {
+                    return;
+                }
+
+                foreach (AsyncEventHandler<ShutdownEventArgs> handler in handlers.GetInvocationList())
+                {
+                    await handler(this, reason).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes

Fixes #1999

AMQP 0-9-1 defines connection opening as `C:OPEN S:OPEN-OK`, and
`connection.open-ok` signals that the connection is ready for use. Currently,
`ConnectionOpenAsync` only waits for the write of `connection.open`, allowing
`CreateConnectionAsync` to return before Open-Ok and permitting `channel.open`
to be sent too early.

This change:

- adds a channel-0 RPC continuation that expects
  `ProtocolCommandId.ConnectionOpenOk`;
- acquires the existing RPC semaphore and enqueues the continuation before
  sending `ConnectionOpen`, so an immediate Open-Ok cannot be lost;
- waits for Open-Ok using `HandshakeContinuationTimeout`;
- preserves peer shutdown reasons and uses the existing late-response cleanup
  for timeouts;
- cleans up the continuation without releasing an RPC semaphore permit when a
  caller is cancelled before acquiring it;
- makes initial connection creation and automatic recovery wait until the
  server confirms that the connection is ready.

Protocol reference:

https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#connectionopen-ok

### Test Plan

- [x] A controlled session delaying Open-Ok keeps `ConnectionOpenAsync`
      incomplete until Open-Ok is delivered.
- [x] Open-Ok delivered from inside `TransmitAsync` is not lost.
- [x] Peer shutdown while waiting preserves the complete shutdown reason in an
      `OperationInterruptedException`.
- [x] `HandshakeContinuationTimeout` cancels the wait, a late Open-Ok is
      absorbed, and the next RPC completes normally.
- [x] Cancellation while waiting for the RPC semaphore sends no frame, releases
      no unowned permit, and does not prevent the next RPC.
- [x] `dotnet test projects/Test/Unit/Unit.csproj --no-restore` (156 passed).
- [x] `dotnet build projects/RabbitMQ.Client/RabbitMQ.Client.csproj --no-restore`
      (`net8.0` and `netstandard2.0`, zero warnings/errors).
- [x] `dotnet format --no-restore --verify-no-changes` for all changed files.
- [x] The integration suite was not run locally because it requires a RabbitMQ
      node plus the repository's TLS/Toxiproxy test environment.

### Compatibility

There are no public API, configuration, persistence, or wire-format changes.
Conforming AMQP 0-9-1 servers already send Open-Ok; connection creation now
includes the final handshake response before exposing the connection. A stalled
or non-conforming peer that never sends Open-Ok will now fail with the configured
handshake timeout instead of returning an unusable connection.

Automatic recovery uses the same `Connection.OpenAsync` path, so takeover,
topology recovery (when enabled), channel recovery, and the recovery-success
event remain gated on a fully opened connection.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #1999)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CLA (see https://github.com/rabbitmq/cla)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

The implementation follows the existing channel RPC continuation pattern. It
intentionally leaves `ConnectionOpenOk` on `DispatchCommandAsync`'s default RPC
response path and keeps the send operation outside the reply-cancellation catch:
a failed send must not register a response as potentially late.
