### PR TITLE
Fix potential deadlocks in connection shutdown sequence

### DIFF
--- a/docs/internal/connection-shutdown-and-cancellation.md
+++ b/docs/internal/connection-shutdown-and-cancellation.md
@@ -8,7 +8,7 @@ Every connection has a hidden channel/session pair on channel number 0 (`_channe
 
 The single most important and least obvious fact about shutdown:
 
-> **Session 0 does not subscribe to `Connection.ConnectionShutdownAsync`.**
+> **Session 0 does not subscribe to either connection-shutdown event.**
 
 See `SessionBase` construction:
 
@@ -20,13 +20,15 @@ protected SessionBase(Connection connection, ushort channelNumber)
     ChannelNumber = channelNumber;
     if (channelNumber != 0)
     {
-        connection.ConnectionShutdownAsync += OnConnectionShutdownAsync;
+        connection.PreConnectionShutdownAsync += OnConnectionShutdownAsync;
     }
     ...
 }
 ```
 
-Application channels (channel number != 0) are shut down automatically when the connection shuts down, because their session is wired to `ConnectionShutdownAsync`. That event handler chain ends in `Channel.OnSessionShutdownAsync -> OnChannelShutdownAsync -> _continuationQueue.HandleChannelShutdown(reason)`, which faults any pending RPC continuation with an `OperationInterruptedException`.
+Application channels (channel number != 0) are shut down automatically when the connection shuts down, because their session is wired to `PreConnectionShutdownAsync`. That event handler chain ends in `Channel.OnSessionShutdownAsync -> OnChannelShutdownAsync -> _continuationQueue.HandleChannelShutdown(reason)`, which faults any pending RPC continuation with an `OperationInterruptedException`.
+
+`PreConnectionShutdownAsync` is an internal event that fires *before* the public `ConnectionShutdownAsync`: `Connection.OnShutdownAsync` awaits every pre-shutdown handler to completion, then awaits the public handlers. The ordering is load-bearing - it guarantees every application session is closed before `AutorecoveringConnection.HandleConnectionShutdownAsync` (a public handler) starts automatic recovery. The subscribe in the `SessionBase` constructor and the unsubscribe in `OnSessionShutdownAsync` must target the same event; a mismatch leaks every closed session's handler onto the connection for its lifetime and re-fires session shutdown when the connection later closes.
 
 Channel 0 has **no such wiring**. Its only shutdown path is `Connection.FinishCloseAsync`:
 

--- a/projects/RabbitMQ.Client/Impl/Connection.cs
+++ b/projects/RabbitMQ.Client/Impl/Connection.cs
@@ -75,8 +75,8 @@ namespace RabbitMQ.Client.Impl
             _connectionUnblockedAsyncWrapper =
                 new AsyncEventingWrapper<AsyncEventArgs>("OnConnectionUnblocked", onExceptionAsync);
 
-            _connectionShutdown0AsyncWrapper =
-                new AsyncEventingWrapper<ShutdownEventArgs>("OnShutdown0", onExceptionAsync);
+            _preConnectionShutdownAsyncWrapper =
+                new AsyncEventingWrapper<ShutdownEventArgs>("OnPreShutdown", onExceptionAsync);
 
             _connectionShutdownAsyncWrapper =
                 new AsyncEventingWrapper<ShutdownEventArgs>("OnShutdown", onExceptionAsync);
@@ -161,54 +161,51 @@ namespace RabbitMQ.Client.Impl
         private AsyncEventingWrapper<RecoveringConsumerEventArgs> _consumerAboutToBeRecoveredAsyncWrapper;
 
         /// <summary>
-        /// Like <see cref="ConnectionShutdownAsync"/>, but handlers are executed before it.
-        /// Is used to prioritize internal handlers.
+        /// Like <see cref="ConnectionShutdownAsync"/>, but its handlers run first, before the
+        /// public <see cref="ConnectionShutdownAsync"/> handlers (see <c>OnShutdownAsync</c>).
+        /// Used to let internal handlers (notably per-channel <see cref="SessionBase"/> teardown)
+        /// clear their state before application code and automatic recovery observe the shutdown.
         /// </summary>
-        internal event AsyncEventHandler<ShutdownEventArgs> ConnectionShutdown0Async
+        internal event AsyncEventHandler<ShutdownEventArgs> PreConnectionShutdownAsync
         {
-            add
-            {
-                ThrowIfDisposed();
-                ShutdownEventArgs? reason = CloseReason;
-                if (reason is null)
-                {
-                    _connectionShutdown0AsyncWrapper.AddHandler(value);
-                }
-                else
-                {
-                    value(this, reason);
-                }
-            }
-            remove
-            {
-                ThrowIfDisposed();
-                _connectionShutdown0AsyncWrapper.RemoveHandler(value);
-            }
+            add => AddConnectionShutdownHandler(ref _preConnectionShutdownAsyncWrapper, value);
+            remove => RemoveConnectionShutdownHandler(ref _preConnectionShutdownAsyncWrapper, value);
         }
-        private AsyncEventingWrapper<ShutdownEventArgs> _connectionShutdown0AsyncWrapper;
+        private AsyncEventingWrapper<ShutdownEventArgs> _preConnectionShutdownAsyncWrapper;
 
         public event AsyncEventHandler<ShutdownEventArgs> ConnectionShutdownAsync
         {
-            add
-            {
-                ThrowIfDisposed();
-                ShutdownEventArgs? reason = CloseReason;
-                if (reason is null)
-                {
-                    _connectionShutdownAsyncWrapper.AddHandler(value);
-                }
-                else
-                {
-                    value(this, reason);
-                }
-            }
-            remove
-            {
-                ThrowIfDisposed();
-                _connectionShutdownAsyncWrapper.RemoveHandler(value);
-            }
+            add => AddConnectionShutdownHandler(ref _connectionShutdownAsyncWrapper, value);
+            remove => RemoveConnectionShutdownHandler(ref _connectionShutdownAsyncWrapper, value);
         }
         private AsyncEventingWrapper<ShutdownEventArgs> _connectionShutdownAsyncWrapper;
+
+        /// <summary>
+        /// Shared add logic for the connection-shutdown events. If the connection is already
+        /// closed, the handler is invoked immediately with the existing close reason; otherwise
+        /// it is registered on <paramref name="wrapper"/>.
+        /// </summary>
+        private void AddConnectionShutdownHandler(ref AsyncEventingWrapper<ShutdownEventArgs> wrapper,
+            AsyncEventHandler<ShutdownEventArgs> value)
+        {
+            ThrowIfDisposed();
+            ShutdownEventArgs? reason = CloseReason;
+            if (reason is null)
+            {
+                wrapper.AddHandler(value);
+            }
+            else
+            {
+                value(this, reason);
+            }
+        }
+
+        private void RemoveConnectionShutdownHandler(ref AsyncEventingWrapper<ShutdownEventArgs> wrapper,
+            AsyncEventHandler<ShutdownEventArgs> value)
+        {
+            ThrowIfDisposed();
+            wrapper.RemoveHandler(value);
+        }
 
         /// <summary>
         /// This event is never fired by non-recovering connections but it is a part of the <see cref="IConnection"/> interface.
@@ -251,7 +248,7 @@ namespace RabbitMQ.Client.Impl
             _callbackExceptionAsyncWrapper.Takeover(other._callbackExceptionAsyncWrapper);
             _connectionBlockedAsyncWrapper.Takeover(other._connectionBlockedAsyncWrapper);
             _connectionUnblockedAsyncWrapper.Takeover(other._connectionUnblockedAsyncWrapper);
-            _connectionShutdown0AsyncWrapper.Takeover(other._connectionShutdown0AsyncWrapper);
+            _preConnectionShutdownAsyncWrapper.Takeover(other._preConnectionShutdownAsyncWrapper);
             _connectionShutdownAsyncWrapper.Takeover(other._connectionShutdownAsyncWrapper);
             _consumerAboutToBeRecoveredAsyncWrapper.Takeover(other._consumerAboutToBeRecoveredAsyncWrapper);
         }
@@ -268,7 +265,7 @@ namespace RabbitMQ.Client.Impl
                  *
                  * MainLoop is what ultimately runs FinishCloseAsync, which is the only
                  * code path that shuts down channel 0 (session 0 does not subscribe to
-                 * ConnectionShutdownAsync). If we allowed cancellation to be observed
+                 * the connection-shutdown events). If we allowed cancellation to be observed
                  * before starting MainLoop, the failed-open cleanup would dispose an
                  * already-open channel 0, whose abort would then hang for the full
                  * ContinuationTimeout awaiting a channel.close-ok that can never arrive.
@@ -551,7 +548,14 @@ namespace RabbitMQ.Client.Impl
         private async Task OnShutdownAsync(ShutdownEventArgs reason)
         {
             ThrowIfDisposed();
-            await _connectionShutdown0AsyncWrapper.InvokeAsync(this, reason).ConfigureAwait(false);
+
+            // Invariant: pre-shutdown handlers run to completion before any public
+            // ConnectionShutdownAsync handler. Per-channel SessionBase teardown subscribes to
+            // PreConnectionShutdownAsync so every session is closed before application code and
+            // AutorecoveringConnection.HandleConnectionShutdownAsync (a public handler) observe
+            // the shutdown and start recovery. The two sequential awaits are what enforce the
+            // ordering; do not merge them into a single event.
+            await _preConnectionShutdownAsyncWrapper.InvokeAsync(this, reason).ConfigureAwait(false);
             await _connectionShutdownAsyncWrapper.InvokeAsync(this, reason).ConfigureAwait(false);
         }
 

--- a/projects/RabbitMQ.Client/Impl/Connection.cs
+++ b/projects/RabbitMQ.Client/Impl/Connection.cs
@@ -75,6 +75,9 @@ namespace RabbitMQ.Client.Impl
             _connectionUnblockedAsyncWrapper =
                 new AsyncEventingWrapper<AsyncEventArgs>("OnConnectionUnblocked", onExceptionAsync);
 
+            _connectionShutdown0AsyncWrapper =
+                new AsyncEventingWrapper<ShutdownEventArgs>("OnShutdown0", onExceptionAsync);
+
             _connectionShutdownAsyncWrapper =
                 new AsyncEventingWrapper<ShutdownEventArgs>("OnShutdown", onExceptionAsync);
 
@@ -157,6 +160,33 @@ namespace RabbitMQ.Client.Impl
         }
         private AsyncEventingWrapper<RecoveringConsumerEventArgs> _consumerAboutToBeRecoveredAsyncWrapper;
 
+        /// <summary>
+        /// Like <see cref="ConnectionShutdownAsync"/>, but handlers are executed before it.
+        /// Is used to prioritize internal handlers.
+        /// </summary>
+        internal event AsyncEventHandler<ShutdownEventArgs> ConnectionShutdown0Async
+        {
+            add
+            {
+                ThrowIfDisposed();
+                ShutdownEventArgs? reason = CloseReason;
+                if (reason is null)
+                {
+                    _connectionShutdown0AsyncWrapper.AddHandler(value);
+                }
+                else
+                {
+                    value(this, reason);
+                }
+            }
+            remove
+            {
+                ThrowIfDisposed();
+                _connectionShutdown0AsyncWrapper.RemoveHandler(value);
+            }
+        }
+        private AsyncEventingWrapper<ShutdownEventArgs> _connectionShutdown0AsyncWrapper;
+
         public event AsyncEventHandler<ShutdownEventArgs> ConnectionShutdownAsync
         {
             add
@@ -221,6 +251,7 @@ namespace RabbitMQ.Client.Impl
             _callbackExceptionAsyncWrapper.Takeover(other._callbackExceptionAsyncWrapper);
             _connectionBlockedAsyncWrapper.Takeover(other._connectionBlockedAsyncWrapper);
             _connectionUnblockedAsyncWrapper.Takeover(other._connectionUnblockedAsyncWrapper);
+            _connectionShutdown0AsyncWrapper.Takeover(other._connectionShutdown0AsyncWrapper);
             _connectionShutdownAsyncWrapper.Takeover(other._connectionShutdownAsyncWrapper);
             _consumerAboutToBeRecoveredAsyncWrapper.Takeover(other._consumerAboutToBeRecoveredAsyncWrapper);
         }
@@ -517,10 +548,11 @@ namespace RabbitMQ.Client.Impl
         }
 
         ///<summary>Broadcasts notification of the final shutdown of the connection.</summary>
-        private Task OnShutdownAsync(ShutdownEventArgs reason)
+        private async Task OnShutdownAsync(ShutdownEventArgs reason)
         {
             ThrowIfDisposed();
-            return _connectionShutdownAsyncWrapper.InvokeAsync(this, reason);
+            await _connectionShutdown0AsyncWrapper.InvokeAsync(this, reason).ConfigureAwait(false);
+            await _connectionShutdownAsyncWrapper.InvokeAsync(this, reason).ConfigureAwait(false);
         }
 
         private bool SetCloseReason(ShutdownEventArgs reason)

--- a/projects/RabbitMQ.Client/Impl/SessionBase.cs
+++ b/projects/RabbitMQ.Client/Impl/SessionBase.cs
@@ -54,9 +54,10 @@ namespace RabbitMQ.Client.Impl
             ChannelNumber = channelNumber;
             if (channelNumber != 0)
             {
-                // Subscribe before other event handlers to make sure that session is cleared
-                // before we raise connection closed event.
-                connection.ConnectionShutdown0Async += OnConnectionShutdownAsync;
+                // Subscribe to the pre-shutdown event so the session is cleared before the public
+                // ConnectionShutdownAsync handlers run (see Connection.OnShutdownAsync). This must
+                // be paired with the matching unsubscribe in OnSessionShutdownAsync.
+                connection.PreConnectionShutdownAsync += OnConnectionShutdownAsync;
             }
             RabbitMqClientEventSource.Log.ChannelOpened();
         }
@@ -183,7 +184,7 @@ namespace RabbitMQ.Client.Impl
 
         private Task OnSessionShutdownAsync(ShutdownEventArgs reason)
         {
-            Connection.ConnectionShutdownAsync -= OnConnectionShutdownAsync;
+            Connection.PreConnectionShutdownAsync -= OnConnectionShutdownAsync;
             return _sessionShutdownAsyncWrapper.InvokeAsync(this, reason);
         }
 

--- a/projects/RabbitMQ.Client/Impl/SessionBase.cs
+++ b/projects/RabbitMQ.Client/Impl/SessionBase.cs
@@ -54,7 +54,9 @@ namespace RabbitMQ.Client.Impl
             ChannelNumber = channelNumber;
             if (channelNumber != 0)
             {
-                connection.ConnectionShutdownAsync += OnConnectionShutdownAsync;
+                // Subscribe before other event handlers to make sure that session is cleared
+                // before we raise connection closed event.
+                connection.ConnectionShutdown0Async += OnConnectionShutdownAsync;
             }
             RabbitMqClientEventSource.Log.ChannelOpened();
         }

--- a/projects/Test/Integration/GH/ConsumeOkSwallowingProxy.cs
+++ b/projects/Test/Integration/GH/ConsumeOkSwallowingProxy.cs
@@ -1,0 +1,183 @@
+// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2026 Broadcom. All Rights Reserved.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       https://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v2.0:
+//
+//---------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//  Copyright (c) 2007-2026 Broadcom. All Rights Reserved.
+//---------------------------------------------------------------------------
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Test.Integration.GH
+{
+    /// <summary>
+    /// A minimal in-process TCP proxy that forwards bytes between a client and an upstream
+    /// broker, and, the first time the broker answers a consume, swallows that
+    /// <c>Basic.ConsumeOk</c> frame and drops the connection instead. This guarantees a
+    /// <c>Basic.Consume</c> RPC is still outstanding at the instant the socket dies, which is
+    /// what makes the shutdown-ordering deadlock in GH-2005 deterministic rather than
+    /// timing-dependent. Ported from the reproducer attached to that issue.
+    /// </summary>
+    public sealed class ConsumeOkSwallowingProxy : IDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly string _upstreamHost;
+        private readonly int _upstreamPort;
+        private readonly Action<string> _log;
+        private readonly List<TcpClient> _sockets = new();
+        private int _armed = 1;
+
+        public ConsumeOkSwallowingProxy(string upstreamHost, int upstreamPort, Action<string> log)
+        {
+            _upstreamHost = upstreamHost;
+            _upstreamPort = upstreamPort;
+            _log = log;
+            _listener = new TcpListener(IPAddress.Loopback, 0);
+        }
+
+        /// <summary>The loopback port the proxy is listening on. Valid after <see cref="Start"/>.</summary>
+        public int ListenPort { get; private set; }
+
+        public void Start()
+        {
+            _listener.Start();
+            ListenPort = ((IPEndPoint)_listener.LocalEndpoint).Port;
+            _ = Task.Run(AcceptLoopAsync);
+        }
+
+        private async Task AcceptLoopAsync()
+        {
+            while (true)
+            {
+                TcpClient client;
+                try
+                {
+                    client = await _listener.AcceptTcpClientAsync();
+                }
+                catch
+                {
+                    return;
+                }
+
+                var server = new TcpClient();
+                await server.ConnectAsync(_upstreamHost, _upstreamPort);
+                lock (_sockets)
+                {
+                    _sockets.Add(client);
+                    _sockets.Add(server);
+                }
+
+                _ = PumpAsync(client, server, inspect: false);
+                _ = PumpAsync(server, client, inspect: true);
+            }
+        }
+
+        private async Task PumpAsync(TcpClient from, TcpClient to, bool inspect)
+        {
+            var buffer = new byte[16 * 1024];
+            var pending = new List<byte>(64 * 1024);
+            try
+            {
+                while (true)
+                {
+                    int read = await from.GetStream().ReadAsync(buffer);
+                    if (read == 0)
+                    {
+                        break;
+                    }
+
+                    if (!inspect)
+                    {
+                        await to.GetStream().WriteAsync(buffer.AsMemory(0, read));
+                        continue;
+                    }
+
+                    // Broker -> client: parse AMQP frames so Basic.ConsumeOk can be spotted.
+                    pending.AddRange(buffer.AsSpan(0, read).ToArray());
+                    while (pending.Count >= 7)
+                    {
+                        int size = (int)BinaryPrimitives.ReadUInt32BigEndian(pending.GetRange(3, 4).ToArray());
+                        int frameLength = 7 + size + 1;
+                        if (pending.Count < frameLength)
+                        {
+                            break;
+                        }
+
+                        byte[] frame = pending.GetRange(0, frameLength).ToArray();
+                        pending.RemoveRange(0, frameLength);
+
+                        bool isBasicConsumeOk = frame[0] == 1 && size >= 4
+                            && BinaryPrimitives.ReadUInt16BigEndian(frame.AsSpan(7, 2)) == 60    // class Basic
+                            && BinaryPrimitives.ReadUInt16BigEndian(frame.AsSpan(9, 2)) == 21;   // method ConsumeOk
+
+                        if (isBasicConsumeOk && Interlocked.Exchange(ref _armed, 0) == 1)
+                        {
+                            _log("proxy: broker answered Basic.ConsumeOk - swallowing it and killing the connection");
+                            Kill();
+                            return;
+                        }
+
+                        await to.GetStream().WriteAsync(frame);
+                    }
+                }
+            }
+            catch
+            {
+            }
+            finally
+            {
+                try { to.Close(); } catch { }
+            }
+        }
+
+        private void Kill()
+        {
+            lock (_sockets)
+            {
+                foreach (TcpClient socket in _sockets)
+                {
+                    try { socket.Close(); } catch { }
+                }
+
+                _sockets.Clear();
+            }
+        }
+
+        public void Dispose()
+        {
+            Kill();
+            try { _listener.Stop(); } catch { }
+        }
+    }
+}

--- a/projects/Test/Integration/GH/ConsumeOkSwallowingProxy.cs
+++ b/projects/Test/Integration/GH/ConsumeOkSwallowingProxy.cs
@@ -111,7 +111,9 @@ namespace Test.Integration.GH
             {
                 while (true)
                 {
-                    int read = await from.GetStream().ReadAsync(buffer);
+                    // Use the (byte[], int, int) overloads: the Memory<byte>-based Stream
+                    // overloads do not exist on net472, which this project also targets.
+                    int read = await from.GetStream().ReadAsync(buffer, 0, buffer.Length);
                     if (read == 0)
                     {
                         break;
@@ -119,7 +121,7 @@ namespace Test.Integration.GH
 
                     if (!inspect)
                     {
-                        await to.GetStream().WriteAsync(buffer.AsMemory(0, read));
+                        await to.GetStream().WriteAsync(buffer, 0, read);
                         continue;
                     }
 
@@ -148,7 +150,7 @@ namespace Test.Integration.GH
                             return;
                         }
 
-                        await to.GetStream().WriteAsync(frame);
+                        await to.GetStream().WriteAsync(frame, 0, frame.Length);
                     }
                 }
             }

--- a/projects/Test/Integration/GH/TestGitHubIssues.cs
+++ b/projects/Test/Integration/GH/TestGitHubIssues.cs
@@ -377,5 +377,102 @@ namespace Test.Integration.GH
                 }
             }
         }
+
+        [Fact]
+        public async Task TestConnectionShutdownHandlerAheadOfSessionDoesNotDeadlock_GH2005()
+        {
+            /*
+             * rabbitmq/rabbitmq-dotnet-client#2005
+             *
+             * An application subscribes to ConnectionShutdownAsync when it creates the connection
+             * - before any channel exists, so its handler sits ahead of every SessionBase in the
+             * shutdown invocation list - and that handler takes a lock which is also held across
+             * an RPC. When the socket dies while a Basic.Consume is outstanding, the two used to
+             * deadlock: the shutdown walk ran the application handler first, it blocked on the
+             * lock, the lock holder was awaiting the consume, and only the session handler (later
+             * in the list) could fault that consume - but the walk never reached it.
+             *
+             * The fix runs session teardown on the internal PreConnectionShutdownAsync event,
+             * which Connection.OnShutdownAsync awaits to completion before the public
+             * ConnectionShutdownAsync handlers. The session faults the outstanding consume first,
+             * releasing the lock, so the application handler completes.
+             *
+             * ConsumeOkSwallowingProxy makes this deterministic: it drops the connection the
+             * instant the broker answers the consume, so the consume RPC is always outstanding
+             * when the shutdown handlers run. Automatic recovery is disabled to keep the test
+             * focused on the first-disconnect ordering and to avoid a recovery loop against the
+             * killed proxy. A deadlock manifests as this test timing out on the awaits below.
+             */
+            Assert.Null(_connFactory);
+            Assert.Null(_conn);
+            Assert.Null(_channel);
+
+            using var proxy = new ConsumeOkSwallowingProxy("localhost", 5672, s => _output.WriteLine(s));
+            proxy.Start();
+
+            _connFactory = CreateConnectionFactory();
+            _connFactory.AutomaticRecoveryEnabled = false;
+            _connFactory.HostName = "localhost";
+            _connFactory.Port = proxy.ListenPort;
+
+            _conn = await _connFactory.CreateConnectionAsync();
+
+            var registryLock = new SemaphoreSlim(1, 1);
+            var shutdownHandlerReturned = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            // Subscribed before any channel exists, so (in the single-event world this fixes) it
+            // is ahead of every session. It takes the same lock the consume caller holds.
+            _conn.ConnectionShutdownAsync += async (_, _) =>
+            {
+                await registryLock.WaitAsync();
+                try
+                {
+                    // The cleanup an application would do here; the point is that it needs the lock.
+                }
+                finally
+                {
+                    registryLock.Release();
+                }
+
+                shutdownHandlerReturned.TrySetResult(true);
+            };
+
+            _channel = await _conn.CreateChannelAsync();
+            QueueDeclareOk q = await _channel.QueueDeclareAsync(string.Empty, durable: true,
+                exclusive: false, autoDelete: false);
+
+            // Not awaited: the proxy drops the connection the moment the broker answers, so this
+            // consume stays outstanding while the shutdown handlers run.
+            Task consuming = ConsumeHoldingLockAsync(_channel, q.QueueName, registryLock);
+
+            // If the ordering invariant holds, the outstanding consume is faulted by session
+            // shutdown (so it completes) and the application handler acquires the lock and returns.
+            // Either await hanging for WaitSpan is the deadlock signal.
+            try
+            {
+                await consuming.WaitAsync(WaitSpan);
+                Assert.Fail("expected the outstanding consume to be faulted by connection shutdown");
+            }
+            catch (OperationInterruptedException)
+            {
+                // expected: the in-flight consume RPC is faulted when the session shuts down
+            }
+
+            await shutdownHandlerReturned.Task.WaitAsync(WaitSpan);
+        }
+
+        private static async Task ConsumeHoldingLockAsync(IChannel channel, string queue, SemaphoreSlim registryLock)
+        {
+            await registryLock.WaitAsync();
+            try
+            {
+                await channel.BasicConsumeAsync(queue, autoAck: false,
+                    consumer: new AsyncEventingBasicConsumer(channel));
+            }
+            finally
+            {
+                registryLock.Release();
+            }
+        }
     }
 }

--- a/projects/Test/Integration/TestConnectionShutdown.cs
+++ b/projects/Test/Integration/TestConnectionShutdown.cs
@@ -402,6 +402,58 @@ namespace Test.Integration
             await _channel.DisposeAsync();
         }
 
+        [Fact]
+        public async Task TestChannelShutdownFiresOnceWhenChannelClosedBeforeConnection_GH2005()
+        {
+            /*
+             * rabbitmq/rabbitmq-dotnet-client#2005
+             *
+             * A channel's SessionBase subscribes to Connection.PreConnectionShutdownAsync in
+             * its constructor and must unsubscribe in OnSessionShutdownAsync when the channel
+             * closes. A regression subscribed to PreConnectionShutdownAsync but unsubscribed
+             * from the public ConnectionShutdownAsync, so the unsubscribe was a no-op: a channel
+             * closed while its connection stayed open leaked its session handler onto the
+             * connection, and that handler re-fired the channel's shutdown when the connection
+             * later closed.
+             *
+             * A non-recovering connection is used so the channel's ChannelShutdownAsync maps
+             * directly to the underlying session shutdown, with no recovery wrapper in between.
+             * The connection close broadcasts PreConnectionShutdownAsync synchronously (awaited)
+             * inside CloseAsync, so any second fire has already happened once CloseAsync returns.
+             */
+            ConnectionFactory cf = CreateConnectionFactory();
+            cf.AutomaticRecoveryEnabled = false;
+
+            IConnection conn = await CreateConnectionAsyncWithRetries(cf);
+            try
+            {
+                IChannel channel = await conn.CreateChannelAsync();
+
+                int shutdownCount = 0;
+                var firstShutdownTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                channel.ChannelShutdownAsync += (_, _) =>
+                {
+                    Interlocked.Increment(ref shutdownCount);
+                    firstShutdownTcs.TrySetResult(true);
+                    return Task.CompletedTask;
+                };
+
+                // Close the channel while the connection stays open. This fires the channel
+                // shutdown once and must unsubscribe the session from PreConnectionShutdownAsync.
+                await channel.CloseAsync();
+                await WaitAsync(firstShutdownTcs, "channel shutdown");
+                Assert.Equal(1, Volatile.Read(ref shutdownCount));
+
+                // Closing the connection must not re-fire the already-closed channel's shutdown.
+                await conn.CloseAsync();
+                Assert.Equal(1, Volatile.Read(ref shutdownCount));
+            }
+            finally
+            {
+                await conn.DisposeAsync();
+            }
+        }
+
         private async Task WaitAllAsync(TaskCompletionSource<bool> tcs, ValueTask frameHandlerCloseTask)
         {
             await WaitAsync(tcs, _waitSpan, "channel shutdown");


### PR DESCRIPTION
## Proposed Changes

### Current design

I'll first start with describing existing library design, so it's more visible what are the issues with the existing behavior.

1. First we create `Connection` which maintains events, in particular `ConnectionShutdownAsync`
2. External consumers and libraries (`EastyNetQ` in particular) are wrapping those object and subscribing to the event to perform lifecycle management. Subscriber is added as a first thing after connection is created (as consumption happens dynamically later).
3. Later we create sessions/channels. Each `SessionBase` subscribes to the `Connection.ConnectionShutdownAsync` to maintain its lifecycle.

With such a design the external subscribers of the `Connection.ConnectionShutdownAsync` are invoked __before__ `SessionBase` (which are subscribing later as we start consuming). There are a few issues with such design:
- Sessions/Channels are not fully closed yet, so external library will deal with half-updated state
- External libraries could introduce substantial delay before sessions are updated
- When external libraries (`EasyNetQ` in particluar) add locking to their handlers, it quickly leads to dead-lock when using connection auto-recovery.
- There is no way for external libraries to subscribe _after_ RabbitMQ is fully uninitialized, so e.g. unsubscribing is behaving correctly.

### Deadlock scenario

I used AI generated project to reproduce how a glitch in the connection reliably leads to a dead-lock: 
[rmq7-deadlock-repro.zip](https://github.com/user-attachments/files/31424647/rmq7-deadlock-repro.zip)

Design is very simple. Create `ConsumerRegistry` which works with RabbitMQ under the lock (to make sure that things are tracked correctly and are in sync). It emulates what `EasyNetQ` library is doing:

<details><summary>ConsumerRegistry</summary>

```c#
sealed class ConsumerRegistry
{
    public async Task StartConsumingAsync(IChannel channel, string queue)
    {
        await _sync.WaitAsync();
        try
        {
            _consumerTags[queue] = await channel.BasicConsumeAsync(queue, autoAck: false, consumer: new AsyncEventingBasicConsumer(channel));
        }
        finally
        {
            _sync.Release();
        }
    }

    public async Task OnConnectionShutdownAsync(object? sender, ShutdownEventArgs e)
    {
        await _sync.WaitAsync();
        try
        {

            _consumerTags.Clear();
        }
        finally
        {
            _sync.Release();
        }
    }
}
```
</details> 

Then just wire it up and use it:

```c#
var registry = new ConsumerRegistry(Log);

// An application that tracks its own consumers subscribes here
connection.ConnectionShutdownAsync += registry.OnConnectionShutdownAsync;

var channel = await connection.CreateChannelAsync();
await channel.QueueDeclareAsync(Queue, durable: false, exclusive: false, autoDelete: true);

var consuming = registry.StartConsumingAsync(channel, Queue);
```

If there is a network glitch inside the consuming request, you will get a reliable dead-lock. 

Thread A

```
ConsumerRegistry.StartConsumingAsync(IChannel, string)                           // holds the semaphore
  RabbitMQ.Client.Impl.AutorecoveringChannel.BasicConsumeAsync(...)
    RabbitMQ.Client.Impl.Channel.BasicConsumeAsync(...)
      await BasicConsumeAsyncRpcContinuation  ->  Task<string>                   // <-- parked here
```

Thread B

```
RabbitMQ.Client.Framing.Connection.MainLoop()
  RabbitMQ.Client.Framing.Connection.HandleMainLoopExceptionAsync(ShutdownEventArgs)
    RabbitMQ.Client.Impl.AsyncEventingWrapper<ShutdownEventArgs>.InternalInvoke(Delegate[], object, ShutdownEventArgs)
      ConsumerRegistry.OnConnectionShutdownAsync(object, ShutdownEventArgs)      // application handler
        System.Threading.SemaphoreSlim.WaitAsync()                               // <-- parked here, waits for semaphore
```

What happens here is that `StartConsumingAsync` is making a request and awaits a confirmation from the server. That confirmation could arrive in the main loop only, but instead of confirmation we got connection exception. Usually RabbitMQ would handle that in `SessionBase` handler (propagating it further down) by failing any outgoing requests - but in our case the `Connection.ConnectionShutdownAsync` is invoked too early. So we are in a dead-lock situation.

There are more complex variations of this happening (e.g. ones involving auto-recovery and re-connection on auto-recovery events), but root-cause is still the same - pending `Channel` operations fired from another thread never return when main loop is blocked.

This issue actively happens with EasyNetQ and it's a hell to figure out what is going on.

If RabbitMQ consumed shutdown in `SessionBase` events _before_ publishing `Connection.ConnectionShutdownAsync` - the dead-lock would not happen, as session/channel would be correctly cancelled by the time external consumers are called.

### Design

One would say that the scenario I demonstrated above is not caused by the library, but is a misuse of the library. You could push back on that. But I would argue that the issue is in the library design:
- The usage with locking is legit and is most likely needed to synchronize with library, especially when there are a lot of concurrent operations. If we start running everything in a background thread, the state would be less deterministic and way harder to synchronize upon.
- It's not expected that library is in a half-closed state when `Connection.ConnectionShutdownAsync` is fired. Usually the semantic of the event is that thing _already happened_, not _is happening_. That's true for the other events.
- There is nothing dictating that sessions/channels shall be disposed after the event is raised. It's a side-effect of the design when we use the same event which external subscribers subscribe to. If we just had a loop disposing channels, it would happen correctly.
- There is no technical possibility to subscribe later at a reliable moment of time when things are settled down. We have to just run background operation with an arbitrary window (e.g. 5 seconds) and hope that things are stable by then.

With the current design we first create connection and then sessions/channel. So the disposal order shall be reverse - first channels are disposed, then connection. And such shall be events order.

### Solution

We need a solution to fix `EasyNetQ` library and I believe that the fix shall be here. My suggestion is to simply introduce a separate internal `Connection.ConnectionShutdown0Async` event and invoke session handlers before. So this way library will dispose sessions/channels and update its state before firing an external event. This change is not breaking in terms of API and is mostly a behavior change.

The change could still be breaking if somebody relied on the event handlers order (that `Session.SessionShutdownAsync` was called _after_ `Connection.ConnectionShutdownAsync`) - but I would say that one shouldn't have relied on that. 

To me the stability of the API is worth the risk, as current design is error-prone and it's hard to reliably work around it.

We used patched RabbitMQ library in our project for a few years where we had this fix and it all was working like a charm. So we want to contribute it back, as investigating those dead-locks is hard.

### Discussion

I only made a change without adding tests - to see what your initial response is. I don't see other nice solutions and would be happy to proceed with it further. But I am totally open if you have other clever ideas or thoughts.

Would be nice to hear what you think.

Thank you 🙏 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (POTENTIALLY ???)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CLA (see https://github.com/rabbitmq/cla)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
