### PR TITLE
Validate and document the process-wide OpenTelemetry tracing configuration

### DIFF
--- a/docs/internal/opentelemetry-tracing-review.md
+++ b/docs/internal/opentelemetry-tracing-review.md
@@ -12,7 +12,7 @@ The findings were split into three groups, because they carry very different ris
 |---|---|---|
 | A | Behavioural defects: ambient-span pollution, failures never recorded, untagged `tcp connection attempt`, the null-`Headers` extractor path, a wrong comment | **Fixed.** Sections below are marked `FIXED` individually. |
 | B | Semantic-convention conformance. Each one changes emitted span names or attributes, and several break existing test assertions. | Open |
-| C | Public API: per-provider tracing configuration. Must land before #1923. | Open |
+| C | Public API: per-provider tracing configuration. Must land before #1923. | **Split into two PRs, both for 7.3.0.** The validation and documentation land first; the per-connection ownership model follows once its API shape is settled. See below. |
 
 Group A was separated out precisely because none of it changes a conforming attribute value or span name, so it can ship without a downstream consumer having to re-key anything. Groups B and C build on this branch as stacked PRs.
 
@@ -41,7 +41,7 @@ An earlier version of this document described this as only "the span now starts 
 | `RabbitMQ.Client.Publisher` | `publish` | `Channel.BasicPublish.cs` |
 | `RabbitMQ.Client.Subscriber` | `fetch`, `fetch (empty)`, `deliver` | `Channel.cs` (`BasicGetAsync`), `AsyncConsumerDispatcher` |
 
-`ConnectionSourceName` is the only tracing member still in `PublicAPI.Unshipped.txt`. Everything else - `TracingOptions`, `ContextInjector`, `ContextExtractor`, `UseRoutingKeyAsOperationName`, and all of `RabbitMQTracingOptions` - shipped in 7.2.1.
+`ConnectionSourceName` is the only tracing member still in `PublicAPI.Unshipped.txt`. Everything else - `TracingOptions`, `ContextInjector`, `ContextExtractor`, `UseRoutingKeyAsOperationName`, and all of `RabbitMQTracingOptions` - shipped in 7.2.0 (2025-11-06), so they have been public across 7.2.0, 7.2.1 and 7.2.2.
 
 ## Guard pattern: the shape that matters
 
@@ -199,7 +199,56 @@ This is not a memory-safety problem. 181,425 publishes with a concurrent writer 
 
 The statics are also unvalidated, so `ContextInjector = null` makes every subsequent publish throw `NullReferenceException` from inside the client.
 
-Because these members shipped in 7.2.1, removing them is a breaking change. Adding a per-provider path alongside them is not.
+Because these members shipped in 7.2.0, removing them is a breaking change. Adding a per-provider path alongside them is not.
+
+### Resolution: split into a prerequisite and the ownership model
+
+Per-`TracerProvider` configuration turned out not to be achievable at all, which reframes the whole finding. One `ActivitySource` produces a single `Activity` shared by every listener, and one publish injects a single set of headers, so neither span shape nor propagated context can differ per provider. No amount of locking or reference counting changes that; the original framing ("per-provider configuration expressed as process-global state") asked for something the platform does not offer.
+
+The work was therefore split in two, both parts targeted at 7.3.0. Landing first is the part that is unambiguously a defect, plus honest documentation of the part that is inherent:
+
+- The three setters reject `null` with `ArgumentNullException`, so a mistake surfaces at the assignment rather than as a `NullReferenceException` thrown from inside the client on some later publish.
+- All four members, and both `RabbitMQTracingOptions` properties, now document that the configuration is process-wide, that the last writer wins, and that disposal restores nothing. `TestTracingConfiguration.ConfigurationIsProcessWideAcrossTracerProviders` characterizes it so the documentation cannot drift from the behaviour.
+- The README gained the scope explanation, the span-name table, and both options.
+
+@danielmarbach's review reframed the real fix as ownership: the configuration belongs to the connection that performs the operation. @paulomorgado independently asked for the same shape, "a process-wide static default, that could be overridden by each connection (or connection factory)". That is the right model and it follows in its own PR rather than being dropped. Two attempts at it were reverted out of this PR, and the reasons are worth recording, because they are not obvious and the next attempt will hit them again.
+
+**Attempt one** made the configuration reference-counted to `TracerProvider` lifetime. Abandoned: it was machinery protecting a premise (per-provider scope) that does not hold.
+
+**Attempt two** added `ConnectionFactory.TracingOptions`, captured per connection, with `RabbitMQTracingOptions` extended to carry the injector and extractor, and the statics kept as a live fallback. A max-effort review found this silently broken on its own documented path, confirmed against a live broker:
+
+- **Whole-object fallback loses the other layer.** Resolution was `tracing ?? s_tracingOptions`, and a fresh `RabbitMQTracingOptions` pre-seeds the *client's* built-in delegates. So `cf.TracingOptions = new RabbitMQTracingOptions { UsePublisherAsParent = false }` - a span-shaping tweak, and exactly what the new docs told users to write - switched that connection off OpenTelemetry propagation. Messages went out with `traceparent` and no `baggage` header, `Propagators.DefaultTextMapPropagator` was never consulted so a B3 or Jaeger propagator was ignored, and the deliver path stopped resetting `Baggage.Current` per message. Spans still exported, so the wiring looked correct.
+- **The same fallback made the two configuration points mutually exclusive.** Configuring a factory and then passing `configure` to the builder-only overload silently ignored the latter, because the factory's non-null instance won as a whole.
+- **A factory-scoped call stopped configuring the process.** `AddRabbitMQInstrumentation(builder, factory, ...)` no longer installed the OpenTelemetry delegates globally, so any connection the caller does not own - a second factory, or one built inside MassTransit, EasyNetQ or Rebus - quietly fell back to the built-in propagation. That is the same behaviour break that had already been rejected as unshippable in a minor release when considering repurposing the no-argument overload.
+
+The fix for all three is **per-member** fallback: each member `null` meaning "inherit the layer below", rather than one nullable options object. Where those nullable members live is the open question, and it is a compatibility decision rather than a technical one.
+
+`RabbitMQTracingOptions` shipped in 7.2.0 with non-nullable `bool` properties (`PublicAPI.Shipped.net8.0.txt` lines 870-875), so expressing "inherit" on that type means changing `bool` to `bool?`. Measured, that break is narrower than it sounds:
+
+| Usage | Under `bool?` |
+|---|---|
+| `new RabbitMQTracingOptions { UseRoutingKeyAsOperationName = true }` | compiles |
+| `options.UseRoutingKeyAsOperationName = flag;` | compiles |
+| `bool x = options.UseRoutingKeyAsOperationName;` | `CS0266` |
+| `if (options.UseRoutingKeyAsOperationName)` | `CS0266` |
+| `options.UseRoutingKeyAsOperationName && y` | `CS0019` |
+
+Writes are unaffected; only reads break at source level, and an options object is written far more often than read. Binary compatibility breaks regardless, because the getter's return type is part of its signature. Within the client only the span factories and the static shortcut read them, and `RabbitMQActivitySource.UseRoutingKeyAsOperationName` can stay `bool` by resolving `null` to the default, so that shipped member need not change.
+
+Four candidate shapes, none of them settled:
+
+1. **`bool?` on `RabbitMQTracingOptions`.** One type, one mental model, one member list. Breaking, as above.
+2. **A new options type for the per-connection layer**, leaving the shipped type as the process-wide default. Non-breaking, but two near-identical types forever, and two member lists to keep in step - the drift risk that already produced a finding against `Clone()`.
+3. **Nullable delegates only.** The delegates are unshipped, so they can be `null`-means-inherit for free, while the two bools keep whole-object semantics. Non-breaking, and it fixes the severe defect (silent propagation loss). The residual wart is real, though: a factory that sets options only to add a custom injector silently reverts both span-shaping flags to `true`, even where the process-wide default had set them `false`.
+4. **Four nullable properties directly on `ConnectionFactory`**, no options object at the connection layer at all. Non-breaking, per-member by construction, and consistent with how the factory already exposes every other knob as an individual property. Costs four more properties on an already-large type, and does not compose as neatly for capturing a snapshot.
+
+Whichever is chosen, `IConnectionFactory` is the second decision: it declares every comparable per-connection knob, adding to a public interface breaks external implementers, and `ConnectionFactory` is `sealed`.
+
+Two further constraints for that work:
+
+- Deprecating the statics before their replacement exists would leave interface-typed consumers with a `CS0618` warning and nothing to migrate to, which is why nothing is marked `[Obsolete]` yet.
+- Resolving the configuration through `Session.Connection` from the channel put an unguarded dereference on the deliver path, load-bearing only because three separate `HasListeners()` gates happen to precede it, and opened a window in the `Channel` constructor where the consumer dispatcher's `Task.Run` starts before `Session` is assigned. `CreateChannelOptions.CreateOrUpdate` already copies `ConnectionConfig` values into the channel options, so a readonly field set in the constructor removes the walk, both gates and the hazard.
+- Resolve the options **once per operation**, into a local. The publish path resolved them twice - once for the span name and again for the injector - which breaks the "callers resolve once and read all options from the returned instance" rule that the resolver's own comment states, and lets a single span take its name from one configuration and its propagated context from another if the configuration changes in between. Passing the resolved instance into the header-population helper fixes the split read and removes a second `Session.Connection` walk per traced publish.
 
 ## Exception events are on a deprecation path
 
@@ -348,7 +397,11 @@ The restore matters beyond politeness. The pre-existing parameterized tag tests 
 
 ## Documentation gap
 
-`messaging-spans.md` states that an instrumentation using the message creation context as the parent of `process` spans SHOULD document that it does so, and MAY offer a configuration option. This client does exactly that by default (`UsePublisherAsParent = true`) and the option exists, but the `RabbitMQ.Client.OpenTelemetry` README documents only SDK wiring - not the trace structure, the span names, the attributes emitted, or either option.
+`messaging-spans.md` states that an instrumentation using the message creation context as the parent of `process` spans SHOULD document that it does so, and MAY offer a configuration option. This client does exactly that by default (`UsePublisherAsParent = true`) and the option exists, but the `RabbitMQ.Client.OpenTelemetry` README documented only SDK wiring - not the trace structure, the span names, the attributes emitted, or either option.
+
+**Mostly closed** alongside the Group C validation work. The README now documents the three activity sources and their span names, both options, and the scope of the configuration. Still missing: the emitted attributes, which belong with Group B, since that is where the attribute set changes.
+
+One correction came out of writing it. Saying that `UsePublisherAsParent = false` attaches the publisher context "as a link instead" is wrong: `StartLinkedRabbitMQActivity` adds the link whenever the extracted context is non-default, in both modes, and the flag only feeds `parentContext`. So the flag drops the parent and leaves the link rather than swapping one for the other. Worth stating precisely, because this is the sentence the convention asks instrumentations to document and therefore the one a downstream consumer will quote.
 
 ## What was checked and found clean
 

--- a/projects/RabbitMQ.Client.OpenTelemetry/README.md
+++ b/projects/RabbitMQ.Client.OpenTelemetry/README.md
@@ -52,3 +52,67 @@ var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .AddConsoleExporter()
     .Build();
 ```
+
+### Options
+
+`RabbitMQTracingOptions` shapes the spans this client produces. Pass a configuration action to
+`AddRabbitMQInstrumentation`:
+
+```csharp
+var tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .AddRabbitMQInstrumentation(options =>
+    {
+        // Append the routing key to publish and delivery span names, for example
+        // "publish my.routing.key". Set this to false where a high-cardinality routing key
+        // would make span names unusable as an aggregation key. Default: true.
+        options.UseRoutingKeyAsOperationName = true;
+
+        // Parent a delivery span to the trace context the publisher propagated in the
+        // message, so a publish and the deliveries it causes form a single trace.
+        // Default: true.
+        options.UsePublisherAsParent = true;
+    })
+    .AddConsoleExporter()
+    .Build();
+```
+
+## Scope of the configuration
+
+**Tracing configuration is process-wide, not per-`TracerProvider`.** `AddRabbitMQInstrumentation`
+writes the static members of `RabbitMQActivitySource`, which every connection in the process reads.
+So when more than one `TracerProvider` configures the client, the last call wins, and disposing a
+provider does not restore what it replaced.
+
+This is a property of the model rather than an implementation shortcut: one `ActivitySource`
+produces a single `Activity` shared by every listener, and one publish injects a single set of
+headers, so neither span shape nor propagated context can differ per provider. Configuration owned
+by something narrower than the process is tracked in
+[#1981](https://github.com/rabbitmq/rabbitmq-dotnet-client/issues/1981).
+
+Two consequences worth planning around:
+
+- Call `AddRabbitMQInstrumentation` from one place. Two providers configured with different options
+  will not each get their own.
+- If you configure the client directly through `RabbitMQActivitySource`, save and restore the
+  previous values yourself if you need them back. Assigning `null` to `ContextInjector`,
+  `ContextExtractor`, or `TracingOptions` throws `ArgumentNullException`.
+
+## What is emitted
+
+Three activity sources, all subscribed by `AddRabbitMQInstrumentation` through the
+`RabbitMQ.Client.*` wildcard:
+
+| Source | Spans |
+|---|---|
+| `RabbitMQ.Client.Publisher` | `publish` |
+| `RabbitMQ.Client.Subscriber` | `deliver`, `fetch`, `fetch (empty)` |
+| `RabbitMQ.Client.Connection` | `connection attempt`, `tcp connection attempt` |
+
+Spans follow the OpenTelemetry
+[messaging semantic conventions](https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/).
+A failed operation sets the span status to `Error` along with `error.type` and an exception event.
+
+By default a delivery span is parented to the message creation context the publisher propagated.
+Whenever a context is extracted it is also attached to the delivery span as a link, in both modes,
+so `UsePublisherAsParent = false` drops the parent and leaves the link rather than swapping one for
+the other.

--- a/projects/RabbitMQ.Client/Impl/RabbitMQActivitySource.cs
+++ b/projects/RabbitMQ.Client/Impl/RabbitMQActivitySource.cs
@@ -59,18 +59,82 @@ namespace RabbitMQ.Client
         public const string SubscriberSourceName = "RabbitMQ.Client.Subscriber";
         public const string ConnectionSourceName = "RabbitMQ.Client.Connection";
 
-        public static Action<Activity, IDictionary<string, object?>> ContextInjector { get; set; } =
-            DefaultContextInjector;
+        private static Action<Activity, IDictionary<string, object?>> s_contextInjector = DefaultContextInjector;
+        private static Func<IReadOnlyBasicProperties, ActivityContext> s_contextExtractor = DefaultContextExtractor;
+        private static RabbitMQTracingOptions s_tracingOptions = new RabbitMQTracingOptions();
 
-        public static Func<IReadOnlyBasicProperties, ActivityContext> ContextExtractor { get; set; } =
-            DefaultContextExtractor;
+        /*
+         * The four members below are process-wide, and the <remarks> on each says so. That is a
+         * property of .NET's tracing model rather than a shortcut in this client, so the docs
+         * explain the consequence instead of promising a scope that cannot be delivered: one
+         * ActivitySource produces a single Activity shared by every listener, and one publish
+         * injects a single set of headers, so neither span shape nor propagation can differ per
+         * TracerProvider. Configuration owned by something narrower than the process - the
+         * connection performing the operation - is tracked separately on #1981.
+         *
+         * The setters reject null. Before that, `ContextInjector = null` left every subsequent
+         * publish throwing NullReferenceException from inside the client, far from the assignment
+         * that caused it, and `TracingOptions = null` did the same to every publish and delivery.
+         */
 
+        /// <summary>
+        /// Delegate that injects the current <see cref="Activity"/> context into a published
+        /// message's headers. Defaults to W3C trace-context propagation using
+        /// <see cref="DistributedContextPropagator.Current"/>.
+        /// </summary>
+        /// <remarks>
+        /// Process-wide: this delegate is used by every connection in the process, so the last
+        /// assignment wins and nothing restores a previous value. Assigning
+        /// <see langword="null"/> throws <see cref="ArgumentNullException"/>.
+        /// </remarks>
+        public static Action<Activity, IDictionary<string, object?>> ContextInjector
+        {
+            get => s_contextInjector;
+            set => s_contextInjector = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        /// <summary>
+        /// Delegate that extracts the upstream <see cref="ActivityContext"/> from a received
+        /// message's properties. Defaults to W3C trace-context propagation using
+        /// <see cref="DistributedContextPropagator.Current"/>.
+        /// </summary>
+        /// <remarks>
+        /// Process-wide: this delegate is used by every connection in the process, so the last
+        /// assignment wins and nothing restores a previous value. Assigning
+        /// <see langword="null"/> throws <see cref="ArgumentNullException"/>.
+        /// </remarks>
+        public static Func<IReadOnlyBasicProperties, ActivityContext> ContextExtractor
+        {
+            get => s_contextExtractor;
+            set => s_contextExtractor = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        /// <summary>
+        /// Shortcut for <see cref="RabbitMQTracingOptions.UseRoutingKeyAsOperationName"/> on
+        /// <see cref="TracingOptions"/>. Reads and writes that instance, so it is affected by
+        /// replacing it.
+        /// </summary>
         public static bool UseRoutingKeyAsOperationName
         {
             get => TracingOptions.UseRoutingKeyAsOperationName;
             set => TracingOptions.UseRoutingKeyAsOperationName = value;
         }
-        public static RabbitMQTracingOptions TracingOptions { get; set; } = new RabbitMQTracingOptions();
+
+        /// <summary>
+        /// The options applied to every tracing span this client produces.
+        /// </summary>
+        /// <remarks>
+        /// Process-wide: these options shape the spans of every connection in the process, so the
+        /// last assignment wins and disposing a <c>TracerProvider</c> that configured them restores
+        /// nothing. Assigning replaces the instance, so a reference obtained from this property
+        /// beforehand is detached and no longer affects the client when mutated. Assigning
+        /// <see langword="null"/> throws <see cref="ArgumentNullException"/>.
+        /// </remarks>
+        public static RabbitMQTracingOptions TracingOptions
+        {
+            get => s_tracingOptions;
+            set => s_tracingOptions = value ?? throw new ArgumentNullException(nameof(value));
+        }
         internal static bool PublisherHasListeners => s_publisherSource.HasListeners();
 
         /*

--- a/projects/RabbitMQ.Client/Impl/RabbitMQTracingOptions.cs
+++ b/projects/RabbitMQ.Client/Impl/RabbitMQTracingOptions.cs
@@ -1,8 +1,32 @@
-﻿namespace RabbitMQ.Client
+namespace RabbitMQ.Client
 {
+    /// <summary>
+    /// Shapes the tracing spans this client produces. Applied through
+    /// <see cref="RabbitMQActivitySource.TracingOptions"/>, which is process-wide.
+    /// </summary>
     public class RabbitMQTracingOptions
     {
+        /// <summary>
+        /// When <see langword="true"/> (the default), the routing key is appended to publish and
+        /// delivery span names, for example <c>publish my.routing.key</c>. Set it to
+        /// <see langword="false"/> where a high-cardinality routing key would make span names
+        /// unusable as an aggregation key.
+        /// </summary>
         public bool UseRoutingKeyAsOperationName { get; set; } = true;
+
+        /// <summary>
+        /// When <see langword="true"/> (the default), a delivery span is parented to the trace
+        /// context the publisher propagated in the message, so a publish and the deliveries it
+        /// causes form a single trace.
+        /// </summary>
+        /// <remarks>
+        /// Only parenting is affected. Whenever a context is successfully extracted from a message it
+        /// is attached to the delivery span as an <see cref="System.Diagnostics.ActivityLink"/> as
+        /// well, in both modes, so setting this to <see langword="false"/> does not replace a parent
+        /// with a link - it drops the parent and leaves the link. Turn it off where the publisher and
+        /// the consumer are better treated as separate traces, for example when one message fans out
+        /// to many long-running consumers.
+        /// </remarks>
         public bool UsePublisherAsParent { get; set; } = true;
     }
 }

--- a/projects/Test/Common/TracingConfigurationScope.cs
+++ b/projects/Test/Common/TracingConfigurationScope.cs
@@ -1,0 +1,93 @@
+// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2026 Broadcom. All Rights Reserved.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       https://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v2.0:
+//
+//---------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//  Copyright (c) 2007-2026 Broadcom. All Rights Reserved.
+//---------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using RabbitMQ.Client;
+
+namespace Test
+{
+    /// <summary>
+    /// Captures every process-wide tracing setting on <see cref="RabbitMQActivitySource"/> and
+    /// restores all of them on dispose.
+    /// </summary>
+    /// <remarks>
+    /// Tracing configuration is process-wide, so a test that changes any of it leaves that change in
+    /// force for whatever runs next in the same process. That has already produced order-dependent
+    /// failures in this suite, which is what this type exists to prevent - see the public-API
+    /// discussion on rabbitmq/rabbitmq-dotnet-client#1967 and #1981.
+    /// <para>
+    /// It covers all five settings on purpose. A scope that saved only the flags let a test that
+    /// installed its own propagation delegates leak them for the rest of the run, and one that saved
+    /// only the options instance missed a test that mutated the instance in place. Restoring both the
+    /// instance and the values it held covers a test that replaced the instance, mutated the original,
+    /// or did both.
+    /// </para>
+    /// </remarks>
+    public sealed class TracingConfigurationScope : IDisposable
+    {
+        private readonly RabbitMQTracingOptions _options;
+        private readonly bool _useRoutingKeyAsOperationName;
+        private readonly bool _usePublisherAsParent;
+        private readonly Action<Activity, IDictionary<string, object>> _contextInjector;
+        private readonly Func<IReadOnlyBasicProperties, ActivityContext> _contextExtractor;
+
+        public TracingConfigurationScope()
+        {
+            _options = RabbitMQActivitySource.TracingOptions;
+            _useRoutingKeyAsOperationName = _options.UseRoutingKeyAsOperationName;
+            _usePublisherAsParent = _options.UsePublisherAsParent;
+            _contextInjector = RabbitMQActivitySource.ContextInjector;
+            _contextExtractor = RabbitMQActivitySource.ContextExtractor;
+        }
+
+        /// <summary>
+        /// Sets <see cref="RabbitMQTracingOptions.UseRoutingKeyAsOperationName"/> to
+        /// <see langword="false"/>, so span names are the bare operation and assertions do not have to
+        /// account for a generated queue name.
+        /// </summary>
+        public TracingConfigurationScope WithPlainOperationNames()
+        {
+            RabbitMQActivitySource.UseRoutingKeyAsOperationName = false;
+            return this;
+        }
+
+        public void Dispose()
+        {
+            RabbitMQActivitySource.TracingOptions = _options;
+            _options.UseRoutingKeyAsOperationName = _useRoutingKeyAsOperationName;
+            _options.UsePublisherAsParent = _usePublisherAsParent;
+            RabbitMQActivitySource.ContextInjector = _contextInjector;
+            RabbitMQActivitySource.ContextExtractor = _contextExtractor;
+        }
+    }
+}

--- a/projects/Test/SequentialIntegration/TestActivitySource.cs
+++ b/projects/Test/SequentialIntegration/TestActivitySource.cs
@@ -85,7 +85,7 @@ namespace Test.SequentialIntegration
         [InlineData(false, false)]
         public async Task TestPublisherAndConsumerActivityTagsAsync(bool useRoutingKeyAsOperationName, bool usePublisherAsParent)
         {
-            using var tracingOptions = new TracingOptionsScope();
+            using var tracingOptions = new TracingConfigurationScope();
             RabbitMQActivitySource.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
             RabbitMQActivitySource.TracingOptions.UsePublisherAsParent = usePublisherAsParent;
             var activities = new List<Activity>();
@@ -124,7 +124,7 @@ namespace Test.SequentialIntegration
         [InlineData(false, false)]
         public async Task TestPublisherWithCachedStringsAndConsumerActivityTagsAsync(bool useRoutingKeyAsOperationName, bool usePublisherAsParent)
         {
-            using var tracingOptions = new TracingOptionsScope();
+            using var tracingOptions = new TracingConfigurationScope();
             RabbitMQActivitySource.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
             RabbitMQActivitySource.TracingOptions.UsePublisherAsParent = usePublisherAsParent;
             var activities = new List<Activity>();
@@ -165,7 +165,7 @@ namespace Test.SequentialIntegration
         [InlineData(false, false)]
         public async Task TestPublisherWithPublicationAddressAndConsumerActivityTagsAsync(bool useRoutingKeyAsOperationName, bool usePublisherAsParent)
         {
-            using var tracingOptions = new TracingOptionsScope();
+            using var tracingOptions = new TracingConfigurationScope();
             RabbitMQActivitySource.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
             RabbitMQActivitySource.TracingOptions.UsePublisherAsParent = usePublisherAsParent;
             var activities = new List<Activity>();
@@ -209,7 +209,7 @@ namespace Test.SequentialIntegration
         [InlineData(false, false, false)]
         public async Task TestPublisherAndBasicGetActivityTagsAsync(bool useRoutingKeyAsOperationName, bool usePublisherAsParent, bool useMessageId)
         {
-            using var tracingOptions = new TracingOptionsScope();
+            using var tracingOptions = new TracingConfigurationScope();
             RabbitMQActivitySource.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
             RabbitMQActivitySource.TracingOptions.UsePublisherAsParent = usePublisherAsParent;
             var activities = new List<Activity>();
@@ -246,7 +246,7 @@ namespace Test.SequentialIntegration
         [InlineData(false, false)]
         public async Task TestPublisherWithCachedStringsAndBasicGetActivityTagsAsync(bool useRoutingKeyAsOperationName, bool usePublisherAsParent)
         {
-            using var tracingOptions = new TracingOptionsScope();
+            using var tracingOptions = new TracingConfigurationScope();
             RabbitMQActivitySource.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
             RabbitMQActivitySource.TracingOptions.UsePublisherAsParent = usePublisherAsParent;
             var activities = new List<Activity>();
@@ -283,7 +283,7 @@ namespace Test.SequentialIntegration
         [InlineData(false, false)]
         public async Task TestPublisherWithPublicationAddressAndBasicGetActivityTagsAsync(bool useRoutingKeyAsOperationName, bool usePublisherAsParent)
         {
-            using var tracingOptions = new TracingOptionsScope();
+            using var tracingOptions = new TracingConfigurationScope();
             RabbitMQActivitySource.UseRoutingKeyAsOperationName = useRoutingKeyAsOperationName;
             RabbitMQActivitySource.TracingOptions.UsePublisherAsParent = usePublisherAsParent;
             var activities = new List<Activity>();
@@ -323,44 +323,6 @@ namespace Test.SequentialIntegration
         /// leaves process-global tracing state mutated for whatever runs next - see the
         /// public-API discussion on rabbitmq/rabbitmq-dotnet-client#1967.
         /// </remarks>
-        private sealed class PlainOperationNames : IDisposable
-        {
-            private readonly bool _previous;
-
-            public PlainOperationNames()
-            {
-                _previous = RabbitMQActivitySource.UseRoutingKeyAsOperationName;
-                RabbitMQActivitySource.UseRoutingKeyAsOperationName = false;
-            }
-
-            public void Dispose() => RabbitMQActivitySource.UseRoutingKeyAsOperationName = _previous;
-        }
-
-        /// <summary>
-        /// Captures UseRoutingKeyAsOperationName and UsePublisherAsParent on construction
-        /// and restores both on dispose. The parameterized tracing-tag tests set these
-        /// process-global options to their theory inputs; without restoring them the last
-        /// case leaves them mutated for whatever test runs next in the same process - see
-        /// the public-API discussion on rabbitmq/rabbitmq-dotnet-client#1967.
-        /// </summary>
-        private sealed class TracingOptionsScope : IDisposable
-        {
-            private readonly bool _useRoutingKeyAsOperationName;
-            private readonly bool _usePublisherAsParent;
-
-            public TracingOptionsScope()
-            {
-                _useRoutingKeyAsOperationName = RabbitMQActivitySource.UseRoutingKeyAsOperationName;
-                _usePublisherAsParent = RabbitMQActivitySource.TracingOptions.UsePublisherAsParent;
-            }
-
-            public void Dispose()
-            {
-                RabbitMQActivitySource.UseRoutingKeyAsOperationName = _useRoutingKeyAsOperationName;
-                RabbitMQActivitySource.TracingOptions.UsePublisherAsParent = _usePublisherAsParent;
-            }
-        }
-
         [Fact]
         public async Task TestPublishFailureIsRecordedOnTheSendActivity_GH1967()
         {
@@ -378,7 +340,7 @@ namespace Test.SequentialIntegration
              * PublishException surfaces from the confirmation await rather than from
              * the send itself.
              */
-            using var plainNames = new PlainOperationNames();
+            using var plainNames = new TracingConfigurationScope().WithPlainOperationNames();
 
             using ActivityRecorder publishRecorder =
                 new(RabbitMQActivitySource.PublisherSourceName, "publish");
@@ -417,7 +379,7 @@ namespace Test.SequentialIntegration
              * sequence is enough because it exercises the same core, and the failure
              * still surfaces from the confirmation await in the finally.
              */
-            using var plainNames = new PlainOperationNames();
+            using var plainNames = new TracingConfigurationScope().WithPlainOperationNames();
 
             using ActivityRecorder publishRecorder =
                 new(RabbitMQActivitySource.PublisherSourceName, "publish");
@@ -460,7 +422,7 @@ namespace Test.SequentialIntegration
              * without tracking there is no task to store the exception on, so it is
              * never handled and never resurfaces.
              */
-            using var plainNames = new PlainOperationNames();
+            using var plainNames = new TracingConfigurationScope().WithPlainOperationNames();
 
             using ActivityRecorder publishRecorder =
                 new(RabbitMQActivitySource.PublisherSourceName, "publish");
@@ -507,7 +469,7 @@ namespace Test.SequentialIntegration
              * await. That is the window the finally's cancellation guard covers; removing
              * it fails this test with an Error status on the span.
              */
-            using var plainNames = new PlainOperationNames();
+            using var plainNames = new TracingConfigurationScope().WithPlainOperationNames();
 
             using ActivityRecorder publishRecorder =
                 new(RabbitMQActivitySource.PublisherSourceName, "publish");
@@ -573,7 +535,7 @@ namespace Test.SequentialIntegration
              * span status=Unset with no exception event. A consumer failing on every
              * message traced as completely healthy.
              */
-            using var plainNames = new PlainOperationNames();
+            using var plainNames = new TracingConfigurationScope().WithPlainOperationNames();
 
             using ActivityRecorder deliverRecorder =
                 new(RabbitMQActivitySource.SubscriberSourceName, "deliver");
@@ -622,7 +584,7 @@ namespace Test.SequentialIntegration
              * AsyncEventingBasicConsumer's event wrapper swallows
              * OperationCanceledException, so it never propagates to the dispatcher.
              */
-            using var plainNames = new PlainOperationNames();
+            using var plainNames = new TracingConfigurationScope().WithPlainOperationNames();
 
             using ActivityRecorder deliverRecorder =
                 new(RabbitMQActivitySource.SubscriberSourceName, "deliver");
@@ -702,7 +664,7 @@ namespace Test.SequentialIntegration
              * The publisher source must have listeners for this to reproduce, which is
              * what the recorder here provides.
              */
-            using var plainNames = new PlainOperationNames();
+            using var plainNames = new TracingConfigurationScope().WithPlainOperationNames();
 
             using ActivityRecorder publishRecorder =
                 new(RabbitMQActivitySource.PublisherSourceName, "publish");

--- a/projects/Test/SequentialIntegration/TestTracingConfiguration.cs
+++ b/projects/Test/SequentialIntegration/TestTracingConfiguration.cs
@@ -1,0 +1,235 @@
+// This source code is dual-licensed under the Apache License, version
+// 2.0, and the Mozilla Public License, version 2.0.
+//
+// The APL v2.0:
+//
+//---------------------------------------------------------------------------
+//   Copyright (c) 2007-2026 Broadcom. All Rights Reserved.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       https://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//---------------------------------------------------------------------------
+//
+// The MPL v2.0:
+//
+//---------------------------------------------------------------------------
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+//  Copyright (c) 2007-2026 Broadcom. All Rights Reserved.
+//---------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+using RabbitMQ.Client;
+using Test;
+using Xunit;
+
+namespace Test.SequentialIntegration
+{
+    /*
+     * rabbitmq/rabbitmq-dotnet-client#1981
+     *
+     * The process-wide tracing configuration on RabbitMQActivitySource. These tests need no broker,
+     * but they mutate process-global state, so they belong here rather than in Unit: this project
+     * injects Xunit.CollectionBehavior.CollectionPerAssembly, which serializes every test class in
+     * the assembly. Unit does not, so its classes run in parallel and would race.
+     */
+    public class TestTracingConfiguration
+    {
+        private static void NoopInjector(Activity activity, IDictionary<string, object> headers)
+        {
+        }
+
+        private static ActivityContext NoopExtractor(IReadOnlyBasicProperties properties) => default;
+
+        [Fact]
+        public void AssigningNullContextInjectorThrows()
+        {
+            /*
+             * Previously these setters accepted null, and the failure surfaced as a
+             * NullReferenceException thrown from inside the client on the next publish or
+             * delivery - arbitrarily far from the assignment that caused it, and on a path the
+             * caller does not own. Throwing at the assignment puts the exception where the
+             * mistake is.
+             */
+            using var scope = new TracingConfigurationScope();
+
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(
+                () => RabbitMQActivitySource.ContextInjector = null);
+            Assert.Equal("value", ex.ParamName);
+
+            // The rejected assignment must not have damaged the existing configuration.
+            Assert.NotNull(RabbitMQActivitySource.ContextInjector);
+        }
+
+        [Fact]
+        public void AssigningNullContextExtractorThrows()
+        {
+            using var scope = new TracingConfigurationScope();
+
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(
+                () => RabbitMQActivitySource.ContextExtractor = null);
+            Assert.Equal("value", ex.ParamName);
+
+            Assert.NotNull(RabbitMQActivitySource.ContextExtractor);
+        }
+
+        [Fact]
+        public void AssigningNullTracingOptionsThrows()
+        {
+            /*
+             * TracingOptions is read on every traced publish, get and delivery, and
+             * UseRoutingKeyAsOperationName forwards to it, so a null here broke more paths than
+             * either delegate did.
+             */
+            using var scope = new TracingConfigurationScope();
+
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(
+                () => RabbitMQActivitySource.TracingOptions = null);
+            Assert.Equal("value", ex.ParamName);
+
+            Assert.NotNull(RabbitMQActivitySource.TracingOptions);
+            // Reachable only because the assignment was rejected; it would throw otherwise.
+            Assert.True(RabbitMQActivitySource.UseRoutingKeyAsOperationName ||
+                        false == RabbitMQActivitySource.UseRoutingKeyAsOperationName);
+        }
+
+        [Fact]
+        public void AssigningContextInjectorTakesEffect()
+        {
+            /*
+             * Asserts against a delegate this test owns, not against a second read of the getter:
+             * comparing two reads of one property passes even if the setter is a no-op, so it
+             * cannot fail for the reason such a test claims to check.
+             */
+            using var scope = new TracingConfigurationScope();
+
+            Action<Activity, IDictionary<string, object>> injector = NoopInjector;
+            RabbitMQActivitySource.ContextInjector = injector;
+
+            Assert.Same(injector, RabbitMQActivitySource.ContextInjector);
+        }
+
+        [Fact]
+        public void AssigningContextExtractorTakesEffect()
+        {
+            using var scope = new TracingConfigurationScope();
+
+            Func<IReadOnlyBasicProperties, ActivityContext> extractor = NoopExtractor;
+            RabbitMQActivitySource.ContextExtractor = extractor;
+
+            Assert.Same(extractor, RabbitMQActivitySource.ContextExtractor);
+        }
+
+        [Fact]
+        public void AssigningTracingOptionsAdoptsTheInstance()
+        {
+            /*
+             * Pins reference-swap semantics: the property holds the instance it was given, so a
+             * caller that keeps a reference can still mutate the live configuration through it.
+             * Code written against 7.2.x relies on this, and an implementation that copied values
+             * out of the instance instead would break two things at once - the held reference would
+             * silently stop working, and save-then-restore would become a no-op, because the getter
+             * would hand back the same singleton the setter had copied into.
+             */
+            using var scope = new TracingConfigurationScope();
+
+            var options = new RabbitMQTracingOptions { UseRoutingKeyAsOperationName = false };
+            RabbitMQActivitySource.TracingOptions = options;
+
+            Assert.Same(options, RabbitMQActivitySource.TracingOptions);
+            Assert.False(RabbitMQActivitySource.UseRoutingKeyAsOperationName);
+
+            // Mutating the instance the caller still holds reaches the client.
+            options.UseRoutingKeyAsOperationName = true;
+            Assert.True(RabbitMQActivitySource.UseRoutingKeyAsOperationName);
+        }
+
+        [Fact]
+        public void SaveAndRestoreRoundTripsTheConfiguration()
+        {
+            /*
+             * The idiom the parameterized tracing tests depend on, and the one an application uses
+             * to configure tracing temporarily. It only works while the setter adopts the instance;
+             * see AssigningTracingOptionsAdoptsTheInstance.
+             */
+            using var scope = new TracingConfigurationScope();
+
+            RabbitMQTracingOptions original = RabbitMQActivitySource.TracingOptions;
+            bool originalFlag = original.UseRoutingKeyAsOperationName;
+
+            RabbitMQActivitySource.TracingOptions =
+                new RabbitMQTracingOptions { UseRoutingKeyAsOperationName = false == originalFlag };
+            Assert.NotSame(original, RabbitMQActivitySource.TracingOptions);
+
+            RabbitMQActivitySource.TracingOptions = original;
+
+            Assert.Same(original, RabbitMQActivitySource.TracingOptions);
+            Assert.Equal(originalFlag, RabbitMQActivitySource.UseRoutingKeyAsOperationName);
+        }
+
+        [Fact]
+        public void UseRoutingKeyAsOperationNameForwardsToTheCurrentOptionsInstance()
+        {
+            using var scope = new TracingConfigurationScope();
+
+            var options = new RabbitMQTracingOptions();
+            RabbitMQActivitySource.TracingOptions = options;
+
+            RabbitMQActivitySource.UseRoutingKeyAsOperationName = false;
+            Assert.False(options.UseRoutingKeyAsOperationName);
+
+            options.UseRoutingKeyAsOperationName = true;
+            Assert.True(RabbitMQActivitySource.UseRoutingKeyAsOperationName);
+        }
+
+        [Fact]
+        public void ConfigurationIsProcessWideAcrossTracerProviders()
+        {
+            /*
+             * Characterizes what the documentation on these members now states plainly, rather than
+             * asserting a scope the platform cannot deliver. Two TracerProviders configure the
+             * client differently; the second wins for both, and disposing it restores nothing.
+             *
+             * This is not a defect that a lock or a reference count could fix. One ActivitySource
+             * produces a single Activity shared by every listener, and one publish injects a single
+             * set of headers, so neither span shape nor propagation can differ per provider. The fix
+             * is configuration owned by something narrower than the process, which is tracked on
+             * #1981 and is not what these members are.
+             */
+            using var scope = new TracingConfigurationScope();
+
+            using (TracerProvider first = Sdk.CreateTracerProviderBuilder()
+                       .AddRabbitMQInstrumentation(options => options.UseRoutingKeyAsOperationName = true)
+                       .Build())
+            {
+                Assert.True(RabbitMQActivitySource.UseRoutingKeyAsOperationName);
+
+                using (TracerProvider second = Sdk.CreateTracerProviderBuilder()
+                           .AddRabbitMQInstrumentation(options => options.UseRoutingKeyAsOperationName = false)
+                           .Build())
+                {
+                    // The first provider's configuration is gone, and it is still alive.
+                    Assert.False(RabbitMQActivitySource.UseRoutingKeyAsOperationName);
+                }
+
+                // Disposing the second restored nothing.
+                Assert.False(RabbitMQActivitySource.UseRoutingKeyAsOperationName);
+            }
+        }
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> This pull request was prepared by Claude (Anthropic's Claude Code) under the direction of @lukebakken, who reviewed it before filing. The code was written and verified jointly, and the decision to split this out of #2009 was @lukebakken's call.

## Summary

Partially addresses #1981, and is a prerequisite for #2009. Group C of the tracing work tracked in #1979, split into two PRs that are both targeted at 7.3.0: this one carries the validation and the documentation, #2009 follows with the per-connection ownership model once its API shape is settled.

`RabbitMQActivitySource.ContextInjector`, `ContextExtractor` and `TracingOptions` accepted `null`, and the failure then surfaced as a `NullReferenceException` thrown from inside the client on some later publish or delivery — arbitrarily far from the assignment that caused it, and on a path the caller does not own. All three setters now throw `ArgumentNullException`.

The rest of #1981 was reported as "configuration is process-global, last writer wins", and asked for per-`TracerProvider` scope. **That part is not achievable**, which is why this PR documents the behaviour instead of changing it: one `ActivitySource` produces a single `Activity` shared by every listener, and one publish injects a single set of headers, so neither span shape nor propagated context can differ per provider. No amount of locking or reference counting changes that.

Configuration owned by something narrower than the process — the connection performing the operation, as @danielmarbach and @paulomorgado both proposed on #2009 — is the right fix, and it stays on #2009. See "Why this is split" below.

## Changes

- `ArgumentNullException` from the three setters that accepted `null`.
- XML documentation on all four public members of `RabbitMQActivitySource` and both `RabbitMQTracingOptions` properties, stating that the configuration is process-wide, that the last writer wins, and that disposal restores nothing.
- README: the three activity sources and their span names, both options, and the scope of the configuration. The messaging semantic conventions ask an instrumentation that parents `process` spans to the message creation context to document that it does so, and the README covered only SDK wiring.
- One `TracingConfigurationScope` in `Test.Common` replaces two partial private copies in `TestActivitySource`, neither of which restored the propagation delegates.

**No public API changes** — `PublicAPI.*.txt` is untouched, and no signatures moved. One documentation correction is worth calling out: `UsePublisherAsParent = false` does *not* attach the publisher context "as a link instead". `StartLinkedRabbitMQActivity` adds the link whenever the extracted context is non-default, in both modes, and the flag only feeds `parentContext`, so it drops the parent and leaves the link.

## Why this is split

#2009 grew a per-connection ownership model over two review rounds. A max-effort review then found it silently broken on the path its own documentation recommended, confirmed against a live broker: because the fallback was whole-object (`tracing ?? s_tracingOptions`) and a fresh `RabbitMQTracingOptions` pre-seeds the *client's* built-in delegates, setting `ConnectionFactory.TracingOptions` for a span-shaping tweak switched that connection off OpenTelemetry propagation. Messages went out with `traceparent` and no `baggage` header, a non-W3C propagator was ignored, and spans still exported — so the wiring looked correct.

The fix is per-member fallback, each member `null` meaning "inherit the layer below". Where those nullable members live is an open compatibility question rather than a technical one, and it is being discussed with the reviewers on #2009. `RabbitMQTracingOptions` shipped in 7.2.0 with non-nullable `bool` properties, so expressing "inherit" on that type means `bool` becomes `bool?`: writes still compile and only reads break at source level, but it is binary-breaking. The alternatives are a second options type, nullable delegates only, or four nullable properties directly on `ConnectionFactory`. `IConnectionFactory` is a second question, since it declares every other comparable per-connection knob, adding to a public interface breaks external implementers, and `ConnectionFactory` is `sealed`.

That is a public-API design worth settling deliberately rather than rewriting a third time inside a PR already in review, which is why it is being discussed on #2009 rather than folded in here. Nothing here is marked `[Obsolete]` for the same reason: deprecating the statics before their replacement exists would leave consumers with a `CS0618` warning and nothing to migrate to. The deprecations belong with #2009. The full write-up, including both abandoned attempts and the constraints that sank them, is in `docs/internal/opentelemetry-tracing-review.md`.

## Testing

Solution builds clean on net8.0 and netstandard2.0, zero warnings. `TestTracingConfiguration` (9, new), `TestOpenTelemetry` (22) and `TestActivitySource` (40) pass; `Unit` 196 pass. Every commit builds independently.

The three null-guard tests were negative-checked by reverting the guards to plain assignments — each then fails, and passes again restored.

The remaining six characterize behaviour `main` already has, so a future attempt at per-connection ownership cannot break it silently. Two are there specifically because the abandoned attempt did break them: assigning `TracingOptions` adopts the instance, so a caller holding a reference can still mutate the live configuration, and save-then-restore round-trips. An implementation that copied values out of the instance breaks both at once, because the getter then hands back the same singleton the setter copied into, making a restore a no-op. The delegate tests assert against a delegate the test owns rather than comparing two reads of one property, which would pass even if the setter were a no-op.

They live in `SequentialIntegration` rather than `Unit` because they mutate process-global state and that project injects `CollectionPerAssembly`; `Unit` runs its classes in parallel.

## For the 7.3.0 release notes

- Assigning `null` to `RabbitMQActivitySource.ContextInjector`, `ContextExtractor`, or `TracingOptions` now throws `ArgumentNullException` at the assignment, instead of causing a `NullReferenceException` on a later publish or delivery.
- Client tracing configuration is process-wide, and this release documents that rather than changing it. When more than one `TracerProvider` calls `AddRabbitMQInstrumentation`, the last call wins and disposing a provider does not restore what it replaced. Per-`TracerProvider` configuration is not achievable, because a single `Activity` and one set of propagated headers are shared across every provider. Configuration owned per connection is a separate change in the same release.
