### PR TITLE
Fix recovery could miss closed connection notification

### DIFF
--- a/projects/RabbitMQ.Client/Impl/AutorecoveringConnection.Recovery.cs
+++ b/projects/RabbitMQ.Client/Impl/AutorecoveringConnection.Recovery.cs
@@ -43,6 +43,8 @@ namespace RabbitMQ.Client.Impl
 {
     internal sealed partial class AutorecoveringConnection
     {
+        // TODO: Use Lock once update to .NET 9+
+        // https://learn.microsoft.com/en-us/dotnet/api/system.threading.lock?view=net-10.0
         private readonly object _recoverySync = new object();
         private Task? _recoveryTask;
         private bool _recoveryPendingRequest;

--- a/projects/RabbitMQ.Client/Impl/AutorecoveringConnection.Recovery.cs
+++ b/projects/RabbitMQ.Client/Impl/AutorecoveringConnection.Recovery.cs
@@ -37,24 +37,35 @@ using System.Threading;
 using System.Threading.Tasks;
 using RabbitMQ.Client.Events;
 using RabbitMQ.Client.Exceptions;
-using RabbitMQ.Client.Framing;
 using RabbitMQ.Client.Logging;
 
 namespace RabbitMQ.Client.Impl
 {
     internal sealed partial class AutorecoveringConnection
     {
+        private readonly object _recoverySync = new object();
         private Task? _recoveryTask;
+        private bool _recoveryPendingRequest;
         private readonly CancellationTokenSource _recoveryCancellationTokenSource = new CancellationTokenSource();
 
         private Task HandleConnectionShutdownAsync(object? _, ShutdownEventArgs args)
         {
             if (ShouldTriggerConnectionRecovery(args))
             {
-                var recoverTask = new Task<Task>(RecoverConnectionAsync);
-                if (Interlocked.CompareExchange(ref _recoveryTask, recoverTask.Unwrap(), null) is null)
+                lock (_recoverySync)
                 {
-                    recoverTask.Start();
+                    if (_recoveryTask == null)
+                    {
+                        var recoverTask = new Task<Task>(RecoverConnectionAsync);
+                        _recoveryTask = recoverTask.Unwrap();
+                        recoverTask.Start();
+                    }
+                    else
+                    {
+                        // Notify current recovery task about new recovery request,
+                        // as there is no other task to catch it.
+                        _recoveryPendingRequest = true;
+                    }
                 }
             }
 
@@ -98,30 +109,54 @@ namespace RabbitMQ.Client.Impl
 
         private async Task RecoverConnectionAsync()
         {
-            try
+            // Capture early, so concurrent source disposal wouldn't throw
+            CancellationToken token = _recoveryCancellationTokenSource.Token;
+
+            bool retryRecovery = true;
+            while (retryRecovery)
             {
-                CancellationToken token = _recoveryCancellationTokenSource.Token;
-                bool success;
-                do
+                try
                 {
-                    await Task.Delay(_config.NetworkRecoveryInterval, token)
-                        .ConfigureAwait(false);
-                    success = await TryPerformAutomaticRecoveryAsync(token)
-                        .ConfigureAwait(false);
-                } while (false == success && false == token.IsCancellationRequested);
-            }
-            catch (OperationCanceledException)
-            {
-                // expected when recovery cancellation token is set.
-            }
-            catch (Exception e)
-            {
-                ESLog.Error("Main recovery loop threw unexpected exception.", e);
-            }
-            finally
-            {
-                // clear recovery task
-                _recoveryTask = null;
+                    // Re-check if connection is not opened already, as we could execute it multiple times.
+                    bool success = IsOpen;
+                    while (false == success && false == token.IsCancellationRequested && false == _disposed)
+                    {
+                        await Task.Delay(_config.NetworkRecoveryInterval, token)
+                            .ConfigureAwait(false);
+                        success = await TryPerformAutomaticRecoveryAsync(token)
+                            .ConfigureAwait(false);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // expected when recovery cancellation token is set.
+                }
+                catch (Exception e)
+                {
+                    ESLog.Error("Main recovery loop threw unexpected exception.", e);
+                }
+                finally
+                {
+                    lock (_recoverySync)
+                    {
+                        /*
+                         * It is possible that the re-opened connection was again shut down while we executed recovery method above.
+                         * In those cases the shutdown callback didn't enqueue a new recovery task, so recovery will not happen.
+                         * There could be a delay between opening the connection and returning from the recovery method,
+                         * so there is a race-condition that could lead to a permanently never recovered connection.
+                         */
+                        if (_recoveryPendingRequest)
+                        {
+                            _recoveryPendingRequest = false;
+                            retryRecovery = true;
+                        }
+                        else
+                        {
+                            _recoveryTask = null;
+                            retryRecovery = false;
+                        }
+                    }
+                }
             }
         }
 
@@ -131,10 +166,13 @@ namespace RabbitMQ.Client.Impl
         /// </summary>
         private async ValueTask StopRecoveryLoopAsync(CancellationToken cancellationToken)
         {
+            // We have to cancel the token regardless of whether there is a task,
+            // as there could be a race condition that starts a new recovery task right after we checked.
+            // It's safer to cancel it, so even if a new task is created - it will be a nop.
+            _recoveryCancellationTokenSource.Cancel();
             Task? task = _recoveryTask;
             if (task != null)
             {
-                _recoveryCancellationTokenSource.Cancel();
                 using var timeoutTokenSource = new CancellationTokenSource(_config.RequestedConnectionTimeout);
                 using var lts = CancellationTokenSource.CreateLinkedTokenSource(timeoutTokenSource.Token, cancellationToken);
                 try

--- a/projects/RabbitMQ.Client/Impl/AutorecoveringConnection.Recovery.cs
+++ b/projects/RabbitMQ.Client/Impl/AutorecoveringConnection.Recovery.cs
@@ -72,9 +72,16 @@ namespace RabbitMQ.Client.Impl
 
                     if (_recoveryTask == null)
                     {
-                        var recoverTask = new Task<Task>(RecoverConnectionAsync);
-                        _recoveryTask = recoverTask.Unwrap();
-                        recoverTask.Start();
+                        // Run the recovery loop on the thread pool. Assigning the task
+                        // returned by Task.Run (rather than invoking RecoverConnectionAsync
+                        // directly) guarantees _recoveryTask is set before the loop's finally
+                        // can run: a direct call executes inline while we hold _recoverySync,
+                        // and if recovery completes synchronously the finally would clear
+                        // _recoveryTask before this assignment resurrected a completed task
+                        // into it, permanently wedging recovery. Task.Run also uses
+                        // TaskScheduler.Default rather than the ambient TaskScheduler.Current
+                        // that a bare Task.Start() would capture.
+                        _recoveryTask = Task.Run(RecoverConnectionAsync);
                     }
                     else
                     {

--- a/projects/RabbitMQ.Client/Impl/AutorecoveringConnection.Recovery.cs
+++ b/projects/RabbitMQ.Client/Impl/AutorecoveringConnection.Recovery.cs
@@ -52,8 +52,22 @@ namespace RabbitMQ.Client.Impl
         {
             if (ShouldTriggerConnectionRecovery(args))
             {
+                // Safe to lock here: no await runs while the lock is held (this method is
+                // not async), so Monitor is entered and released on the same thread. An
+                // await inside a lock is a C# compile error precisely because it would
+                // break that thread affinity.
                 lock (_recoverySync)
                 {
+                    if (_disposed)
+                    {
+                        // Disposal has begun; _recoveryCancellationTokenSource may already be
+                        // disposed, so do not start a new recovery task. This is best-effort
+                        // (DisposeAsync does not take _recoverySync); RecoverConnectionAsync
+                        // still tolerates a disposed source by capturing the token inside its
+                        // try.
+                        return Task.CompletedTask;
+                    }
+
                     if (_recoveryTask == null)
                     {
                         var recoverTask = new Task<Task>(RecoverConnectionAsync);
@@ -109,14 +123,19 @@ namespace RabbitMQ.Client.Impl
 
         private async Task RecoverConnectionAsync()
         {
-            // Capture early, so concurrent source disposal wouldn't throw
-            CancellationToken token = _recoveryCancellationTokenSource.Token;
-
             bool retryRecovery = true;
             while (retryRecovery)
             {
                 try
                 {
+                    // Capture the token inside the try. If _recoveryCancellationTokenSource
+                    // was already disposed (a shutdown notification racing with DisposeAsync),
+                    // reading Token throws ObjectDisposedException; catching it here logs it
+                    // and lets the finally clear _recoveryTask, rather than faulting this task
+                    // unobserved and leaving _recoveryTask non-null (which would permanently
+                    // block further recovery).
+                    CancellationToken token = _recoveryCancellationTokenSource.Token;
+
                     // Re-check if connection is not opened already, as we could execute it multiple times.
                     bool success = IsOpen;
                     while (false == success && false == token.IsCancellationRequested && false == _disposed)
@@ -137,6 +156,9 @@ namespace RabbitMQ.Client.Impl
                 }
                 finally
                 {
+                    // Safe to lock inside this async method: the lock body has no await
+                    // (all awaits are in the try above), so Monitor is entered and released
+                    // on the same thread.
                     lock (_recoverySync)
                     {
                         /*
@@ -170,7 +192,21 @@ namespace RabbitMQ.Client.Impl
             // as there could be a race condition that starts a new recovery task right after we checked.
             // It's safer to cancel it, so even if a new task is created - it will be a nop.
             _recoveryCancellationTokenSource.Cancel();
-            Task? task = _recoveryTask;
+
+            // Read _recoveryTask under _recoverySync so we serialize with
+            // HandleConnectionShutdownAsync: if it is concurrently starting a task, we wait
+            // for it to publish _recoveryTask and then await that task. Any task started
+            // strictly after this read sees the already-cancelled token and is a nop.
+            //
+            // Safe to lock inside this async method: the lock body only reads a field and
+            // holds no await (the WaitAsync below runs after the lock is released), so
+            // Monitor is entered and released on the same thread.
+            Task? task;
+            lock (_recoverySync)
+            {
+                task = _recoveryTask;
+            }
+
             if (task != null)
             {
                 using var timeoutTokenSource = new CancellationTokenSource(_config.RequestedConnectionTimeout);

--- a/projects/Test/Integration/ConnectionRecovery/TestBasicConnectionRecovery.cs
+++ b/projects/Test/Integration/ConnectionRecovery/TestBasicConnectionRecovery.cs
@@ -29,6 +29,7 @@
 //  Copyright (c) 2007-2026 Broadcom. All Rights Reserved.
 //---------------------------------------------------------------------------
 
+using System.Threading;
 using System.Threading.Tasks;
 using RabbitMQ.Client;
 using Xunit;
@@ -47,6 +48,48 @@ namespace Test.Integration.ConnectionRecovery
         {
             Assert.True(_conn.IsOpen);
             await CloseAndWaitForRecoveryAsync();
+            Assert.True(_conn.IsOpen);
+        }
+
+        /// <summary>
+        /// Only one recovery loop runs at a time, and the RecoverySucceededAsync handlers are awaited
+        /// as part of it. A connection can therefore be shut down again after it was recovered but
+        /// before the loop that recovered it has finished. That shutdown has to result in another
+        /// recovery, otherwise the connection stays down for good.
+        /// </summary>
+        [Fact]
+        public async Task TestShutdownWhileRecoveryLoopIsStillRunningIsRecovered()
+        {
+            var firstRecoveryStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseFirstRecovery = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var secondRecoveryFinished = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            int recoveryCount = 0;
+            _conn.RecoverySucceededAsync += async (_, _) =>
+            {
+                if (Interlocked.Increment(ref recoveryCount) == 1)
+                {
+                    firstRecoveryStarted.TrySetResult(true);
+                    await releaseFirstRecovery.Task;
+                }
+                else
+                {
+                    secondRecoveryFinished.TrySetResult(true);
+                }
+            };
+
+            await CloseConnectionAsync(_conn);
+            await WaitAsync(firstRecoveryStarted, "first connection recovery");
+
+            // The connection has been recovered, but the loop that recovered it is held inside the
+            // handler above and so is still considered to be running.
+            TaskCompletionSource<bool> secondShutdown = PrepareForShutdown(_conn);
+            await CloseConnectionAsync(_conn);
+            await WaitAsync(secondShutdown, "second connection shutdown");
+
+            releaseFirstRecovery.TrySetResult(true);
+
+            await WaitAsync(secondRecoveryFinished, "second connection recovery");
             Assert.True(_conn.IsOpen);
         }
 


### PR DESCRIPTION
## Proposed Changes

I have found a race-condition in the connection recovery loop which could lead to connection being never recovered. It happens as a race condition of a few factors:
- we don't start a new recovery task if there is an existing one
- we reset existing recovery task handle some time after the connection was open, adding an unsafe gap
- we run user callbacks after we re-open connection and before we reset the existing recovery task handle, so race-condition window could be large

If newly re-opened connection shortly closes before we reset the handle, we effectively miss it and never recover the connection again.

I fixed it by adding a flag, so we could signal to the existing recovery that a new recovery request has arrived. After long time of playing with lock-free I ended up having a lock, as code is much simpler this way and it's not a hot path anyway. Lock-free is hard as we have to synchronize both `recoveryTask` and `recoveryPendingRequest` in a right way and it becomes tricky. Lock is trivial.

I also did a bit of robustness enhancements:
- cancel recovery token unconditionally, as race could happen between running this loop and a new recovery request coming in the meanwhile
- capture cancellation token early in the method and check for the disposal flag, as disposal loop without closing the connection could lead to _potentially_ infinite recovery loop (token not cancelled, `success = false` always)

Added a unit test which demonstrates the issue (and fails before the fix).

Related issue: #1871 (not marking as a fix as there could be a different root-cause).

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ч] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CLA (see https://github.com/rabbitmq/cla)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
