### PR TITLE
Skip the GH1930 scenarios when the write loop does not stall

### DIFF
--- a/projects/Test/Integration/TestToxiproxy.cs
+++ b/projects/Test/Integration/TestToxiproxy.cs
@@ -463,6 +463,29 @@ namespace Test.Integration
             Assert.True(sawContinuationTimeout);
         }
 
+        /*
+         * Both GH1930 scenarios need the client's write loop to stall, which they arrange by filling
+         * the OS socket send buffer: 512 bodies of 65 KB through a Rate=1 toxic. Whether that
+         * actually blocks depends on how much the environment buffers, and some do not block at all.
+         * Measured on WSL2 with Docker, both scenarios reported 0 of 512 publishes blocked on most
+         * runs, so the state under test was never reached; the same tests pass on the CI runners.
+         *
+         * A test that cannot reach its pre-condition has not found a defect, so say so rather than
+         * failing, and only outside CI. In CI a missing stall stays a loud failure, because there it
+         * would mean the mechanism really has changed.
+         */
+        private static void SkipIfWriteLoopDidNotStall(int blockedCount, int publishCount)
+        {
+            if (blockedCount > 128)
+            {
+                return;
+            }
+
+            Skip.IfNot(IsRunningInCI,
+                $"only {blockedCount}/{publishCount} publishes blocked, so this environment did not " +
+                "stall the write loop and the scenario under test cannot be reached here");
+        }
+
         // Regression test for https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/1930
         // Scenario A: publisher confirms disabled.
         //
@@ -548,8 +571,9 @@ namespace Test.Integration
             // exact pre-condition the test exercises. How many complete before the
             // stall depends on OS TCP send-buffer size, so we only assert the minimum.
             int blockedCount = publishTasks.Count(t => !t.IsCompleted);
+            SkipIfWriteLoopDidNotStall(blockedCount, PublishCount);
             Assert.True(blockedCount > 128,
-                $"{blockedCount}/{PublishCount} tasks are blocked before flush timeout – the write loop " +
+                $"{blockedCount}/{PublishCount} tasks are blocked before flush timeout - the write loop " +
                 $"may not have stalled. Increase PublishCount or body size.");
 
             var publishCompletionTimeout = TimeSpan.FromSeconds(15);
@@ -701,8 +725,9 @@ namespace Test.Integration
             // exact pre-condition the test exercises. How many complete before the
             // stall depends on OS TCP send-buffer size, so we only assert the minimum.
             int blockedCount = publishTasks.Count(t => !t.IsCompleted);
+            SkipIfWriteLoopDidNotStall(blockedCount, PublishCount);
             Assert.True(blockedCount > 128,
-                $"{blockedCount}/{PublishCount} tasks are blocked before flush timeout – the write loop " +
+                $"{blockedCount}/{PublishCount} tasks are blocked before flush timeout - the write loop " +
                 $"may not have stalled. Increase PublishCount or body size.");
 
             // Use a test-local timeout that is short enough to keep CI fast but long


### PR DESCRIPTION
> [!NOTE]
> This pull request was prepared by Claude (Anthropic's Claude Code) under the direction of @lukebakken, who reviewed it before filing. The measurements below were taken on @lukebakken's machine and against `main`.

## Summary

Both `TestPublishDoesNotHangAfterConnectionLoss_*_GH1930` scenarios need the client's write loop to stall, which they arrange by filling the OS socket send buffer with 512 bodies of 65 KB through a `Rate=1` toxic. Whether that blocks depends on how much the environment buffers.

On WSL2 with Docker it does not. Both scenarios report 0 of 512 publishes blocked on most runs, so the state under test is never reached and the existing guard fails the test while nothing is wrong. Measured against `main`: 3 failures in 3 runs for the confirms scenario (0/512, 17/512, 0/512 blocked) and 2 in 3 for the other. The same tests pass on the CI runners.

A test that cannot reach its pre-condition has not found a defect, so this skips with the observed count instead of failing, and only outside CI. In CI a missing stall would mean the mechanism really had changed, so it stays a loud failure there.

## Why not treat it as a flake

It is not intermittent in the usual sense: it fails consistently wherever the environment buffers enough, so retrying does not help. A local suite that is reliably red is how genuine failures start getting ignored, which is the actual cost being paid here.

## Testing

The existing assertion is unchanged, so a stall that appears and then partially regresses is still caught.

Verified both ways on a machine where the stall is absent:

- `CI` unset: 1 passed, 1 skipped, no failure.
- `CI=true`: fails with `50/512 tasks are blocked before flush timeout`, so the CI signal is preserved.

No library code is touched.
